### PR TITLE
Add no-change test for Plan.Human

### DIFF
--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -89,3 +89,19 @@ func TestPlanToJSON(t *testing.T) {
 		t.Error("JSON output should contain created_at timestamp")
 	}
 }
+func TestPlanNoChanges(t *testing.T) {
+	sql := `CREATE TABLE users (
+                id integer NOT NULL
+        );`
+
+	oldIR := parseSQL(t, sql)
+	newIR := parseSQL(t, sql)
+	ddlDiff := diff.Diff(oldIR, newIR)
+
+	plan := NewPlan(ddlDiff, "public")
+	summary := strings.TrimSpace(plan.Human())
+
+	if summary != "No changes detected." {
+		t.Errorf("expected %q, got %q", "No changes detected.", summary)
+	}
+}


### PR DESCRIPTION
## Summary
- add `TestPlanNoChanges` verifying that `Plan.Human()` returns "No changes detected." when comparing identical SQL

## Testing
- `go test ./...` *(fails: rootless Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c531246883329797f408484561cd