### PR TITLE
Fix: Quote identifiers in constraint definitions

### DIFF
--- a/internal/diff/constraint.go
+++ b/internal/diff/constraint.go
@@ -13,7 +13,7 @@ func generateConstraintSQL(constraint *ir.Constraint, _ string) string {
 	getColumnNames := func(columns []*ir.ConstraintColumn) []string {
 		var names []string
 		for _, col := range columns {
-			names = append(names, col.Name)
+			names = append(names, quoteIdentifier(col.Name))
 		}
 		return names
 	}
@@ -26,7 +26,7 @@ func generateConstraintSQL(constraint *ir.Constraint, _ string) string {
 	case ir.ConstraintTypeForeignKey:
 		stmt := fmt.Sprintf("FOREIGN KEY (%s) REFERENCES %s (%s)",
 			strings.Join(getColumnNames(constraint.Columns), ", "),
-			constraint.ReferencedTable, strings.Join(getColumnNames(constraint.ReferencedColumns), ", "))
+			quoteIdentifier(constraint.ReferencedTable), strings.Join(getColumnNames(constraint.ReferencedColumns), ", "))
 		// Only add ON DELETE/UPDATE if they are not the default "NO ACTION"
 		if constraint.DeleteRule != "" && constraint.DeleteRule != "NO ACTION" {
 			stmt += fmt.Sprintf(" ON DELETE %s", constraint.DeleteRule)

--- a/internal/diff/constraint_quote_test.go
+++ b/internal/diff/constraint_quote_test.go
@@ -1,0 +1,76 @@
+package diff
+
+import (
+	"testing"
+	"github.com/pgschema/pgschema/internal/ir"
+)
+
+func TestGenerateConstraintSQL_WithQuoting(t *testing.T) {
+	tests := []struct {
+		name       string
+		constraint *ir.Constraint
+		want       string
+	}{
+		{
+			name: "UNIQUE with camelCase columns",
+			constraint: &ir.Constraint{
+				Name: "test_unique",
+				Type: ir.ConstraintTypeUnique,
+				Columns: []*ir.ConstraintColumn{
+					{Name: "userId", Position: 1},
+					{Name: "accountId", Position: 2},
+				},
+			},
+			want: `UNIQUE ("userId", "accountId")`,
+		},
+		{
+			name: "PRIMARY KEY with reserved word",
+			constraint: &ir.Constraint{
+				Name: "test_pk",
+				Type: ir.ConstraintTypePrimaryKey,
+				Columns: []*ir.ConstraintColumn{
+					{Name: "user", Position: 1},
+					{Name: "order", Position: 2},
+				},
+			},
+			want: `PRIMARY KEY ("user", "order")`,
+		},
+		{
+			name: "FOREIGN KEY with camelCase",
+			constraint: &ir.Constraint{
+				Name: "test_fk",
+				Type: ir.ConstraintTypeForeignKey,
+				Columns: []*ir.ConstraintColumn{
+					{Name: "userId", Position: 1},
+				},
+				ReferencedTable: "users",
+				ReferencedColumns: []*ir.ConstraintColumn{
+					{Name: "id", Position: 1},
+				},
+				DeleteRule: "CASCADE",
+			},
+			want: `FOREIGN KEY ("userId") REFERENCES users (id) ON DELETE CASCADE`,
+		},
+		{
+			name: "UNIQUE with lowercase columns (no quotes needed)",
+			constraint: &ir.Constraint{
+				Name: "test_unique_lower",
+				Type: ir.ConstraintTypeUnique,
+				Columns: []*ir.ConstraintColumn{
+					{Name: "email", Position: 1},
+					{Name: "username", Position: 2},
+				},
+			},
+			want: `UNIQUE (email, username)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := generateConstraintSQL(tt.constraint, "public")
+			if got != tt.want {
+				t.Errorf("generateConstraintSQL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -641,7 +641,7 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			columns := sortConstraintColumnsByPosition(constraint.Columns)
 			var columnNames []string
 			for _, col := range columns {
-				columnNames = append(columnNames, col.Name)
+				columnNames = append(columnNames, quoteIdentifier(col.Name))
 			}
 			tableName := getTableNameWithSchema(td.Table.Schema, td.Table.Name, targetSchema)
 			sql := fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s UNIQUE (%s);",
@@ -676,7 +676,7 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			columns := sortConstraintColumnsByPosition(constraint.Columns)
 			var columnNames []string
 			for _, col := range columns {
-				columnNames = append(columnNames, col.Name)
+				columnNames = append(columnNames, quoteIdentifier(col.Name))
 			}
 
 			// Sort referenced columns by position
@@ -729,7 +729,7 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			columns := sortConstraintColumnsByPosition(constraint.Columns)
 			var columnNames []string
 			for _, col := range columns {
-				columnNames = append(columnNames, col.Name)
+				columnNames = append(columnNames, quoteIdentifier(col.Name))
 			}
 			tableName := getTableNameWithSchema(td.Table.Schema, td.Table.Name, targetSchema)
 			sql := fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s PRIMARY KEY (%s);",
@@ -770,7 +770,7 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			columns := sortConstraintColumnsByPosition(constraint.Columns)
 			var columnNames []string
 			for _, col := range columns {
-				columnNames = append(columnNames, col.Name)
+				columnNames = append(columnNames, quoteIdentifier(col.Name))
 			}
 			addSQL = fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s UNIQUE (%s);",
 				tableName, constraint.Name, strings.Join(columnNames, ", "))
@@ -785,7 +785,7 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			columns := sortConstraintColumnsByPosition(constraint.Columns)
 			var columnNames []string
 			for _, col := range columns {
-				columnNames = append(columnNames, col.Name)
+				columnNames = append(columnNames, quoteIdentifier(col.Name))
 			}
 
 			// Sort referenced columns by position
@@ -828,7 +828,7 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			columns := sortConstraintColumnsByPosition(constraint.Columns)
 			var columnNames []string
 			for _, col := range columns {
-				columnNames = append(columnNames, col.Name)
+				columnNames = append(columnNames, quoteIdentifier(col.Name))
 			}
 			addSQL = fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s PRIMARY KEY (%s);",
 				tableName, constraint.Name, strings.Join(columnNames, ", "))


### PR DESCRIPTION
## Problem
After PR #7, constraints (UNIQUE, PRIMARY KEY, FOREIGN KEY) were not quoting column names, causing failures with camelCase columns.

## Solution  
This PR completes the identifier quoting feature by:
- Quoting column names in all constraint types
- Quoting referenced table names in FOREIGN KEY constraints
- Adding comprehensive tests for constraints with camelCase and reserved words

## Example
Before this fix:
```sql
-- Input
UNIQUE ("userId", "accountId")

-- pgschema output (broken)
UNIQUE (userId, accountId)  -- ERROR: column "userid" does not exist
```

After this fix:
```sql
-- pgschema output (fixed)
UNIQUE ("userId", "accountId")  -- Works correctly!
```

## Testing
- Added unit tests for constraint quoting
- Tested with Better Auth schema
- Verified camelCase columns in constraints work properly

Fixes the issue discovered when using Better Auth with camelCase column names in UNIQUE constraints.