### PR TITLE
fix: parentheses handling in CHECK constraint normalization

### DIFF
--- a/internal/ir/normalize.go
+++ b/internal/ir/normalize.go
@@ -849,9 +849,15 @@ func normalizeCheckClause(checkClause string) string {
 		clause = after
 	}
 
-	// Remove outer parentheses if present (may be multiple layers)
-	for strings.HasPrefix(clause, "(") && strings.HasSuffix(clause, ")") {
-		clause = strings.TrimSpace(clause[1 : len(clause)-1])
+	// Remove ONLY outer parentheses if they are balanced and not part of complex expression
+	clause = strings.TrimSpace(clause)
+	for len(clause) > 0 && clause[0] == '(' && clause[len(clause)-1] == ')' {
+		// Check if parentheses are balanced
+		if isBalancedParentheses(clause[1 : len(clause)-1]) {
+			clause = strings.TrimSpace(clause[1 : len(clause)-1])
+		} else {
+			break
+		}
 	}
 
 	// First apply legacy conversions to handle PostgreSQL-specific patterns

--- a/testdata/diff/create_table/add_check/diff.sql
+++ b/testdata/diff/create_table/add_check/diff.sql
@@ -1,0 +1,2 @@
+ALTER TABLE code
+    ADD CONSTRAINT code_check CHECK (code > 0 AND code < 255);

--- a/testdata/diff/create_table/add_check/new.sql
+++ b/testdata/diff/create_table/add_check/new.sql
@@ -1,0 +1,3 @@
+CREATE TABLE public.code (
+    code integer PRIMARY KEY CONSTRAINT code_check CHECK (code > 0 AND code < 255)
+);

--- a/testdata/diff/create_table/add_check/old.sql
+++ b/testdata/diff/create_table/add_check/old.sql
@@ -1,0 +1,3 @@
+CREATE TABLE IF NOT EXISTS code (
+    code integer PRIMARY KEY
+);

--- a/testdata/diff/create_table/add_check/plan.json
+++ b/testdata/diff/create_table/add_check/plan.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.1.0",
+  "created_at": "2025-09-23T18:49:35+03:00",
+  "source_fingerprint": {
+    "hash": "a9d472cd406e27485b570b72906ad224b8282469bd50699bddd6da04acdabaef"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "ALTER TABLE code\nADD CONSTRAINT code_check CHECK (code > 0 AND code < 255) NOT VALID;",
+          "type": "table.constraint",
+          "operation": "create",
+          "path": "public.code.code_check"
+        },
+        {
+          "sql": "ALTER TABLE code VALIDATE CONSTRAINT code_check;",
+          "type": "table.constraint",
+          "operation": "create",
+          "path": "public.code.code_check"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_table/add_check/plan.sql
+++ b/testdata/diff/create_table/add_check/plan.sql
@@ -1,0 +1,4 @@
+ALTER TABLE code
+ADD CONSTRAINT code_check CHECK (code > 0 AND code < 255) NOT VALID;
+
+ALTER TABLE code VALIDATE CONSTRAINT code_check;

--- a/testdata/diff/create_table/add_check/plan.txt
+++ b/testdata/diff/create_table/add_check/plan.txt
@@ -1,0 +1,16 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ code
+    + code_check (constraint)
+
+DDL to be executed:
+--------------------------------------------------
+
+ALTER TABLE code
+ADD CONSTRAINT code_check CHECK (code > 0 AND code < 255) NOT VALID;
+
+ALTER TABLE code VALIDATE CONSTRAINT code_check;


### PR DESCRIPTION
This PR fixes a critical issue in the CHECK constraint normalization logic where improperly balanced parentheses could lead to incorrect expression parsing.

Problem Fixed

The previous implementation would remove ALL outer parentheses without checking if they were properly balanced or part of a larger expression structure. 

This break expressions like: `CHECK ((code >= 0) AND (code <= 255))` 
Previous: `CHECK (code >= 0) AND (code <= 255)` 
Current: `CHECK (code >= 0 AND code <= 255)` 