### PR TITLE
chore: drop PostgreSQL 14 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,6 @@ jobs:
         with:
           go-version: "1.24"
 
-      - name: Run tests (PostgreSQL 14)
-        run: |
-          echo "Testing with PostgreSQL 14"
-          PGSCHEMA_POSTGRES_VERSION=14 go test -v ./...
-
       - name: Run tests (PostgreSQL 15)
         run: |
           echo "Testing with PostgreSQL 15"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ The tool is written in Go 1.24+ (toolchain go1.24.7) and uses:
 - Cobra for CLI commands
 - embedded-postgres v1.29.0 for plan command (temporary instances) and testing (no Docker required)
 - pgx/v5 v5.7.5 for database connections
-- Supports PostgreSQL versions 14-17
+- Supports PostgreSQL versions 15-17
 
 Key differentiators:
 
@@ -184,7 +184,7 @@ The tool supports comprehensive PostgreSQL schema objects (see `ir/ir.go` for co
   - `PGSCHEMA_PLAN_PASSWORD` - Plan database password
 - **Environment files**: `.env` - automatically loaded by main.go
 - **Test filtering**: `PGSCHEMA_TEST_FILTER` - run specific test cases (e.g., `"create_table/"` or `"create_table/add_column"`)
-- **Postgres version**: `PGSCHEMA_POSTGRES_VERSION` - test against specific versions (14, 15, 16, 17)
+- **Postgres version**: `PGSCHEMA_POSTGRES_VERSION` - test against specific versions (15, 16, 17)
 
 ## Important Implementation Notes
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Think of it as Terraform for your Postgres schemas - declare your desired state,
 
 ## Key differentiators from other tools
 
-1. **Comprehensive Postgres Support**: Handles virtually all schema-level database objects across Postgres versions 14 through 17
+1. **Comprehensive Postgres Support**: Handles virtually all schema-level database objects across Postgres versions 15 through 17
 1. **State-Based Terraform-Like Workflow**: No separate migration table needed to track migration history - determines changes by comparing your schema files with actual database state
 1. **Schema-Level Focus**: Designed for real-world Postgres usage patterns, from single-schema applications to multi-tenant architectures
 1. **No Shadow Database Required**: Works directly with your schema files and target database - no temporary databases needed for validation

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -14,7 +14,7 @@ title: "FAQ"
 
 ### Which PostgreSQL versions are supported?
 
-pgschema is tested with PostgreSQL versions 14, 15, 16, and 17. While it may work with older versions, we recommend using one of these tested versions for the best experience.
+pgschema is tested with PostgreSQL versions 15, 16, and 17. While it may work with older versions, we recommend using one of these tested versions for the best experience.
 
 ### What operating systems are supported?
 

--- a/internal/postgres/embedded.go
+++ b/internal/postgres/embedded.go
@@ -233,11 +233,9 @@ func findAvailablePort() (int, error) {
 }
 
 // mapToEmbeddedPostgresVersion maps a PostgreSQL major version to embedded-postgres version
-// Supported versions: 14, 15, 16, 17
+// Supported versions: 15, 16, 17
 func mapToEmbeddedPostgresVersion(majorVersion int) (PostgresVersion, error) {
 	switch majorVersion {
-	case 14:
-		return PostgresVersion("14.18.0"), nil
 	case 15:
 		return PostgresVersion("15.13.0"), nil
 	case 16:
@@ -245,7 +243,7 @@ func mapToEmbeddedPostgresVersion(majorVersion int) (PostgresVersion, error) {
 	case 17:
 		return PostgresVersion("17.5.0"), nil
 	default:
-		return "", fmt.Errorf("unsupported PostgreSQL version %d (supported: 14, 15, 16, 17)", majorVersion)
+		return "", fmt.Errorf("unsupported PostgreSQL version %d (supported: 15, 16, 17)", majorVersion)
 	}
 }
 

--- a/testutil/postgres.go
+++ b/testutil/postgres.go
@@ -137,8 +137,6 @@ func ConnectToPostgres(t testing.TB, embeddedPG *postgres.EmbeddedPostgres) (con
 func getPostgresVersion() postgres.PostgresVersion {
 	versionStr := os.Getenv("PGSCHEMA_POSTGRES_VERSION")
 	switch versionStr {
-	case "14":
-		return postgres.PostgresVersion("14.18.0")
 	case "15":
 		return postgres.PostgresVersion("15.13.0")
 	case "16":


### PR DESCRIPTION
PostgreSQL 14's pg_get_viewdef() function produces different output compared to PostgreSQL 15+, causing systematic test failures in view definitions.

The key difference is in how column references are formatted:
- PostgreSQL 14: Uses table-qualified column names Example: SELECT dept_emp.emp_no, max(dept_emp.from_date) ...
- PostgreSQL 15+: Simplifies unambiguous column references Example: SELECT emp_no, max(from_date) ...

This behavior change in PostgreSQL's internal ruleutils.c code affects all views (regular and materialized) and makes it impossible to maintain version-consistent output. The difference appears when pg_get_viewdef() reconstructs view definitions from stored metadata.

Test failure example (TestDumpCommand_Employee):
- Expected (PG 15+): SELECT emp_no, max(from_date) AS from_date ...
- Actual (PG 14): SELECT dept_emp.emp_no, max(dept_emp.from_date) ...

This is a PostgreSQL behavior change, not a pgschema bug. Since pgschema relies on pg_get_viewdef() for view introspection, supporting PG 14 would require version-specific view normalization logic that would be complex and error-prone.

Changes:
- Removed PG 14 from mapToEmbeddedPostgresVersion() and getPostgresVersion()
- Removed PG 14 test job from GitHub Actions workflow
- Updated all documentation to reflect minimum version PostgreSQL 15
- Updated README.md, CLAUDE.md, docs/faq.mdx

Minimum supported version is now PostgreSQL 15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)