### PR TITLE
Fix normalization of custom array type

### DIFF
--- a/ir/normalize.go
+++ b/ir/normalize.go
@@ -780,6 +780,12 @@ func normalizePostgreSQLType(input string) string {
 		return after
 	}
 
+	// Handle custom array types (internal PostgreSQL array notation)
+	// e.g., _my_enum_type -> my_enum_type[]
+	if strings.HasPrefix(typeName, "_") {
+		return typeName[1:] + "[]"
+	}
+
 	// Return as-is if no mapping found
 	return typeName
 }

--- a/testdata/diff/create_table/enum_array_column/diff.sql
+++ b/testdata/diff/create_table/enum_array_column/diff.sql
@@ -1,0 +1,1 @@
+ALTER TABLE items ADD COLUMN statuses status[];

--- a/testdata/diff/create_table/enum_array_column/new.sql
+++ b/testdata/diff/create_table/enum_array_column/new.sql
@@ -1,0 +1,12 @@
+CREATE TYPE status AS ENUM (
+    'pending',
+    'active',
+    'inactive',
+    'archived'
+);
+
+CREATE TABLE items (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name varchar(255) NOT NULL,
+    statuses status[]
+);

--- a/testdata/diff/create_table/enum_array_column/old.sql
+++ b/testdata/diff/create_table/enum_array_column/old.sql
@@ -1,0 +1,11 @@
+CREATE TYPE status AS ENUM (
+    'pending',
+    'active',
+    'inactive',
+    'archived'
+);
+
+CREATE TABLE items (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name varchar(255) NOT NULL
+);

--- a/testdata/diff/create_table/enum_array_column/plan.json
+++ b/testdata/diff/create_table/enum_array_column/plan.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.4.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "68e81c1d995e4acafbcc1d7cb0f4d8e866e177daf6d08e6f00c69e1338c6a14c"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "ALTER TABLE items ADD COLUMN statuses status[];",
+          "type": "table.column",
+          "operation": "create",
+          "path": "public.items.statuses"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_table/enum_array_column/plan.sql
+++ b/testdata/diff/create_table/enum_array_column/plan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE items ADD COLUMN statuses status[];

--- a/testdata/diff/create_table/enum_array_column/plan.txt
+++ b/testdata/diff/create_table/enum_array_column/plan.txt
@@ -1,0 +1,13 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ items
+    + statuses (column)
+
+DDL to be executed:
+--------------------------------------------------
+
+ALTER TABLE items ADD COLUMN statuses status[];


### PR DESCRIPTION
Fix custom type arrays (enums, composites, domains) incorrectly outputting PostgreSQL's internal `_typename` format instead of SQL standard `typename[]` syntax.
