### PR TITLE
fix: preserve constraints to ignored tables in multi-file dumps

### DIFF
--- a/internal/dump/formatter.go
+++ b/internal/dump/formatter.go
@@ -228,7 +228,7 @@ func (f *DumpFormatter) getObjectDirectory(objectType string) string {
 		return "views"
 	case "materialized_view":
 		return "materialized_views"
-	case "table.index", "table.trigger", "table.policy", "table.rls", "table.comment", "table.column.comment", "table.index.comment":
+	case "table.index", "table.trigger", "table.constraint", "table.policy", "table.rls", "table.comment", "table.column.comment", "table.index.comment":
 		// These are included with their tables
 		return "tables"
 	case "view.comment":
@@ -249,7 +249,7 @@ func (f *DumpFormatter) getObjectDirectory(objectType string) string {
 func (f *DumpFormatter) getGroupingName(step diff.Diff) string {
 	// For table-related objects, try to extract the table name from Source
 	switch step.Type {
-	case diff.DiffTypeTableIndex, diff.DiffTypeTableTrigger, diff.DiffTypeTablePolicy, diff.DiffTypeTableRLS, diff.DiffTypeTableComment, diff.DiffTypeTableColumnComment, diff.DiffTypeTableIndexComment:
+	case diff.DiffTypeTableIndex, diff.DiffTypeTableTrigger, diff.DiffTypeTableConstraint, diff.DiffTypeTablePolicy, diff.DiffTypeTableRLS, diff.DiffTypeTableComment, diff.DiffTypeTableColumnComment, diff.DiffTypeTableIndexComment:
 		if tableName := f.extractTableNameFromContext(step); tableName != "" {
 			return tableName
 		}
@@ -331,6 +331,8 @@ func (f *DumpFormatter) extractTableNameFromContext(step diff.Diff) string {
 	case *ir.RLSPolicy:
 		return obj.Table
 	case *ir.Trigger:
+		return obj.Table
+	case *ir.Constraint:
 		return obj.Table
 	// For other table-related objects, we might need to parse or handle differently
 	default:


### PR DESCRIPTION
Fix https://github.com/pgschema/pgschema/issues/167

**Problem:**
Foreign key constraints referencing ignored tables were being lost in multi-file dumps (--multi-file flag). Single-file dumps worked correctly.

**Root Cause:**
In internal/dump/formatter.go, two issues prevented constraints from being properly grouped with their tables in multi-file output:

1. DiffTypeTableConstraint was missing from getGroupingName() switch statement, so constraints weren't grouped with their parent tables
2. "table.constraint" was missing from getObjectDirectory() case statement, so constraints went to "misc" directory instead of "tables"

**Solution:**
- Added DiffTypeTableConstraint to getGroupingName() to group constraints with their tables (line 252)
- Added "table.constraint" to getObjectDirectory() case statement to route constraints to tables directory (line 246)
- Added *ir.Constraint case to extractTableNameFromContext() to extract table name from constraint objects (line 335)
