### PR TITLE
Add `limit` to missing "smart-quote" Keywords

### DIFF
--- a/ir/quote.go
+++ b/ir/quote.go
@@ -61,6 +61,7 @@ var reservedWords = map[string]bool{
 	"lateral":     true,
 	"left":        true,
 	"like":        true,
+	"limit":       true,
 	// N-P
 	"not":         true,
 	"null":        true,

--- a/ir/quote_test.go
+++ b/ir/quote_test.go
@@ -12,6 +12,7 @@ func TestNeedsQuoting(t *testing.T) {
 	}{
 		{"simple lowercase", "users", false},
 		{"reserved word", "user", true},
+		{"limit keyword", "limit", true},
 		{"camelCase", "firstName", true},
 		{"UPPERCASE", "USERS", true},
 		{"MixedCase", "MyApp", true},
@@ -40,6 +41,7 @@ func TestQuoteIdentifier(t *testing.T) {
 	}{
 		{"simple lowercase", "users", "users"},
 		{"reserved word", "user", `"user"`},
+		{"limit keyword", "limit", `"limit"`},
 		{"camelCase", "firstName", `"firstName"`},
 		{"UPPERCASE", "USERS", `"USERS"`},
 		{"MixedCase", "MyApp", `"MyApp"`},


### PR DESCRIPTION
Adds `limit` to the list of "smart-quote" keywords that render column/variable names with a quote. 


Note: Will be adding more as a follow-up (https://github.com/pgschema/pgschema/pull/178)