### PR TITLE
fix: support overloaded functions and procedures in dump (#191)

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -500,8 +500,8 @@ func GenerateMigration(oldIR, newIR *ir.IR, targetSchema string) []Diff {
 		funcNames := sortedKeys(dbSchema.Functions)
 		for _, funcName := range funcNames {
 			function := dbSchema.Functions[funcName]
-			// Use schema.name(arguments) as key to distinguish functions with different signatures
-			key := function.Schema + "." + funcName + "(" + function.GetArguments() + ")"
+			// funcName already contains signature as name(arguments) from inspector
+			key := function.Schema + "." + funcName
 			oldFunctions[key] = function
 		}
 	}
@@ -511,8 +511,8 @@ func GenerateMigration(oldIR, newIR *ir.IR, targetSchema string) []Diff {
 		funcNames := sortedKeys(dbSchema.Functions)
 		for _, funcName := range funcNames {
 			function := dbSchema.Functions[funcName]
-			// Use schema.name(arguments) as key to distinguish functions with different signatures
-			key := function.Schema + "." + funcName + "(" + function.GetArguments() + ")"
+			// funcName already contains signature as name(arguments) from inspector
+			key := function.Schema + "." + funcName
 			newFunctions[key] = function
 		}
 	}
@@ -557,7 +557,7 @@ func GenerateMigration(oldIR, newIR *ir.IR, targetSchema string) []Diff {
 		procNames := sortedKeys(dbSchema.Procedures)
 		for _, procName := range procNames {
 			procedure := dbSchema.Procedures[procName]
-			// Use schema.name as key - procedures with same name but different signatures are modifications
+			// procName already contains signature as name(arguments) from inspector
 			key := procedure.Schema + "." + procName
 			oldProcedures[key] = procedure
 		}
@@ -568,7 +568,7 @@ func GenerateMigration(oldIR, newIR *ir.IR, targetSchema string) []Diff {
 		procNames := sortedKeys(dbSchema.Procedures)
 		for _, procName := range procNames {
 			procedure := dbSchema.Procedures[procName]
-			// Use schema.name as key - procedures with same name but different signatures are modifications
+			// procName already contains signature as name(arguments) from inspector
 			key := procedure.Schema + "." + procName
 			newProcedures[key] = procedure
 		}

--- a/internal/dump/formatter.go
+++ b/internal/dump/formatter.go
@@ -411,6 +411,16 @@ func (f *DumpFormatter) formatObjectCommentHeader(step diff.Diff) string {
 		}
 	}
 
+	// For functions and procedures, include the signature in the name to distinguish overloads
+	if step.Source != nil {
+		switch obj := step.Source.(type) {
+		case *ir.Function:
+			objectName = obj.Name + "(" + obj.GetArguments() + ")"
+		case *ir.Procedure:
+			objectName = obj.Name + "(" + obj.GetArguments() + ")"
+		}
+	}
+
 	output.WriteString(fmt.Sprintf("-- Name: %s; Type: %s; Schema: %s; Owner: -\n", objectName, displayType, commentSchemaName))
 	output.WriteString("--\n")
 	output.WriteString("\n")

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -949,7 +949,10 @@ func (i *Inspector) buildFunctions(ctx context.Context, schema *IR, targetSchema
 			Parallel:          parallelMode,
 		}
 
-		dbSchema.SetFunction(functionName, function)
+		// Use name(arguments) as key to support function overloading
+		// This allows multiple functions with the same name but different signatures
+		functionKey := functionName + "(" + function.GetArguments() + ")"
+		dbSchema.SetFunction(functionKey, function)
 	}
 
 	return nil
@@ -1190,7 +1193,10 @@ func (i *Inspector) buildProcedures(ctx context.Context, schema *IR, targetSchem
 			Parameters: parameters,
 		}
 
-		dbSchema.SetProcedure(procedureName, procedure)
+		// Use name(arguments) as key to support procedure overloading
+		// This allows multiple procedures with the same name but different signatures
+		procedureKey := procedureName + "(" + procedure.GetArguments() + ")"
+		dbSchema.SetProcedure(procedureKey, procedure)
 	}
 
 	return nil

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -379,7 +379,25 @@ type Procedure struct {
 	Comment    string       `json:"comment,omitempty"`
 }
 
+// GetArguments returns the procedure arguments string (types only) for procedure identification.
+// This is built dynamically from the Parameters array to ensure it uses normalized types.
+// Per PostgreSQL DROP PROCEDURE syntax, only input parameters are included (IN, INOUT, VARIADIC).
+func (p *Procedure) GetArguments() string {
+	if len(p.Parameters) == 0 {
+		return ""
+	}
 
+	var argTypes []string
+	for _, param := range p.Parameters {
+		// Include only input parameter modes for DROP PROCEDURE compatibility
+		// Exclude OUT and TABLE mode parameters (they're part of return signature)
+		if param.Mode == "" || param.Mode == "IN" || param.Mode == "INOUT" || param.Mode == "VARIADIC" {
+			argTypes = append(argTypes, param.DataType)
+		}
+	}
+
+	return strings.Join(argTypes, ", ")
+}
 
 // NewIR creates a new empty catalog IR
 func NewIR() *IR {

--- a/testdata/diff/create_function/alter_function_attributes/plan.json
+++ b/testdata/diff/create_function/alter_function_attributes/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "547c251b85c0364b36816db73820a51c5980be1979e614ead337b3f93052cb1c"
+    "hash": "d3760381c0e30abb35769924c7ae22d0868a81496ec73d6c427a39d4a3abe131"
   },
   "groups": [
     {

--- a/testdata/diff/create_function/alter_function_different_signature/plan.json
+++ b/testdata/diff/create_function/alter_function_different_signature/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "60f48278b090a2550f1634778976ec483638f67d06485a7e54b22a59d79f31b2"
+    "hash": "897bceabded15a8e2f91cc1081213c355d1c54584f1787dd4f7a81f9aa038636"
   },
   "groups": [
     {

--- a/testdata/diff/create_function/alter_function_same_signature/plan.json
+++ b/testdata/diff/create_function/alter_function_same_signature/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "f8f674906f2aa0fee086c386c8ee9da81b6be4db116ef22b9e2e97411fd7e695"
+    "hash": "07aea23ff65a63da587c7fddf4fe417ec7e0cbddbff86a8775bb4bfc5d1b011f"
   },
   "groups": [
     {

--- a/testdata/diff/create_function/drop_function/plan.json
+++ b/testdata/diff/create_function/drop_function/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "b50e4d62ed25f92850157eef13f4f129a5f082f37da2fe5731342900892c263f"
+    "hash": "1228242f86da4b19cafc006075668cd3e73588c01012241f6e72ed02432a158b"
   },
   "groups": [
     {

--- a/testdata/diff/create_procedure/alter_procedure/plan.json
+++ b/testdata/diff/create_procedure/alter_procedure/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "08df93dce9ea1ef62c3edfbfdd06ee868ec8976c33d28242bc2618ba4e9688d8"
+    "hash": "e4687125bf0145e37b9703d74c5cf09f0e69733284549b1f28498afd7753a102"
   },
   "groups": [
     {
@@ -11,13 +11,13 @@
         {
           "sql": "DROP PROCEDURE IF EXISTS process_payment(IN order_id integer, IN amount numeric);",
           "type": "procedure",
-          "operation": "alter",
+          "operation": "drop",
           "path": "public.process_payment"
         },
         {
           "sql": "CREATE OR REPLACE PROCEDURE process_payment(\n    IN order_id integer,\n    IN amount numeric,\n    IN payment_method text DEFAULT 'credit_card'\n)\nLANGUAGE plpgsql\nAS $$\nBEGIN\n    UPDATE orders \n    SET status = 'paid', \n        payment_amount = amount,\n        payment_method = payment_method,\n        processed_at = NOW()\n    WHERE id = order_id;\n    \n    INSERT INTO payment_history (order_id, amount, method, processed_at)\n    VALUES (order_id, amount, payment_method, NOW());\n    \n    COMMIT;\nEND;\n$$;",
           "type": "procedure",
-          "operation": "alter",
+          "operation": "create",
           "path": "public.process_payment"
         }
       ]

--- a/testdata/diff/create_procedure/alter_procedure/plan.txt
+++ b/testdata/diff/create_procedure/alter_procedure/plan.txt
@@ -1,10 +1,11 @@
-Plan: 1 to modify.
+Plan: 1 to add, 1 to drop.
 
 Summary by type:
-  procedures: 1 to modify
+  procedures: 1 to add, 1 to drop
 
 Procedures:
-  ~ process_payment
+  - process_payment
+  + process_payment
 
 DDL to be executed:
 --------------------------------------------------

--- a/testdata/diff/create_procedure/drop_procedure/plan.json
+++ b/testdata/diff/create_procedure/drop_procedure/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "9f8e6e768179535ba16d74d4ebbb96c3c72439b06bc367c26cc58bfefdc6b17f"
+    "hash": "da1177810da568202dbdcc89a5b9979ff01c589ddcd7618f76f8debccb5f2283"
   },
   "groups": [
     {

--- a/testdata/diff/create_trigger/add_trigger/plan.json
+++ b/testdata/diff/create_trigger/add_trigger/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "76b8935489231ab4bd0742f7f1273e9302474f4f6e73ef99b4e24e211058ce37"
+    "hash": "134d2530bcab506f61be0b5e1cb7af725c83cf0cb7b4b7eb82bd3142d8b7f055"
   },
   "groups": [
     {

--- a/testdata/diff/create_trigger/add_trigger_constraint/plan.json
+++ b/testdata/diff/create_trigger/add_trigger_constraint/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "40681940fc8b6f55df564abf77a173d29f0faf13cc2a6d3f346ee17f1727dae2"
+    "hash": "a3821fdda0b2dbfcc09b52c370049def323f72be8d6cdf362a7c09bdca5e7704"
   },
   "groups": [
     {

--- a/testdata/diff/create_trigger/add_trigger_old_table/plan.json
+++ b/testdata/diff/create_trigger/add_trigger_old_table/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "c7d5d7ce56f814aa8bc8287c6054c7dbbe0b2df7bdc9563d709d074d7ba4b863"
+    "hash": "034e47c5dce9a3b2a69c27d0fafa287627a2c1e76f293214c8462971fdf8eae4"
   },
   "groups": [
     {

--- a/testdata/diff/create_trigger/add_trigger_when_distinct/plan.json
+++ b/testdata/diff/create_trigger/add_trigger_when_distinct/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "9f531a58a8a6e5160d9c22fd497d42a0fadbb9324994494f819629b94e46b868"
+    "hash": "add8e84aea63492f9b9d54566153e7ab05bdbfa0c80bab242990bcf7b5df1538"
   },
   "groups": [
     {

--- a/testdata/diff/create_trigger/alter_trigger/plan.json
+++ b/testdata/diff/create_trigger/alter_trigger/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "ba218be2c63f4cf69ba70b4f8dca11b3832609c271cde6166f570aa47026b923"
+    "hash": "c4bbf53294203081bf5a4c3f26333dd5d74b4c3d3b4d28af61ba6f2ee040c8e3"
   },
   "groups": [
     {

--- a/testdata/diff/create_trigger/drop_trigger/plan.json
+++ b/testdata/diff/create_trigger/drop_trigger/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "ba218be2c63f4cf69ba70b4f8dca11b3832609c271cde6166f570aa47026b923"
+    "hash": "c4bbf53294203081bf5a4c3f26333dd5d74b4c3d3b4d28af61ba6f2ee040c8e3"
   },
   "groups": [
     {

--- a/testdata/diff/dependency/function_to_trigger/plan.json
+++ b/testdata/diff/dependency/function_to_trigger/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "318032a6f9451c9ed14e90c4ff0557d9ecf9a5620e9305314a549d884da5f154"
+    "hash": "20a989c794b418a8cc923aeca226f4be89e31b16b8bd0fd00adb2b4e2936ac18"
   },
   "groups": [
     {

--- a/testdata/diff/migrate/v4/plan.json
+++ b/testdata/diff/migrate/v4/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "c21343c0165a56727a51734705b31278a07e32f8a88cd17fb12dd0a026756403"
+    "hash": "a51544f8a42466271edf94486458c736751f3e18db92371137fafad144e95bfc"
   },
   "groups": [
     {

--- a/testdata/diff/migrate/v5/plan.json
+++ b/testdata/diff/migrate/v5/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.5.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "9a12c55798891493337f5358504b1c58cddb3260d0d581698c849c6ae57a4359"
+    "hash": "79ba873c42fd02b3faebc027cefce1ad32bfa45985caa85ae35ed39762424cf5"
   },
   "groups": [
     {

--- a/testdata/dump/employee/pgschema.sql
+++ b/testdata/dump/employee/pgschema.sql
@@ -2,8 +2,8 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 17.5
--- Dumped by pgschema version 1.4.3
+-- Dumped from database version PostgreSQL 18.0
+-- Dumped by pgschema version 1.5.0
 
 
 --
@@ -148,7 +148,7 @@ CREATE TABLE IF NOT EXISTS title (
 );
 
 --
--- Name: log_dml_operations; Type: FUNCTION; Schema: -; Owner: -
+-- Name: log_dml_operations(); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION log_dml_operations()
@@ -195,7 +195,7 @@ END;
 $$;
 
 --
--- Name: simple_salary_update; Type: PROCEDURE; Schema: -; Owner: -
+-- Name: simple_salary_update(integer, integer); Type: PROCEDURE; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE PROCEDURE simple_salary_update(

--- a/testdata/dump/issue_125_function_default/pgschema.sql
+++ b/testdata/dump/issue_125_function_default/pgschema.sql
@@ -2,12 +2,12 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 17.5
--- Dumped by pgschema version 1.4.3
+-- Dumped from database version PostgreSQL 18.0
+-- Dumped by pgschema version 1.5.0
 
 
 --
--- Name: test_complex_defaults; Type: FUNCTION; Schema: -; Owner: -
+-- Name: test_complex_defaults(integer[], jsonb, int4range, integer); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION test_complex_defaults(
@@ -31,7 +31,7 @@ END;
 $$;
 
 --
--- Name: test_inout_params; Type: FUNCTION; Schema: -; Owner: -
+-- Name: test_inout_params(integer, numeric, numeric); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION test_inout_params(
@@ -50,7 +50,7 @@ END;
 $$;
 
 --
--- Name: test_mixed_params; Type: FUNCTION; Schema: -; Owner: -
+-- Name: test_mixed_params(boolean, text, integer); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION test_mixed_params(
@@ -71,7 +71,7 @@ END;
 $$;
 
 --
--- Name: test_simple_defaults; Type: FUNCTION; Schema: -; Owner: -
+-- Name: test_simple_defaults(integer, text, boolean, numeric, timestamp); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION test_simple_defaults(
@@ -91,7 +91,7 @@ END;
 $$;
 
 --
--- Name: test_variadic_defaults; Type: FUNCTION; Schema: -; Owner: -
+-- Name: test_variadic_defaults(text, integer[]); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION test_variadic_defaults(

--- a/testdata/dump/issue_191_function_procedure_overload/manifest.json
+++ b/testdata/dump/issue_191_function_procedure_overload/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "issue_191_function_procedure_overload",
+  "description": "Test case for overloaded functions and procedures not being fully dumped (GitHub issue #191)",
+  "source": "https://github.com/pgschema/pgschema/issues/191",
+  "notes": [
+    "Tests that all overloaded functions are preserved when dumping (not just the last one)",
+    "Tests that all overloaded procedures are preserved when dumping",
+    "Covers overloads with different parameter counts: test_func(integer) vs test_func(integer, integer)",
+    "Covers overloads with different parameter types: test_func(integer) vs test_func(text)"
+  ]
+}

--- a/testdata/dump/issue_191_function_procedure_overload/pgdump.sql
+++ b/testdata/dump/issue_191_function_procedure_overload/pgdump.sql
@@ -1,0 +1,100 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 17.5 (Debian 17.5-1.pgdg120+1)
+-- Dumped by pg_dump version 17.6 (Homebrew)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: test_func(integer); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.test_func(a integer) RETURNS integer
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RETURN a * 2;
+END;
+$$;
+
+
+--
+-- Name: test_func(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.test_func(a text) RETURNS text
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RETURN 'Hello, ' || a;
+END;
+$$;
+
+
+--
+-- Name: test_func(integer, integer); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.test_func(a integer, b integer) RETURNS integer
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RETURN a + b;
+END;
+$$;
+
+
+--
+-- Name: test_proc(integer); Type: PROCEDURE; Schema: public; Owner: -
+--
+
+CREATE PROCEDURE public.test_proc(IN a integer)
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RAISE NOTICE 'Integer: %', a;
+END;
+$$;
+
+
+--
+-- Name: test_proc(text); Type: PROCEDURE; Schema: public; Owner: -
+--
+
+CREATE PROCEDURE public.test_proc(IN a text)
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RAISE NOTICE 'Text: %', a;
+END;
+$$;
+
+
+--
+-- Name: test_proc(integer, integer); Type: PROCEDURE; Schema: public; Owner: -
+--
+
+CREATE PROCEDURE public.test_proc(IN a integer, IN b integer)
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RAISE NOTICE 'Sum: %', a + b;
+END;
+$$;
+
+
+--
+-- PostgreSQL database dump complete
+--

--- a/testdata/dump/issue_191_function_procedure_overload/pgschema.sql
+++ b/testdata/dump/issue_191_function_procedure_overload/pgschema.sql
@@ -1,0 +1,99 @@
+--
+-- pgschema database dump
+--
+
+-- Dumped from database version PostgreSQL 17.5
+-- Dumped by pgschema version 1.5.0
+
+
+--
+-- Name: test_func(integer); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION test_func(
+    a integer
+)
+RETURNS integer
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    RETURN a * 2;
+END;
+$$;
+
+--
+-- Name: test_func(integer, integer); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION test_func(
+    a integer,
+    b integer
+)
+RETURNS integer
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    RETURN a + b;
+END;
+$$;
+
+--
+-- Name: test_func(text); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION test_func(
+    a text
+)
+RETURNS text
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    RETURN 'Hello, ' || a;
+END;
+$$;
+
+--
+-- Name: test_proc(integer); Type: PROCEDURE; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE PROCEDURE test_proc(
+    IN a integer
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE NOTICE 'Integer: %', a;
+END;
+$$;
+
+--
+-- Name: test_proc(integer, integer); Type: PROCEDURE; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE PROCEDURE test_proc(
+    IN a integer,
+    IN b integer
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE NOTICE 'Sum: %', a + b;
+END;
+$$;
+
+--
+-- Name: test_proc(text); Type: PROCEDURE; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE PROCEDURE test_proc(
+    IN a text
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE NOTICE 'Text: %', a;
+END;
+$$;

--- a/testdata/dump/issue_191_function_procedure_overload/raw.sql
+++ b/testdata/dump/issue_191_function_procedure_overload/raw.sql
@@ -1,0 +1,72 @@
+--
+-- Test case for GitHub issue #191: Overloaded functions and procedures not fully dumped
+--
+-- This test case reproduces a bug where only the last overloaded function/procedure
+-- is included in the dump output. Functions and procedures are stored by name only,
+-- causing overloads with different signatures to overwrite each other.
+--
+
+--
+-- Function overloads: 3 versions of test_func with different signatures
+--
+
+-- Overload 1: Single integer parameter
+CREATE OR REPLACE FUNCTION test_func(a integer)
+RETURNS integer
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN a * 2;
+END;
+$$;
+
+-- Overload 2: Two integer parameters (different count)
+CREATE OR REPLACE FUNCTION test_func(a integer, b integer)
+RETURNS integer
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN a + b;
+END;
+$$;
+
+-- Overload 3: Single text parameter (different type)
+CREATE OR REPLACE FUNCTION test_func(a text)
+RETURNS text
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN 'Hello, ' || a;
+END;
+$$;
+
+--
+-- Procedure overloads: 3 versions of test_proc with different signatures
+--
+
+-- Overload 1: Single integer parameter
+CREATE OR REPLACE PROCEDURE test_proc(a integer)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE NOTICE 'Integer: %', a;
+END;
+$$;
+
+-- Overload 2: Two integer parameters (different count)
+CREATE OR REPLACE PROCEDURE test_proc(a integer, b integer)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE NOTICE 'Sum: %', a + b;
+END;
+$$;
+
+-- Overload 3: Single text parameter (different type)
+CREATE OR REPLACE PROCEDURE test_proc(a text)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE NOTICE 'Text: %', a;
+END;
+$$;

--- a/testdata/dump/sakila/pgschema.sql
+++ b/testdata/dump/sakila/pgschema.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version PostgreSQL 17.5
--- Dumped by pgschema version 1.4.3
+-- Dumped by pgschema version 1.5.0
 
 
 --
@@ -592,7 +592,7 @@ CREATE INDEX IF NOT EXISTS idx_fk_payment_p2022_07_staff_id ON payment_p2022_07 
 CREATE INDEX IF NOT EXISTS payment_p2022_07_customer_id_idx ON payment_p2022_07 (customer_id);
 
 --
--- Name: _group_concat; Type: FUNCTION; Schema: -; Owner: -
+-- Name: _group_concat(text, text); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION _group_concat(
@@ -611,7 +611,7 @@ END
 $_$;
 
 --
--- Name: film_in_stock; Type: FUNCTION; Schema: -; Owner: -
+-- Name: film_in_stock(integer, integer); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION film_in_stock(
@@ -631,7 +631,7 @@ AS $_$
 $_$;
 
 --
--- Name: film_not_in_stock; Type: FUNCTION; Schema: -; Owner: -
+-- Name: film_not_in_stock(integer, integer); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION film_not_in_stock(
@@ -651,7 +651,7 @@ AS $_$
 $_$;
 
 --
--- Name: get_customer_balance; Type: FUNCTION; Schema: -; Owner: -
+-- Name: get_customer_balance(integer, timestamptz); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION get_customer_balance(
@@ -698,7 +698,7 @@ END
 $$;
 
 --
--- Name: inventory_held_by_customer; Type: FUNCTION; Schema: -; Owner: -
+-- Name: inventory_held_by_customer(integer); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION inventory_held_by_customer(
@@ -722,7 +722,7 @@ END
 $$;
 
 --
--- Name: inventory_in_stock; Type: FUNCTION; Schema: -; Owner: -
+-- Name: inventory_in_stock(integer); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION inventory_in_stock(
@@ -761,7 +761,7 @@ END
 $$;
 
 --
--- Name: last_day; Type: FUNCTION; Schema: -; Owner: -
+-- Name: last_day(with time zone); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION last_day(
@@ -781,7 +781,7 @@ AS $_$
 $_$;
 
 --
--- Name: last_updated; Type: FUNCTION; Schema: -; Owner: -
+-- Name: last_updated(); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION last_updated()
@@ -796,7 +796,7 @@ END
 $$;
 
 --
--- Name: rewards_report; Type: FUNCTION; Schema: -; Owner: -
+-- Name: rewards_report(integer, numeric); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION rewards_report(

--- a/testdata/dump/tenant/pgschema.sql
+++ b/testdata/dump/tenant/pgschema.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version PostgreSQL 17.5
--- Dumped by pgschema version 1.4.3
+-- Dumped by pgschema version 1.5.0
 
 
 --
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS posts (
 );
 
 --
--- Name: create_task_assignment; Type: FUNCTION; Schema: -; Owner: -
+-- Name: create_task_assignment(text, priority_level, integer); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION create_task_assignment(
@@ -113,7 +113,7 @@ END;
 $$;
 
 --
--- Name: generate_task_id; Type: FUNCTION; Schema: -; Owner: -
+-- Name: generate_task_id(); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION generate_task_id()
@@ -127,7 +127,7 @@ END;
 $$;
 
 --
--- Name: set_task_priority; Type: FUNCTION; Schema: -; Owner: -
+-- Name: set_task_priority(priority_level); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION set_task_priority(
@@ -143,7 +143,7 @@ END;
 $$;
 
 --
--- Name: assign_task; Type: PROCEDURE; Schema: -; Owner: -
+-- Name: assign_task(integer, priority_level, task_assignment); Type: PROCEDURE; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE PROCEDURE assign_task(

--- a/testdata/include/expected_full_schema.sql
+++ b/testdata/include/expected_full_schema.sql
@@ -53,7 +53,7 @@ CREATE SEQUENCE IF NOT EXISTS order_number_seq;
 
 -- Include trigger function (needed by users table trigger)
 --
--- Name: update_timestamp; Type: FUNCTION; Schema: -; Owner: -
+-- Name: update_timestamp(); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION update_timestamp()
@@ -160,7 +160,7 @@ CREATE POLICY orders_policy ON orders TO PUBLIC USING (user_id = 1);
 
 -- Include other functions (after tables that they reference)
 --
--- Name: get_user_count; Type: FUNCTION; Schema: -; Owner: -
+-- Name: get_user_count(); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION get_user_count()
@@ -171,7 +171,7 @@ AS $$
     SELECT COUNT(*) FROM users;
 $$;
 --
--- Name: get_order_count; Type: FUNCTION; Schema: -; Owner: -
+-- Name: get_order_count(integer); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION get_order_count(
@@ -186,7 +186,7 @@ $$;
 
 -- Include procedures folder
 --
--- Name: cleanup_orders; Type: PROCEDURE; Schema: -; Owner: -
+-- Name: cleanup_orders(); Type: PROCEDURE; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE PROCEDURE cleanup_orders()
@@ -195,7 +195,7 @@ AS $$
     DELETE FROM orders WHERE status = 'completed';
 $$;
 --
--- Name: update_status; Type: PROCEDURE; Schema: -; Owner: -
+-- Name: update_status(integer, text); Type: PROCEDURE; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE PROCEDURE update_status(

--- a/testdata/include/functions/get_order_count.sql
+++ b/testdata/include/functions/get_order_count.sql
@@ -1,5 +1,5 @@
 --
--- Name: get_order_count; Type: FUNCTION; Schema: -; Owner: -
+-- Name: get_order_count(integer); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION get_order_count(

--- a/testdata/include/functions/get_user_count.sql
+++ b/testdata/include/functions/get_user_count.sql
@@ -1,5 +1,5 @@
 --
--- Name: get_user_count; Type: FUNCTION; Schema: -; Owner: -
+-- Name: get_user_count(); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION get_user_count()

--- a/testdata/include/functions/update_timestamp.sql
+++ b/testdata/include/functions/update_timestamp.sql
@@ -1,5 +1,5 @@
 --
--- Name: update_timestamp; Type: FUNCTION; Schema: -; Owner: -
+-- Name: update_timestamp(); Type: FUNCTION; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE FUNCTION update_timestamp()

--- a/testdata/include/procedures/cleanup_orders.sql
+++ b/testdata/include/procedures/cleanup_orders.sql
@@ -1,5 +1,5 @@
 --
--- Name: cleanup_orders; Type: PROCEDURE; Schema: -; Owner: -
+-- Name: cleanup_orders(); Type: PROCEDURE; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE PROCEDURE cleanup_orders()

--- a/testdata/include/procedures/update_status.sql
+++ b/testdata/include/procedures/update_status.sql
@@ -1,5 +1,5 @@
 --
--- Name: update_status; Type: PROCEDURE; Schema: -; Owner: -
+-- Name: update_status(integer, text); Type: PROCEDURE; Schema: -; Owner: -
 --
 
 CREATE OR REPLACE PROCEDURE update_status(


### PR DESCRIPTION
Fix https://github.com/pgschema/pgschema/issues/191

Functions and procedures with the same name but different signatures were being overwritten during dump because they were stored using only the name as the map key. Now uses name(arguments) as the key to distinguish overloads.

Changes:
- Add GetArguments() method to Procedure (matching Function)
- Use signature-based keys in inspector for functions and procedures
- Update diff logic to use signature-based keys for procedures
- Include signature in dump comment headers for functions/procedures
- Add test case for issue #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)