### PR TITLE
fix: include public in search_path for extension type resolution

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -484,7 +484,7 @@ func GenerateMigration(oldIR, newIR *ir.IR, targetSchema string) []Diff {
 					diff.modifiedTables = append(diff.modifiedTables, tableDiff)
 				}
 			} else {
-				if tableDiff := diffTables(oldTable, newTable); tableDiff != nil {
+				if tableDiff := diffTables(oldTable, newTable, targetSchema); tableDiff != nil {
 					diff.modifiedTables = append(diff.modifiedTables, tableDiff)
 				}
 			}

--- a/internal/postgres/embedded.go
+++ b/internal/postgres/embedded.go
@@ -199,8 +199,9 @@ func (ep *EmbeddedPostgres) ApplySchema(ctx context.Context, schema string, sql 
 		return fmt.Errorf("failed to create temporary schema %s: %w", ep.tempSchema, err)
 	}
 
-	// Set search_path to the temporary schema
-	setSearchPathSQL := fmt.Sprintf("SET search_path TO \"%s\"", ep.tempSchema)
+	// Set search_path to the temporary schema, with public as fallback
+	// for resolving extension types installed in public schema (issue #197)
+	setSearchPathSQL := fmt.Sprintf("SET search_path TO \"%s\", public", ep.tempSchema)
 	if _, err := util.ExecContextWithLogging(ctx, ep.db, setSearchPathSQL, "set search_path for desired state"); err != nil {
 		return fmt.Errorf("failed to set search_path: %w", err)
 	}

--- a/internal/postgres/external.go
+++ b/internal/postgres/external.go
@@ -105,8 +105,9 @@ func (ed *ExternalDatabase) ApplySchema(ctx context.Context, schema string, sql 
 		return fmt.Errorf("failed to create temporary schema %s: %w", ed.tempSchema, err)
 	}
 
-	// Set search_path to the temporary schema
-	setSearchPathSQL := fmt.Sprintf("SET search_path TO \"%s\"", ed.tempSchema)
+	// Set search_path to the temporary schema, with public as fallback
+	// for resolving extension types installed in public schema (issue #197)
+	setSearchPathSQL := fmt.Sprintf("SET search_path TO \"%s\", public", ed.tempSchema)
 	if _, err := util.ExecContextWithLogging(ctx, ed.db, setSearchPathSQL, "set search_path for desired state"); err != nil {
 		return fmt.Errorf("failed to set search_path: %w", err)
 	}

--- a/testdata/diff/create_function/alter_function_same_signature/setup.sql
+++ b/testdata/diff/create_function/alter_function_same_signature/setup.sql
@@ -1,4 +1,6 @@
 -- Create utils schema with a custom type for cross-schema testing
-CREATE SCHEMA IF NOT EXISTS utils;
+-- Drop and recreate for idempotency (setup runs for both old.sql and new.sql)
+DROP SCHEMA IF EXISTS utils CASCADE;
+CREATE SCHEMA utils;
 
 CREATE TYPE utils.priority_level AS ENUM ('low', 'medium', 'high', 'critical');

--- a/testdata/diff/create_table/add_column_cross_schema_custom_type/diff.sql
+++ b/testdata/diff/create_table/add_column_cross_schema_custom_type/diff.sql
@@ -1,4 +1,4 @@
+ALTER TABLE users ADD COLUMN fqdn citext NOT NULL;
 ALTER TABLE users ADD COLUMN metadata utils.hstore;
-ALTER TABLE users ADD COLUMN fqdn utils.citext NOT NULL;
 ALTER TABLE users ADD COLUMN description utils.custom_text;
 ALTER TABLE users ADD COLUMN status utils.custom_enum DEFAULT 'active';

--- a/testdata/diff/create_table/add_column_cross_schema_custom_type/new.sql
+++ b/testdata/diff/create_table/add_column_cross_schema_custom_type/new.sql
@@ -1,18 +1,27 @@
 -- New state: Add columns using extension types, custom domain, and enum
 -- Types are created via setup.sql
--- This tests GitHub #144 fix and PR #145 functionality:
---   - Extension types in external schemas (hstore) should be qualified
---   - Custom domains and enums in external schemas should be qualified
+--
+-- This tests GitHub #197 and #144/#145:
+--
+-- PUBLIC schema type (citext):
+--   Written unqualified because both table and type are in public schema.
+--   This is natural usage - pgschema must handle this by including public
+--   in search_path when applying to temp schema.
+--
+-- CUSTOM schema types (hstore, custom_text, custom_enum):
+--   Written with schema qualifier because they're in utils schema.
 
 CREATE TABLE public.users (
     id bigint PRIMARY KEY,
     username text NOT NULL,
     created_at timestamp DEFAULT CURRENT_TIMESTAMP,
-    -- Extension type from utils schema: must be qualified
+    -- Extension type from public schema: unqualified (natural usage)
+    -- Reproduces #197 - pgschema must include public in search_path
+    fqdn citext NOT NULL,
+    -- Extension type from utils schema: must be schema-qualified
     metadata utils.hstore,
-    fqdn utils.citext NOT NULL,
-    -- Custom domain from utils schema: must be qualified
+    -- Custom domain from utils schema: must be schema-qualified
     description utils.custom_text,
-    -- Enum type from utils schema: must be qualified
+    -- Enum type from utils schema: must be schema-qualified
     status utils.custom_enum DEFAULT 'active'
 );

--- a/testdata/diff/create_table/add_column_cross_schema_custom_type/plan.json
+++ b/testdata/diff/create_table/add_column_cross_schema_custom_type/plan.json
@@ -9,16 +9,16 @@
     {
       "steps": [
         {
+          "sql": "ALTER TABLE users ADD COLUMN fqdn citext NOT NULL;",
+          "type": "table.column",
+          "operation": "create",
+          "path": "public.users.fqdn"
+        },
+        {
           "sql": "ALTER TABLE users ADD COLUMN metadata utils.hstore;",
           "type": "table.column",
           "operation": "create",
           "path": "public.users.metadata"
-        },
-        {
-          "sql": "ALTER TABLE users ADD COLUMN fqdn utils.citext NOT NULL;",
-          "type": "table.column",
-          "operation": "create",
-          "path": "public.users.fqdn"
         },
         {
           "sql": "ALTER TABLE users ADD COLUMN description utils.custom_text;",

--- a/testdata/diff/create_table/add_column_cross_schema_custom_type/plan.sql
+++ b/testdata/diff/create_table/add_column_cross_schema_custom_type/plan.sql
@@ -1,6 +1,6 @@
-ALTER TABLE users ADD COLUMN metadata utils.hstore;
+ALTER TABLE users ADD COLUMN fqdn citext NOT NULL;
 
-ALTER TABLE users ADD COLUMN fqdn utils.citext NOT NULL;
+ALTER TABLE users ADD COLUMN metadata utils.hstore;
 
 ALTER TABLE users ADD COLUMN description utils.custom_text;
 

--- a/testdata/diff/create_table/add_column_cross_schema_custom_type/plan.txt
+++ b/testdata/diff/create_table/add_column_cross_schema_custom_type/plan.txt
@@ -13,9 +13,9 @@ Tables:
 DDL to be executed:
 --------------------------------------------------
 
-ALTER TABLE users ADD COLUMN metadata utils.hstore;
+ALTER TABLE users ADD COLUMN fqdn citext NOT NULL;
 
-ALTER TABLE users ADD COLUMN fqdn utils.citext NOT NULL;
+ALTER TABLE users ADD COLUMN metadata utils.hstore;
 
 ALTER TABLE users ADD COLUMN description utils.custom_text;
 

--- a/testdata/diff/create_table/add_column_cross_schema_custom_type/setup.sql
+++ b/testdata/diff/create_table/add_column_cross_schema_custom_type/setup.sql
@@ -1,16 +1,25 @@
--- Setup: Create extension type, custom domain, and enum to test type qualification
--- This reproduces GitHub #144 and validates PR #145 fixes
--- All types from external schemas (not the target schema) should be schema-qualified
--- This includes:
---   - Extension types (hstore)
---   - Custom domains and enums
+-- Setup: Test type qualification for types in different schemas
+-- This reproduces GitHub #197 and validates fixes for:
+--
+-- PUBLIC schema types (citext):
+--   Users naturally write unqualified types when both table and type are in public.
+--   pgschema must include public in search_path when applying to temp schema,
+--   otherwise type resolution fails with "type citext does not exist".
+--
+-- CUSTOM schema types (hstore, custom_text, custom_enum):
+--   Types in non-public schemas must always be schema-qualified in the output.
 
-CREATE SCHEMA IF NOT EXISTS utils;
+-- Drop and recreate utils schema for idempotency (setup runs for both old.sql and new.sql)
+DROP SCHEMA IF EXISTS utils CASCADE;
+CREATE SCHEMA utils;
 
+-- Domain and enum in utils schema - must be schema-qualified
 CREATE DOMAIN utils.custom_text AS text;
-
 CREATE TYPE utils.custom_enum AS ENUM ('active', 'inactive', 'pending');
 
--- hstore type stays in utils schema
+-- hstore in utils schema - tests cross-schema type qualification
 CREATE EXTENSION IF NOT EXISTS hstore SCHEMA utils;
-CREATE EXTENSION IF NOT EXISTS citext SCHEMA utils;
+
+-- citext in public schema - reproduces #197
+-- Users write unqualified "citext" when in public schema (natural usage)
+CREATE EXTENSION IF NOT EXISTS citext SCHEMA public;


### PR DESCRIPTION
Fix #197 

When applying SQL to temporary schemas, extension types installed in the public schema (e.g., citext) failed to resolve because the search_path only included the temp schema.

Changes:
- Add public to search_path in embedded.go, external.go, and testutil
- Add ParseSQLToIRWithSetup() for tests needing setup SQL after schema reset
- Update test case to reproduce the bug with citext in public schema
- Make setup.sql files idempotent for repeated execution
- Add `stripSchemaPrefix` in generating type statement

🤖 Generated with [Claude Code](https://claude.com/claude-code)