### PR TITLE
fix: normalize table references in policy expressions

### DIFF
--- a/testdata/diff/create_policy/same_schema_table_reference/diff.sql
+++ b/testdata/diff/create_policy/same_schema_table_reference/diff.sql
@@ -1,0 +1,1 @@
+CREATE POLICY select_own_orders ON orders FOR SELECT TO PUBLIC USING (user_id IN ( SELECT u.id FROM users u WHERE (u.tenant_id = 1)));

--- a/testdata/diff/create_policy/same_schema_table_reference/new.sql
+++ b/testdata/diff/create_policy/same_schema_table_reference/new.sql
@@ -1,0 +1,21 @@
+-- Test case for Issue #224: Table references in policy expressions
+-- This tests that same-schema table references are properly normalized
+
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    tenant_id INTEGER NOT NULL
+);
+
+CREATE TABLE orders (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id)
+);
+
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+
+-- Policy with subquery referencing another table in the same schema
+-- The table reference "users" should be normalized regardless of schema prefix
+CREATE POLICY select_own_orders ON orders
+    FOR SELECT
+    TO PUBLIC
+    USING (user_id IN (SELECT u.id FROM users u WHERE u.tenant_id = 1));

--- a/testdata/diff/create_policy/same_schema_table_reference/old.sql
+++ b/testdata/diff/create_policy/same_schema_table_reference/old.sql
@@ -1,0 +1,14 @@
+-- Test case for Issue #224: Table references in policy expressions
+-- This tests that same-schema table references are properly normalized
+
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    tenant_id INTEGER NOT NULL
+);
+
+CREATE TABLE orders (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id)
+);
+
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;

--- a/testdata/diff/create_policy/same_schema_table_reference/plan.json
+++ b/testdata/diff/create_policy/same_schema_table_reference/plan.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.5.1",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "48bc23dfa4645111f3629340b47451db977912c1c85e523f09f66d9548435fe8"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE POLICY select_own_orders ON orders FOR SELECT TO PUBLIC USING (user_id IN ( SELECT u.id FROM users u WHERE (u.tenant_id = 1)));",
+          "type": "table.policy",
+          "operation": "create",
+          "path": "public.orders.select_own_orders"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_policy/same_schema_table_reference/plan.sql
+++ b/testdata/diff/create_policy/same_schema_table_reference/plan.sql
@@ -1,0 +1,1 @@
+CREATE POLICY select_own_orders ON orders FOR SELECT TO PUBLIC USING (user_id IN ( SELECT u.id FROM users u WHERE (u.tenant_id = 1)));

--- a/testdata/diff/create_policy/same_schema_table_reference/plan.txt
+++ b/testdata/diff/create_policy/same_schema_table_reference/plan.txt
@@ -1,0 +1,13 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ orders
+    + select_own_orders (policy)
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE POLICY select_own_orders ON orders FOR SELECT TO PUBLIC USING (user_id IN ( SELECT u.id FROM users u WHERE (u.tenant_id = 1)));


### PR DESCRIPTION
## Summary

Fixes #224 - Perpetual diffs when policy expressions contain table references in same-schema subqueries.

Following the pattern established in PR #222 for function qualifiers, this extends policy expression normalization to also strip same-schema qualifiers from table references.

**Problem:**
- User writes: `USING (user_id IN (SELECT u.id FROM users u))`
- pgschema adds schema: `FROM public.users u`
- PostgreSQL's `pg_get_expr()` returns: `FROM users u`
- Result: perpetual diff on every plan/apply cycle

**Solution:**
- Add regex pattern to strip same-schema table qualifiers (matching the function qualifier approach)
- Pattern matches `schema.identifier` followed by whitespace, comma, `)`, or end of string

## Changes

- `ir/normalize.go`: Extended `normalizePolicyExpression()` to normalize table references
- `testdata/diff/create_policy/same_schema_table_reference/`: New test case

## Test plan

- [x] New test case passes: `PGSCHEMA_TEST_FILTER="create_policy/same_schema_table_reference" go test ./internal/diff -run TestDiffFromFiles`
- [x] Integration test passes with idempotency check: `PGSCHEMA_TEST_FILTER="create_policy/same_schema_table_reference" go test ./cmd -run TestPlanAndApply`
- [x] All existing policy tests pass: `PGSCHEMA_TEST_FILTER="create_policy/" go test ./internal/diff -run TestDiffFromFiles`
- [x] Verified fix works in downstream project

🤖 Generated with [Claude Code](https://claude.com/claude-code)