### PR TITLE
fix: defer FK constraints until all table batches are created

### DIFF
--- a/testdata/diff/dependency/table_fk_to_generated_column/diff.sql
+++ b/testdata/diff/dependency/table_fk_to_generated_column/diff.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS articlesource (
+    id integer,
+    article_id integer NOT NULL,
+    source_url text,
+    CONSTRAINT articlesource_pkey PRIMARY KEY (id)
+);
+
+CREATE OR REPLACE FUNCTION calc_priority()
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$SELECT 1
+$$;
+
+CREATE TABLE IF NOT EXISTS article (
+    id integer,
+    title text NOT NULL,
+    priority integer GENERATED ALWAYS AS (public.calc_priority()) STORED,
+    CONSTRAINT article_pkey PRIMARY KEY (id)
+);
+
+ALTER TABLE articlesource
+ADD CONSTRAINT articlesource_article_id_fkey FOREIGN KEY (article_id) REFERENCES article (id);

--- a/testdata/diff/dependency/table_fk_to_generated_column/new.sql
+++ b/testdata/diff/dependency/table_fk_to_generated_column/new.sql
@@ -1,0 +1,20 @@
+-- Function used in generated column
+CREATE FUNCTION public.calc_priority() RETURNS integer
+    LANGUAGE sql
+    IMMUTABLE
+    AS $$SELECT 1$$;
+
+-- Table with generated column using the function
+CREATE TABLE public.article (
+    id integer PRIMARY KEY,
+    title text NOT NULL,
+    priority integer GENERATED ALWAYS AS (calc_priority()) STORED
+);
+
+-- Table with FK referencing article
+CREATE TABLE public.articlesource (
+    id integer PRIMARY KEY,
+    article_id integer NOT NULL,
+    source_url text,
+    CONSTRAINT articlesource_article_id_fkey FOREIGN KEY (article_id) REFERENCES public.article(id)
+);

--- a/testdata/diff/dependency/table_fk_to_generated_column/old.sql
+++ b/testdata/diff/dependency/table_fk_to_generated_column/old.sql
@@ -1,0 +1,1 @@
+-- Empty schema (no objects)

--- a/testdata/diff/dependency/table_fk_to_generated_column/plan.json
+++ b/testdata/diff/dependency/table_fk_to_generated_column/plan.json
@@ -1,0 +1,38 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.5.1",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS articlesource (\n    id integer,\n    article_id integer NOT NULL,\n    source_url text,\n    CONSTRAINT articlesource_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.articlesource"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION calc_priority()\nRETURNS integer\nLANGUAGE sql\nIMMUTABLE\nAS $$SELECT 1\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.calc_priority"
+        },
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS article (\n    id integer,\n    title text NOT NULL,\n    priority integer GENERATED ALWAYS AS (public.calc_priority()) STORED,\n    CONSTRAINT article_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.article"
+        },
+        {
+          "sql": "ALTER TABLE articlesource\nADD CONSTRAINT articlesource_article_id_fkey FOREIGN KEY (article_id) REFERENCES article (id);",
+          "type": "table.constraint",
+          "operation": "create",
+          "path": "public.articlesource.articlesource_article_id_fkey"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/dependency/table_fk_to_generated_column/plan.sql
+++ b/testdata/diff/dependency/table_fk_to_generated_column/plan.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS articlesource (
+    id integer,
+    article_id integer NOT NULL,
+    source_url text,
+    CONSTRAINT articlesource_pkey PRIMARY KEY (id)
+);
+
+CREATE OR REPLACE FUNCTION calc_priority()
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$SELECT 1
+$$;
+
+CREATE TABLE IF NOT EXISTS article (
+    id integer,
+    title text NOT NULL,
+    priority integer GENERATED ALWAYS AS (public.calc_priority()) STORED,
+    CONSTRAINT article_pkey PRIMARY KEY (id)
+);
+
+ALTER TABLE articlesource
+ADD CONSTRAINT articlesource_article_id_fkey FOREIGN KEY (article_id) REFERENCES article (id);

--- a/testdata/diff/dependency/table_fk_to_generated_column/plan.txt
+++ b/testdata/diff/dependency/table_fk_to_generated_column/plan.txt
@@ -1,0 +1,40 @@
+Plan: 3 to add.
+
+Summary by type:
+  functions: 1 to add
+  tables: 2 to add
+
+Functions:
+  + calc_priority
+
+Tables:
+  + article
+  + articlesource
+    + articlesource_article_id_fkey (constraint)
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS articlesource (
+    id integer,
+    article_id integer NOT NULL,
+    source_url text,
+    CONSTRAINT articlesource_pkey PRIMARY KEY (id)
+);
+
+CREATE OR REPLACE FUNCTION calc_priority()
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$SELECT 1
+$$;
+
+CREATE TABLE IF NOT EXISTS article (
+    id integer,
+    title text NOT NULL,
+    priority integer GENERATED ALWAYS AS (public.calc_priority()) STORED,
+    CONSTRAINT article_pkey PRIMARY KEY (id)
+);
+
+ALTER TABLE articlesource
+ADD CONSTRAINT articlesource_article_id_fkey FOREIGN KEY (article_id) REFERENCES article (id);

--- a/testdata/dump/tenant/pgschema.sql
+++ b/testdata/dump/tenant/pgschema.sql
@@ -68,13 +68,6 @@ CREATE TABLE IF NOT EXISTS posts (
 );
 
 --
--- Name: posts_author_id_fkey; Type: CONSTRAINT; Schema: -; Owner: -
---
-
-ALTER TABLE posts
-ADD CONSTRAINT posts_author_id_fkey FOREIGN KEY (author_id) REFERENCES users (id);
-
---
 -- Name: auth_uid(); Type: FUNCTION; Schema: -; Owner: -
 --
 
@@ -197,6 +190,13 @@ CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);
 --
 
 ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: posts_author_id_fkey; Type: CONSTRAINT; Schema: -; Owner: -
+--
+
+ALTER TABLE posts
+ADD CONSTRAINT posts_author_id_fkey FOREIGN KEY (author_id) REFERENCES users (id);
 
 --
 -- Name: users_isolation; Type: POLICY; Schema: -; Owner: -


### PR DESCRIPTION
Fix #225

When tables are split into function-dependent and non-function-dependent batches, FK constraints from the first batch were applied before the second batch was created. This caused failures when a table without function dependencies had a FK to a table with function dependencies (e.g., generated columns).

The fix consolidates deferred FK constraint application to run after both table batches are created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)