### PR TITLE
fix: add SearchPath comparison to functionsEqualExceptAttributes

### DIFF
--- a/internal/diff/function.go
+++ b/internal/diff/function.go
@@ -359,6 +359,9 @@ func functionsEqualExceptAttributes(old, new *ir.Function) bool {
 	if old.IsSecurityDefiner != new.IsSecurityDefiner {
 		return false
 	}
+	if old.SearchPath != new.SearchPath {
+		return false
+	}
 	// Note: We intentionally do NOT compare IsLeakproof or Parallel here
 	// That's the whole point - we want to detect when only those attributes changed
 

--- a/testdata/diff/create_function/alter_function_attributes/diff.sql
+++ b/testdata/diff/create_function/alter_function_attributes/diff.sql
@@ -5,3 +5,16 @@ ALTER FUNCTION calculate_total(numeric, numeric) LEAKPROOF;
 ALTER FUNCTION process_data(text) PARALLEL SAFE;
 
 ALTER FUNCTION process_data(text) LEAKPROOF;
+
+CREATE OR REPLACE FUNCTION secure_lookup(
+    id integer
+)
+RETURNS text
+LANGUAGE plpgsql
+VOLATILE
+SET search_path = pg_catalog
+AS $$
+BEGIN
+    RETURN 'result';
+END;
+$$;

--- a/testdata/diff/create_function/alter_function_attributes/new.sql
+++ b/testdata/diff/create_function/alter_function_attributes/new.sql
@@ -19,3 +19,13 @@ LEAKPROOF
 AS $$
     SELECT amount * (1 + tax_rate);
 $$;
+
+CREATE FUNCTION secure_lookup(id integer)
+RETURNS text
+LANGUAGE plpgsql
+SET search_path = pg_catalog
+AS $$
+BEGIN
+    RETURN 'result';
+END;
+$$;

--- a/testdata/diff/create_function/alter_function_attributes/old.sql
+++ b/testdata/diff/create_function/alter_function_attributes/old.sql
@@ -15,3 +15,12 @@ STABLE
 AS $$
     SELECT amount * (1 + tax_rate);
 $$;
+
+CREATE FUNCTION secure_lookup(id integer)
+RETURNS text
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN 'result';
+END;
+$$;

--- a/testdata/diff/create_function/alter_function_attributes/plan.json
+++ b/testdata/diff/create_function/alter_function_attributes/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.6.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "d3760381c0e30abb35769924c7ae22d0868a81496ec73d6c427a39d4a3abe131"
+    "hash": "1f121ae09b8a9c9a88444396c16c27b8690f6ff7a123cf72c204103111a49649"
   },
   "groups": [
     {
@@ -31,6 +31,12 @@
           "type": "function",
           "operation": "alter",
           "path": "public.process_data"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION secure_lookup(\n    id integer\n)\nRETURNS text\nLANGUAGE plpgsql\nVOLATILE\nSET search_path = pg_catalog\nAS $$\nBEGIN\n    RETURN 'result';\nEND;\n$$;",
+          "type": "function",
+          "operation": "alter",
+          "path": "public.secure_lookup"
         }
       ]
     }

--- a/testdata/diff/create_function/alter_function_attributes/plan.sql
+++ b/testdata/diff/create_function/alter_function_attributes/plan.sql
@@ -5,3 +5,16 @@ ALTER FUNCTION calculate_total(numeric, numeric) LEAKPROOF;
 ALTER FUNCTION process_data(text) PARALLEL SAFE;
 
 ALTER FUNCTION process_data(text) LEAKPROOF;
+
+CREATE OR REPLACE FUNCTION secure_lookup(
+    id integer
+)
+RETURNS text
+LANGUAGE plpgsql
+VOLATILE
+SET search_path = pg_catalog
+AS $$
+BEGIN
+    RETURN 'result';
+END;
+$$;

--- a/testdata/diff/create_function/alter_function_attributes/plan.txt
+++ b/testdata/diff/create_function/alter_function_attributes/plan.txt
@@ -1,13 +1,14 @@
-Plan: 4 to modify.
+Plan: 5 to modify.
 
 Summary by type:
-  functions: 4 to modify
+  functions: 5 to modify
 
 Functions:
   ~ calculate_total
   ~ calculate_total
   ~ process_data
   ~ process_data
+  ~ secure_lookup
 
 DDL to be executed:
 --------------------------------------------------
@@ -19,3 +20,16 @@ ALTER FUNCTION calculate_total(numeric, numeric) LEAKPROOF;
 ALTER FUNCTION process_data(text) PARALLEL SAFE;
 
 ALTER FUNCTION process_data(text) LEAKPROOF;
+
+CREATE OR REPLACE FUNCTION secure_lookup(
+    id integer
+)
+RETURNS text
+LANGUAGE plpgsql
+VOLATILE
+SET search_path = pg_catalog
+AS $$
+BEGIN
+    RETURN 'result';
+END;
+$$;


### PR DESCRIPTION
## Summary

- Fixed bug where `SET search_path` changes were detected but silently dropped (no DDL generated)
- Added missing `SearchPath` field comparison to `functionsEqualExceptAttributes()` in `internal/diff/function.go`
- Extended existing `alter_function_attributes` test case to cover SearchPath changes

## Root Cause

The `functionsEqualExceptAttributes()` function was missing a `SearchPath` comparison, while the other two comparison functions (`functionsEqual` and `functionsEqualExceptComment`) correctly compared it. This caused the function to incorrectly return `true` when only SearchPath differed, entering the attribute-only branch which only handles `Parallel` and `IsLeakproof`.

## Test plan

- [x] Added test function to existing `alter_function_attributes` test case
- [x] Verified test fails before fix (SearchPath change produces no DDL)
- [x] Verified test passes after fix (SearchPath change produces CREATE OR REPLACE)
- [x] `PGSCHEMA_TEST_FILTER="create_function/alter_function_attributes" go test -v ./internal/diff -run TestDiffFromFiles`
- [x] `PGSCHEMA_TEST_FILTER="create_function/alter_function_attributes" go test -v ./cmd -run TestPlanAndApply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)