### PR TITLE
feat: add support for column-level GRANT privileges

### DIFF
--- a/internal/diff/column_privilege.go
+++ b/internal/diff/column_privilege.go
@@ -1,0 +1,264 @@
+package diff
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pgschema/pgschema/ir"
+)
+
+// generateCreateColumnPrivilegesSQL generates GRANT statements for new column privileges
+func generateCreateColumnPrivilegesSQL(privileges []*ir.ColumnPrivilege, targetSchema string, collector *diffCollector) {
+	for _, cp := range privileges {
+		sql := generateGrantColumnPrivilegeSQL(cp)
+
+		// Path format: column_privileges.TABLE.{table_name}.{columns}.{grantee}
+		sortedCols := make([]string, len(cp.Columns))
+		copy(sortedCols, cp.Columns)
+		sort.Strings(sortedCols)
+		colKey := strings.Join(sortedCols, ",")
+
+		context := &diffContext{
+			Type:                DiffTypeColumnPrivilege,
+			Operation:           DiffOperationCreate,
+			Path:                fmt.Sprintf("column_privileges.TABLE.%s.%s.%s", cp.TableName, colKey, cp.Grantee),
+			Source:              cp,
+			CanRunInTransaction: true,
+		}
+
+		collector.collect(context, sql)
+	}
+}
+
+// generateDropColumnPrivilegesSQL generates REVOKE statements for removed column privileges
+func generateDropColumnPrivilegesSQL(privileges []*ir.ColumnPrivilege, targetSchema string, collector *diffCollector) {
+	for _, cp := range privileges {
+		sql := generateRevokeColumnPrivilegeSQL(cp)
+
+		sortedCols := make([]string, len(cp.Columns))
+		copy(sortedCols, cp.Columns)
+		sort.Strings(sortedCols)
+		colKey := strings.Join(sortedCols, ",")
+
+		context := &diffContext{
+			Type:                DiffTypeColumnPrivilege,
+			Operation:           DiffOperationDrop,
+			Path:                fmt.Sprintf("column_privileges.TABLE.%s.%s.%s", cp.TableName, colKey, cp.Grantee),
+			Source:              cp,
+			CanRunInTransaction: true,
+		}
+
+		collector.collect(context, sql)
+	}
+}
+
+// generateModifyColumnPrivilegesSQL generates ALTER column privilege statements for modifications
+func generateModifyColumnPrivilegesSQL(diffs []*columnPrivilegeDiff, targetSchema string, collector *diffCollector) {
+	for _, diff := range diffs {
+		statements := diff.generateAlterColumnPrivilegeStatements()
+
+		sortedCols := make([]string, len(diff.New.Columns))
+		copy(sortedCols, diff.New.Columns)
+		sort.Strings(sortedCols)
+		colKey := strings.Join(sortedCols, ",")
+
+		for _, stmt := range statements {
+			context := &diffContext{
+				Type:                DiffTypeColumnPrivilege,
+				Operation:           DiffOperationAlter,
+				Path:                fmt.Sprintf("column_privileges.TABLE.%s.%s.%s", diff.New.TableName, colKey, diff.New.Grantee),
+				Source:              diff,
+				CanRunInTransaction: true,
+			}
+
+			collector.collect(context, stmt)
+		}
+	}
+}
+
+// generateGrantColumnPrivilegeSQL generates a GRANT statement for column privileges
+func generateGrantColumnPrivilegeSQL(cp *ir.ColumnPrivilege) string {
+	// Sort privileges for deterministic output
+	sortedPrivs := make([]string, len(cp.Privileges))
+	copy(sortedPrivs, cp.Privileges)
+	sort.Strings(sortedPrivs)
+
+	privStr := strings.Join(sortedPrivs, ", ")
+
+	// Format columns with proper quoting
+	quotedCols := make([]string, len(cp.Columns))
+	for i, col := range cp.Columns {
+		quotedCols[i] = ir.QuoteIdentifier(col)
+	}
+	sort.Strings(quotedCols)
+	colStr := strings.Join(quotedCols, ", ")
+
+	grantee := formatGrantee(cp.Grantee)
+	tableName := ir.QuoteIdentifier(cp.TableName)
+
+	sql := fmt.Sprintf("GRANT %s (%s) ON TABLE %s TO %s", privStr, colStr, tableName, grantee)
+
+	if cp.WithGrantOption {
+		sql += " WITH GRANT OPTION"
+	}
+
+	return sql + ";"
+}
+
+// generateRevokeColumnPrivilegeSQL generates a REVOKE statement for column privileges
+func generateRevokeColumnPrivilegeSQL(cp *ir.ColumnPrivilege) string {
+	// Sort privileges for deterministic output
+	sortedPrivs := make([]string, len(cp.Privileges))
+	copy(sortedPrivs, cp.Privileges)
+	sort.Strings(sortedPrivs)
+
+	privStr := strings.Join(sortedPrivs, ", ")
+
+	// Format columns with proper quoting
+	quotedCols := make([]string, len(cp.Columns))
+	for i, col := range cp.Columns {
+		quotedCols[i] = ir.QuoteIdentifier(col)
+	}
+	sort.Strings(quotedCols)
+	colStr := strings.Join(quotedCols, ", ")
+
+	grantee := formatGrantee(cp.Grantee)
+	tableName := ir.QuoteIdentifier(cp.TableName)
+
+	return fmt.Sprintf("REVOKE %s (%s) ON TABLE %s FROM %s;", privStr, colStr, tableName, grantee)
+}
+
+// generateAlterColumnPrivilegeStatements generates statements for column privilege modifications
+func (d *columnPrivilegeDiff) generateAlterColumnPrivilegeStatements() []string {
+	var statements []string
+
+	// Find privileges to revoke (in old but not in new)
+	oldPrivSet := make(map[string]bool)
+	for _, p := range d.Old.Privileges {
+		oldPrivSet[p] = true
+	}
+	newPrivSet := make(map[string]bool)
+	for _, p := range d.New.Privileges {
+		newPrivSet[p] = true
+	}
+
+	var toRevoke []string
+	for p := range oldPrivSet {
+		if !newPrivSet[p] {
+			toRevoke = append(toRevoke, p)
+		}
+	}
+
+	var toGrant []string
+	for p := range newPrivSet {
+		if !oldPrivSet[p] {
+			toGrant = append(toGrant, p)
+		}
+	}
+
+	grantee := formatGrantee(d.New.Grantee)
+	tableName := ir.QuoteIdentifier(d.New.TableName)
+
+	// Format columns with proper quoting
+	quotedCols := make([]string, len(d.New.Columns))
+	for i, col := range d.New.Columns {
+		quotedCols[i] = ir.QuoteIdentifier(col)
+	}
+	sort.Strings(quotedCols)
+	colStr := strings.Join(quotedCols, ", ")
+
+	// Generate REVOKE for removed privileges
+	if len(toRevoke) > 0 {
+		sort.Strings(toRevoke)
+		statements = append(statements, fmt.Sprintf("REVOKE %s (%s) ON TABLE %s FROM %s;",
+			strings.Join(toRevoke, ", "), colStr, tableName, grantee))
+	}
+
+	// Generate GRANT for added privileges
+	if len(toGrant) > 0 {
+		sort.Strings(toGrant)
+		sql := fmt.Sprintf("GRANT %s (%s) ON TABLE %s TO %s",
+			strings.Join(toGrant, ", "), colStr, tableName, grantee)
+		if d.New.WithGrantOption {
+			sql += " WITH GRANT OPTION"
+		}
+		statements = append(statements, sql+";")
+	}
+
+	// Handle WITH GRANT OPTION changes for unchanged privileges
+	if d.Old.WithGrantOption != d.New.WithGrantOption {
+		// Find unchanged privileges (in both old and new)
+		var unchanged []string
+		for p := range oldPrivSet {
+			if newPrivSet[p] {
+				unchanged = append(unchanged, p)
+			}
+		}
+
+		if len(unchanged) > 0 {
+			sort.Strings(unchanged)
+			unchangedStr := strings.Join(unchanged, ", ")
+
+			if d.Old.WithGrantOption && !d.New.WithGrantOption {
+				// Revoke grant option only (keep the privilege)
+				statements = append(statements, fmt.Sprintf("REVOKE GRANT OPTION FOR %s (%s) ON TABLE %s FROM %s;",
+					unchangedStr, colStr, tableName, grantee))
+			} else if !d.Old.WithGrantOption && d.New.WithGrantOption {
+				// Add grant option (re-grant with grant option)
+				statements = append(statements, fmt.Sprintf("GRANT %s (%s) ON TABLE %s TO %s WITH GRANT OPTION;",
+					unchangedStr, colStr, tableName, grantee))
+			}
+		}
+	}
+
+	return statements
+}
+
+// columnPrivilegesEqual checks if two column privileges are structurally equal
+func columnPrivilegesEqual(old, new *ir.ColumnPrivilege) bool {
+	if old.TableName != new.TableName {
+		return false
+	}
+	if old.Grantee != new.Grantee {
+		return false
+	}
+	if old.WithGrantOption != new.WithGrantOption {
+		return false
+	}
+
+	// Compare columns (order-independent)
+	if len(old.Columns) != len(new.Columns) {
+		return false
+	}
+	oldColSet := make(map[string]bool)
+	for _, c := range old.Columns {
+		oldColSet[c] = true
+	}
+	for _, c := range new.Columns {
+		if !oldColSet[c] {
+			return false
+		}
+	}
+
+	// Compare privileges (order-independent)
+	if len(old.Privileges) != len(new.Privileges) {
+		return false
+	}
+	oldPrivSet := make(map[string]bool)
+	for _, p := range old.Privileges {
+		oldPrivSet[p] = true
+	}
+	for _, p := range new.Privileges {
+		if !oldPrivSet[p] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// GetObjectName returns a unique identifier for the column privilege diff
+func (d *columnPrivilegeDiff) GetObjectName() string {
+	return d.New.GetObjectKey()
+}

--- a/internal/dump/formatter.go
+++ b/internal/dump/formatter.go
@@ -242,7 +242,7 @@ func (f *DumpFormatter) getObjectDirectory(objectType string) string {
 		return "tables" // fallback, will be overridden
 	case "default_privilege":
 		return "default_privileges"
-	case "privilege", "revoked_default_privilege":
+	case "privilege", "revoked_default_privilege", "column_privilege":
 		return "privileges"
 	default:
 		return "misc"
@@ -352,6 +352,9 @@ func (f *DumpFormatter) getGroupingName(step diff.Diff) string {
 		if parts := strings.Split(step.Path, "."); len(parts) >= 2 {
 			return parts[1] // Return object type
 		}
+	case diff.DiffTypeColumnPrivilege:
+		// For column privileges, group by TABLE (always table-based)
+		return "TABLE"
 	}
 
 	// For standalone objects or if table name extraction fails, use object name

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -102,6 +102,7 @@ const (
 	TypeRLS                     Type = "rls"
 	TypeDefaultPrivilege        Type = "default privileges"
 	TypePrivilege               Type = "privileges"
+	TypeColumnPrivilege         Type = "column privileges"
 	TypeRevokedDefaultPrivilege Type = "revoked default privileges"
 )
 
@@ -133,6 +134,7 @@ func getObjectOrder() []Type {
 		TypeColumn,
 		TypeRLS,
 		TypePrivilege,
+		TypeColumnPrivilege,
 		TypeRevokedDefaultPrivilege,
 	}
 }

--- a/testdata/diff/privilege/grant_table_select/diff.sql
+++ b/testdata/diff/privilege/grant_table_select/diff.sql
@@ -1,1 +1,2 @@
 GRANT SELECT ON TABLE users TO readonly_role;
+GRANT SELECT (id) ON TABLE users TO column_reader;

--- a/testdata/diff/privilege/grant_table_select/new.sql
+++ b/testdata/diff/privilege/grant_table_select/new.sql
@@ -3,8 +3,15 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'readonly_role') THEN
         CREATE ROLE readonly_role;
     END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'column_reader') THEN
+        CREATE ROLE column_reader;
+    END IF;
 END $$;
 
 CREATE TABLE users (id serial PRIMARY KEY);
 
+-- Table-level grant (existing)
 GRANT SELECT ON users TO readonly_role;
+
+-- Column-level grant (new - tests column privilege support)
+GRANT SELECT (id) ON users TO column_reader;

--- a/testdata/diff/privilege/grant_table_select/old.sql
+++ b/testdata/diff/privilege/grant_table_select/old.sql
@@ -3,6 +3,9 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'readonly_role') THEN
         CREATE ROLE readonly_role;
     END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'column_reader') THEN
+        CREATE ROLE column_reader;
+    END IF;
 END $$;
 
 CREATE TABLE users (id serial PRIMARY KEY);

--- a/testdata/diff/privilege/grant_table_select/plan.json
+++ b/testdata/diff/privilege/grant_table_select/plan.json
@@ -13,6 +13,12 @@
           "type": "privilege",
           "operation": "create",
           "path": "privileges.TABLE.users.readonly_role"
+        },
+        {
+          "sql": "GRANT SELECT (id) ON TABLE users TO column_reader;",
+          "type": "column_privilege",
+          "operation": "create",
+          "path": "column_privileges.TABLE.users.id.column_reader"
         }
       ]
     }

--- a/testdata/diff/privilege/grant_table_select/plan.sql
+++ b/testdata/diff/privilege/grant_table_select/plan.sql
@@ -1,1 +1,3 @@
 GRANT SELECT ON TABLE users TO readonly_role;
+
+GRANT SELECT (id) ON TABLE users TO column_reader;

--- a/testdata/diff/privilege/grant_table_select/plan.txt
+++ b/testdata/diff/privilege/grant_table_select/plan.txt
@@ -1,12 +1,18 @@
-Plan: 1 to add.
+Plan: 2 to add.
 
 Summary by type:
   privileges: 1 to add
+  column privileges: 1 to add
 
 Privileges:
   + readonly_role
+
+Column privileges:
+  + column_reader
 
 DDL to be executed:
 --------------------------------------------------
 
 GRANT SELECT ON TABLE users TO readonly_role;
+
+GRANT SELECT (id) ON TABLE users TO column_reader;


### PR DESCRIPTION
## Summary

- Column-level privileges like `GRANT SELECT (col1, col2) ON TABLE t TO role` were previously silently ignored during schema inspection
- This caused privilege drift between desired and actual state - column grants in schema files would not be detected or included in migration plans
- This PR adds full support for column-level privileges

## Changes

- Add `ColumnPrivilege` struct to IR with proper identity (table + columns + grantee)
- Add `GetColumnPrivilegesForSchema` query to extract from `pg_attribute.attacl`
- Add `buildColumnPrivileges` to inspector to resolve grantee OIDs and group columns
- Add `DiffTypeColumnPrivilege` and comparison logic in diff package
- Add `column_privilege.go` with GRANT/REVOKE DDL generation
- Update formatter and plan output to display column privileges

## Test plan

- [x] Extended existing `grant_table_select` test case with column-level GRANT
- [x] Used TDD approach: added expected output first to verify test failure, then implemented feature and verified test passes
- [x] Verified both diff unit tests (`TestDiffFromFiles`) and integration tests (`TestPlanAndApply`) pass
- [x] Ran full test suite to ensure no regressions across all 100+ test cases