### PR TITLE
fix: ensure embedded postgres cleanup in TestMain

### DIFF
--- a/cmd/apply/apply_integration_test.go
+++ b/cmd/apply/apply_integration_test.go
@@ -30,11 +30,7 @@ func TestMain(m *testing.M) {
 	sharedEmbeddedPG = testutil.SetupPostgres(nil)
 	defer sharedEmbeddedPG.Stop()
 
-	// Run tests
-	code := m.Run()
-
-	// Exit with test result code
-	os.Exit(code)
+	m.Run()
 }
 
 // TestApplyCommand_TransactionRollback verifies that the apply command uses proper

--- a/cmd/migrate_integration_test.go
+++ b/cmd/migrate_integration_test.go
@@ -37,11 +37,7 @@ func TestMain(m *testing.M) {
 	sharedEmbeddedPG = testutil.SetupPostgres(nil)
 	defer sharedEmbeddedPG.Stop()
 
-	// Run tests
-	code := m.Run()
-
-	// Exit with test result code
-	os.Exit(code)
+	m.Run()
 }
 
 // TestPlanAndApply tests the complete CLI (plan and apply) workflow using test cases

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -19,11 +19,7 @@ func TestMain(m *testing.M) {
 	sharedTestPostgres = testutil.SetupPostgres(nil)
 	defer sharedTestPostgres.Stop()
 
-	// Run tests
-	code := m.Run()
-
-	// Exit with test result code
-	os.Exit(code)
+	m.Run()
 }
 
 // buildSQLFromSteps builds a SQL string from collected plan diffs

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -26,11 +26,7 @@ func TestMain(m *testing.M) {
 	sharedTestPostgres = testutil.SetupPostgres(nil)
 	defer sharedTestPostgres.Stop()
 
-	// Run tests
-	code := m.Run()
-
-	// Exit with test result code
-	os.Exit(code)
+	m.Run()
 }
 
 // discoverTestDataVersions discovers available test data versions in the testdata directory


### PR DESCRIPTION
## Summary

- Remove `os.Exit()` calls from `TestMain` functions to allow deferred `Stop()` calls to execute properly
- Fixes embedded postgres process leaks after test runs

## Problem

The `TestMain` functions in 4 test files were calling `os.Exit(code)` after `m.Run()`. In Go, `os.Exit()` terminates the program immediately **without running deferred functions**. This meant `defer sharedEmbeddedPG.Stop()` never executed, leaving orphaned postgres processes after each test package run.

## Solution

Go 1.15+ automatically handles the exit code when `TestMain` returns without calling `os.Exit()`. By simply removing the `os.Exit()` calls, the deferred cleanup now executes properly.

Ref: https://github.com/golang/go/issues/34129

## Test plan

- [x] Verified no postgres processes running before tests (`ps aux | grep postgres`)
- [x] Ran `go test ./...`
- [x] Confirmed postgres processes are cleaned up after tests complete
- [x] `go build ./...` passes