### PR TITLE
fix: emit REVOKE statements before DROP statements

### DIFF
--- a/testdata/diff/create_function/drop_function/diff.sql
+++ b/testdata/diff/create_function/drop_function/diff.sql
@@ -1,3 +1,4 @@
+REVOKE EXECUTE ON FUNCTION process_order(order_id integer, discount_percent numeric) FROM api_role;
 DROP FUNCTION IF EXISTS get_user_stats(integer);
 DROP FUNCTION IF EXISTS process_order(integer, numeric);
 DROP FUNCTION IF EXISTS process_payment(integer, text);

--- a/testdata/diff/create_function/drop_function/old.sql
+++ b/testdata/diff/create_function/drop_function/old.sql
@@ -55,3 +55,13 @@ BEGIN
     processed_at := NOW();
 END;
 $$;
+
+-- Role and grant for testing REVOKE ordering
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'api_role') THEN
+        CREATE ROLE api_role;
+    END IF;
+END $$;
+
+GRANT EXECUTE ON FUNCTION process_order(integer, numeric) TO api_role;

--- a/testdata/diff/create_function/drop_function/plan.json
+++ b/testdata/diff/create_function/drop_function/plan.json
@@ -3,11 +3,17 @@
   "pgschema_version": "1.6.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "1228242f86da4b19cafc006075668cd3e73588c01012241f6e72ed02432a158b"
+    "hash": "755b64b40a0ad2e6918bb3ff23f9b9ac6936c38ff588b5ad7ddc98bbf36315de"
   },
   "groups": [
     {
       "steps": [
+        {
+          "sql": "REVOKE EXECUTE ON FUNCTION process_order(order_id integer, discount_percent numeric) FROM api_role;",
+          "type": "privilege",
+          "operation": "drop",
+          "path": "privileges.FUNCTION.process_order(order_id integer, discount_percent numeric).api_role"
+        },
         {
           "sql": "DROP FUNCTION IF EXISTS get_user_stats(integer);",
           "type": "function",

--- a/testdata/diff/create_function/drop_function/plan.sql
+++ b/testdata/diff/create_function/drop_function/plan.sql
@@ -1,3 +1,5 @@
+REVOKE EXECUTE ON FUNCTION process_order(order_id integer, discount_percent numeric) FROM api_role;
+
 DROP FUNCTION IF EXISTS get_user_stats(integer);
 
 DROP FUNCTION IF EXISTS process_order(integer, numeric);

--- a/testdata/diff/create_function/drop_function/plan.txt
+++ b/testdata/diff/create_function/drop_function/plan.txt
@@ -1,15 +1,21 @@
-Plan: 3 to drop.
+Plan: 4 to drop.
 
 Summary by type:
   functions: 3 to drop
+  privileges: 1 to drop
 
 Functions:
   - get_user_stats
   - process_order
   - process_payment
 
+Privileges:
+  - api_role
+
 DDL to be executed:
 --------------------------------------------------
+
+REVOKE EXECUTE ON FUNCTION process_order(order_id integer, discount_percent numeric) FROM api_role;
 
 DROP FUNCTION IF EXISTS get_user_stats(integer);
 


### PR DESCRIPTION
## Summary
- Fix incorrect ordering where REVOKE statements were emitted after DROP statements
- Objects must exist for REVOKE to succeed, so REVOKEs must come before DROPs

## Problem
When dropping objects (functions, tables, etc.) that have explicit privileges granted, pgschema generated:
```sql
DROP FUNCTION IF EXISTS example_function();
REVOKE EXECUTE ON FUNCTION example_function() FROM service_role;  -- FAILS!
```

The REVOKE fails with "function does not exist" because the object was already dropped.

## Fix
Reorder `generateDropSQL()` in `internal/diff/diff.go` to emit privilege revocations before object drops.

## Test plan
- [x] Extended `create_function/drop_function` test to include a function with GRANT EXECUTE
- [x] Verified REVOKE now comes before DROP in generated DDL
- [x] All `privilege/` tests pass (10 tests)
- [x] All `create_function/` tests pass (5 tests)