### PR TITLE
refactor: convert multi-pass to single-pass in plan module

### DIFF
--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -486,7 +486,7 @@ func (p *Plan) calculateSummaryFromSteps() PlanSummary {
 			materializedViewOperations[step.Path] = step.Operation
 		} else if isSubResource(step.Type) {
 			// For sub-resources, determine parent type from step.Type prefix
-			// Types are: "table.index", "view.index", "materialized_view.index", etc.
+			// Types are: "table.index", "table.column", "view.comment", "materialized_view.index", etc.
 			parentPath := extractTablePathFromSubResource(step.Path, step.Type)
 			if parentPath != "" {
 				if strings.HasPrefix(step.Type, "materialized_view.") {


### PR DESCRIPTION
Related #240

- groupDiffs: merge three loops into one by tracking creates incrementally (diffs are topologically sorted, so creates come before dependent operations)
- calculateSummaryFromSteps: remove pre-scan loop by determining parent type directly from step.Type prefix (table.index, view.index, materialized_view.index)