### PR TITLE
fix: missing parentheses in CREATE POLICY USING clause output

### DIFF
--- a/testdata/diff/create_policy/add_policy/diff.sql
+++ b/testdata/diff/create_policy/add_policy/diff.sql
@@ -1,6 +1,7 @@
 ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
 CREATE POLICY orders_user_access ON orders FOR SELECT TO PUBLIC USING (user_id IN ( SELECT users.id FROM users));
 CREATE POLICY "UserPolicy" ON users TO PUBLIC USING (tenant_id = current_setting('app.current_tenant')::integer);
+CREATE POLICY admin_only ON users FOR DELETE TO PUBLIC USING (is_admin());
 CREATE POLICY "my-policy" ON users FOR INSERT TO PUBLIC WITH CHECK ((role)::text = 'user');
 CREATE POLICY "select" ON users FOR SELECT TO PUBLIC USING (true);
 CREATE POLICY user_tenant_isolation ON users FOR UPDATE TO PUBLIC USING (tenant_id = current_setting('app.current_tenant')::integer);

--- a/testdata/diff/create_policy/add_policy/new.sql
+++ b/testdata/diff/create_policy/add_policy/new.sql
@@ -11,11 +11,21 @@ CREATE TABLE orders (
     total NUMERIC(10,2)
 );
 
+-- Function to check if user is admin (for Issue #259)
+CREATE FUNCTION is_admin() RETURNS boolean LANGUAGE sql AS $$ SELECT true $$;
+
 -- RLS is enabled with multiple policies demonstrating quoting scenarios
 ALTER TABLE users ENABLE ROW LEVEL SECURITY;
 
 -- RLS on orders with policy referencing users table (Issue #224)
 ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+
+-- Policy with function call in USING clause (Issue #259)
+-- Tests that parentheses are correctly preserved around function calls
+CREATE POLICY admin_only ON users
+    FOR DELETE
+    TO PUBLIC
+    USING (is_admin());
 
 -- Policy with reserved word name (requires quoting)
 CREATE POLICY "select" ON users

--- a/testdata/diff/create_policy/add_policy/old.sql
+++ b/testdata/diff/create_policy/add_policy/old.sql
@@ -11,5 +11,8 @@ CREATE TABLE orders (
     total NUMERIC(10,2)
 );
 
+-- Function to check if user is admin (for Issue #259)
+CREATE FUNCTION is_admin() RETURNS boolean LANGUAGE sql AS $$ SELECT true $$;
+
 -- RLS is enabled but no policies exist yet
 ALTER TABLE users ENABLE ROW LEVEL SECURITY;

--- a/testdata/diff/create_policy/add_policy/plan.json
+++ b/testdata/diff/create_policy/add_policy/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.6.1",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "9323772d9678bd1630383ff088214914f1c01c427086930540c96be45e4be387"
+    "hash": "261f1966678419184a6d17b5ad2c09d590b77fff9dbe01fd56849d53f3079c8e"
   },
   "groups": [
     {
@@ -25,6 +25,12 @@
           "type": "table.policy",
           "operation": "create",
           "path": "public.users.UserPolicy"
+        },
+        {
+          "sql": "CREATE POLICY admin_only ON users FOR DELETE TO PUBLIC USING (is_admin());",
+          "type": "table.policy",
+          "operation": "create",
+          "path": "public.users.admin_only"
         },
         {
           "sql": "CREATE POLICY \"my-policy\" ON users FOR INSERT TO PUBLIC WITH CHECK ((role)::text = 'user');",

--- a/testdata/diff/create_policy/add_policy/plan.sql
+++ b/testdata/diff/create_policy/add_policy/plan.sql
@@ -4,6 +4,8 @@ CREATE POLICY orders_user_access ON orders FOR SELECT TO PUBLIC USING (user_id I
 
 CREATE POLICY "UserPolicy" ON users TO PUBLIC USING (tenant_id = current_setting('app.current_tenant')::integer);
 
+CREATE POLICY admin_only ON users FOR DELETE TO PUBLIC USING (is_admin());
+
 CREATE POLICY "my-policy" ON users FOR INSERT TO PUBLIC WITH CHECK ((role)::text = 'user');
 
 CREATE POLICY "select" ON users FOR SELECT TO PUBLIC USING (true);

--- a/testdata/diff/create_policy/add_policy/plan.txt
+++ b/testdata/diff/create_policy/add_policy/plan.txt
@@ -9,6 +9,7 @@ Tables:
     + orders (rls)
   ~ users
     + UserPolicy (policy)
+    + admin_only (policy)
     + my-policy (policy)
     + select (policy)
     + user_tenant_isolation (policy)
@@ -21,6 +22,8 @@ ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
 CREATE POLICY orders_user_access ON orders FOR SELECT TO PUBLIC USING (user_id IN ( SELECT users.id FROM users));
 
 CREATE POLICY "UserPolicy" ON users TO PUBLIC USING (tenant_id = current_setting('app.current_tenant')::integer);
+
+CREATE POLICY admin_only ON users FOR DELETE TO PUBLIC USING (is_admin());
 
 CREATE POLICY "my-policy" ON users FOR INSERT TO PUBLIC WITH CHECK ((role)::text = 'user');
 


### PR DESCRIPTION
PostgreSQL's CREATE POLICY syntax requires parentheses around USING and WITH CHECK expressions. When pg_get_expr returns simple function calls without outer parentheses (e.g., is_admin()), pgschema was outputting invalid SQL like `USING is_admin()` instead of `USING (is_admin())`.

Added ensureParentheses() helper to wrap expressions in parentheses if not already wrapped.

Fix #259