### PR TITLE
fix(internal): apply QuotedIdentifier in more cases

### DIFF
--- a/internal/diff/column.go
+++ b/internal/diff/column.go
@@ -27,7 +27,7 @@ func (cd *ColumnDiff) generateColumnSQL(tableSchema, tableName string, targetSch
 	// If type is changing with USING clause and there's an existing default, drop the default first
 	if needsUsing && hasOldDefault {
 		sql := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP DEFAULT;",
-			qualifiedTableName, cd.New.Name)
+			qualifiedTableName, ir.QuoteIdentifier(cd.New.Name))
 		statements = append(statements, sql)
 	}
 
@@ -38,11 +38,11 @@ func (cd *ColumnDiff) generateColumnSQL(tableSchema, tableName string, targetSch
 		// because PostgreSQL cannot implicitly cast these types
 		if needsUsing {
 			sql := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s TYPE %s USING %s::%s;",
-				qualifiedTableName, cd.New.Name, newType, cd.New.Name, newType)
+				qualifiedTableName, ir.QuoteIdentifier(cd.New.Name), newType, ir.QuoteIdentifier(cd.New.Name), newType)
 			statements = append(statements, sql)
 		} else {
 			sql := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s TYPE %s;",
-				qualifiedTableName, cd.New.Name, newType)
+				qualifiedTableName, ir.QuoteIdentifier(cd.New.Name), newType)
 			statements = append(statements, sql)
 		}
 	}
@@ -52,12 +52,12 @@ func (cd *ColumnDiff) generateColumnSQL(tableSchema, tableName string, targetSch
 		if cd.New.IsNullable {
 			// DROP NOT NULL
 			sql := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL;",
-				qualifiedTableName, cd.New.Name)
+				qualifiedTableName, ir.QuoteIdentifier(cd.New.Name))
 			statements = append(statements, sql)
 		} else {
 			// ADD NOT NULL - generate canonical SQL only
 			sql := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET NOT NULL;",
-				qualifiedTableName, cd.New.Name)
+				qualifiedTableName, ir.QuoteIdentifier(cd.New.Name))
 			statements = append(statements, sql)
 		}
 	}
@@ -69,7 +69,7 @@ func (cd *ColumnDiff) generateColumnSQL(tableSchema, tableName string, targetSch
 		// Default was dropped above; add new default if specified
 		if newDefault != nil && *newDefault != "" {
 			sql := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s;",
-				qualifiedTableName, cd.New.Name, *newDefault)
+				qualifiedTableName, ir.QuoteIdentifier(cd.New.Name), *newDefault)
 			statements = append(statements, sql)
 		}
 	} else {
@@ -80,10 +80,10 @@ func (cd *ColumnDiff) generateColumnSQL(tableSchema, tableName string, targetSch
 			var sql string
 			if newDefault == nil {
 				sql = fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP DEFAULT;",
-					qualifiedTableName, cd.New.Name)
+					qualifiedTableName, ir.QuoteIdentifier(cd.New.Name))
 			} else {
 				sql = fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s;",
-					qualifiedTableName, cd.New.Name, *newDefault)
+					qualifiedTableName, ir.QuoteIdentifier(cd.New.Name), *newDefault)
 			}
 
 			statements = append(statements, sql)

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -437,7 +437,7 @@ func generateCreateTablesSQL(
 		for _, column := range table.Columns {
 			if column.Comment != "" {
 				tableName := qualifyEntityName(table.Schema, table.Name, targetSchema)
-				sql := fmt.Sprintf("COMMENT ON COLUMN %s.%s IS %s;", tableName, column.Name, quoteString(column.Comment))
+				sql := fmt.Sprintf("COMMENT ON COLUMN %s.%s IS %s;", tableName, ir.QuoteIdentifier(column.Name), quoteString(column.Comment))
 
 				// Create context for this statement
 				context := &diffContext{
@@ -1163,9 +1163,9 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			tableName := getTableNameWithSchema(td.Table.Schema, td.Table.Name, targetSchema)
 			var sql string
 			if colDiff.New.Comment == "" {
-				sql = fmt.Sprintf("COMMENT ON COLUMN %s.%s IS NULL;", tableName, colDiff.New.Name)
+				sql = fmt.Sprintf("COMMENT ON COLUMN %s.%s IS NULL;", tableName, ir.QuoteIdentifier(colDiff.New.Name))
 			} else {
-				sql = fmt.Sprintf("COMMENT ON COLUMN %s.%s IS %s;", tableName, colDiff.New.Name, quoteString(colDiff.New.Comment))
+				sql = fmt.Sprintf("COMMENT ON COLUMN %s.%s IS %s;", tableName, ir.QuoteIdentifier(colDiff.New.Name), quoteString(colDiff.New.Comment))
 			}
 
 			context := &diffContext{

--- a/testdata/diff/comment/column_comment_quoted_identifier/diff.sql
+++ b/testdata/diff/comment/column_comment_quoted_identifier/diff.sql
@@ -1,0 +1,1 @@
+COMMENT ON COLUMN ex."ID" IS 'Primary identifier';

--- a/testdata/diff/comment/column_comment_quoted_identifier/new.sql
+++ b/testdata/diff/comment/column_comment_quoted_identifier/new.sql
@@ -1,0 +1,5 @@
+CREATE TABLE public.ex (
+    "ID" integer NOT NULL
+);
+
+COMMENT ON COLUMN ex."ID" IS 'Primary identifier';

--- a/testdata/diff/comment/column_comment_quoted_identifier/old.sql
+++ b/testdata/diff/comment/column_comment_quoted_identifier/old.sql
@@ -1,0 +1,3 @@
+CREATE TABLE public.ex (
+    "ID" integer NOT NULL
+);

--- a/testdata/diff/comment/column_comment_quoted_identifier/plan.json
+++ b/testdata/diff/comment/column_comment_quoted_identifier/plan.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.6.1",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "9d443bc536153eed8fce077bfacc3d7f42b1a94f02d33868bb78be3b9de05088"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "COMMENT ON COLUMN ex.\"ID\" IS 'Primary identifier';",
+          "type": "table.column.comment",
+          "operation": "alter",
+          "path": "public.ex.ID"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/comment/column_comment_quoted_identifier/plan.sql
+++ b/testdata/diff/comment/column_comment_quoted_identifier/plan.sql
@@ -1,0 +1,1 @@
+COMMENT ON COLUMN ex."ID" IS 'Primary identifier';

--- a/testdata/diff/comment/column_comment_quoted_identifier/plan.txt
+++ b/testdata/diff/comment/column_comment_quoted_identifier/plan.txt
@@ -1,0 +1,13 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ ex
+    ~ ID (column.comment)
+
+DDL to be executed:
+--------------------------------------------------
+
+COMMENT ON COLUMN ex."ID" IS 'Primary identifier';

--- a/testdata/diff/create_table/alter_column_quoted_identifier/diff.sql
+++ b/testdata/diff/create_table/alter_column_quoted_identifier/diff.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ex ALTER COLUMN "ID" TYPE bigint;

--- a/testdata/diff/create_table/alter_column_quoted_identifier/new.sql
+++ b/testdata/diff/create_table/alter_column_quoted_identifier/new.sql
@@ -1,0 +1,3 @@
+CREATE TABLE public.ex (
+    "ID" bigint NOT NULL
+);

--- a/testdata/diff/create_table/alter_column_quoted_identifier/old.sql
+++ b/testdata/diff/create_table/alter_column_quoted_identifier/old.sql
@@ -1,0 +1,3 @@
+CREATE TABLE public.ex (
+    "ID" integer NOT NULL
+);

--- a/testdata/diff/create_table/alter_column_quoted_identifier/plan.json
+++ b/testdata/diff/create_table/alter_column_quoted_identifier/plan.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.6.1",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "9d443bc536153eed8fce077bfacc3d7f42b1a94f02d33868bb78be3b9de05088"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "ALTER TABLE ex ALTER COLUMN \"ID\" TYPE bigint;",
+          "type": "table.column",
+          "operation": "alter",
+          "path": "public.ex.ID"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_table/alter_column_quoted_identifier/plan.sql
+++ b/testdata/diff/create_table/alter_column_quoted_identifier/plan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ex ALTER COLUMN "ID" TYPE bigint;

--- a/testdata/diff/create_table/alter_column_quoted_identifier/plan.txt
+++ b/testdata/diff/create_table/alter_column_quoted_identifier/plan.txt
@@ -1,0 +1,13 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ ex
+    ~ ID (column)
+
+DDL to be executed:
+--------------------------------------------------
+
+ALTER TABLE ex ALTER COLUMN "ID" TYPE bigint;


### PR DESCRIPTION
Add test cases to test for these, fixes #270
---

Example of this fixing the issue:

```raw
Summary by type:
  tables: 1 to modify

Tables:
  ~ ex
    ~ ID (column)

DDL to be executed:
--------------------------------------------------

ALTER TABLE ex ALTER COLUMN "ID" TYPE bigint;

Do you want to apply these changes? (yes/no): yes

Applying changes...
time=2026-01-30T15:31:41.750-06:00 level=DEBUG msg="Attempting database connection" host=localhost port=5432 database=postgres user=postgres sslmode=prefer application_name=pgschema
time=2026-01-30T15:31:41.765-06:00 level=DEBUG msg="Database connection established successfully"
time=2026-01-30T15:31:41.765-06:00 level=DEBUG msg="Executing SQL" description="set search_path to target schema" sql="SET search_path TO example, public"
time=2026-01-30T15:31:41.766-06:00 level=DEBUG msg="SQL execution succeeded" description="set search_path to target schema"
Set search_path to: example, public

Executing group 1/1...
  Executing 1 statements in implicit transaction
time=2026-01-30T15:31:41.766-06:00 level=DEBUG msg="Executing SQL" description="execute 1 statements in group 1" sql="ALTER TABLE ex ALTER COLUMN \"ID\" TYPE bigint;;"
time=2026-01-30T15:31:41.778-06:00 level=DEBUG msg="SQL execution succeeded" description="execute 1 statements in group 1"
Changes applied successfully!
```