### PR TITLE
fix: reserved keyword not quoted in online rewrite DDL (#286)

### DIFF
--- a/internal/plan/rewrite.go
+++ b/internal/plan/rewrite.go
@@ -435,10 +435,11 @@ WHERE c.relname = '%s';`, indexName)
 // Helper functions
 
 func getTableNameWithSchema(schema, table string) string {
+	quotedTable := ir.QuoteIdentifier(table)
 	if schema != "" && schema != "public" {
-		return fmt.Sprintf("%s.%s", schema, table)
+		return fmt.Sprintf("%s.%s", ir.QuoteIdentifier(schema), quotedTable)
 	}
-	return table
+	return quotedTable
 }
 
 func joinStrings(strs []string, sep string) string {

--- a/testdata/diff/online/issue_286_reserved_keyword_quoting/diff.sql
+++ b/testdata/diff/online/issue_286_reserved_keyword_quoting/diff.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "order"
+ADD COLUMN tenant_id uuid CONSTRAINT "FK_order_tenant" REFERENCES tenant (id);
+
+CREATE INDEX IF NOT EXISTS "IDX_order_tenant_order_number" ON "order" (tenant_id, order_number);

--- a/testdata/diff/online/issue_286_reserved_keyword_quoting/new.sql
+++ b/testdata/diff/online/issue_286_reserved_keyword_quoting/new.sql
@@ -1,0 +1,17 @@
+-- Test Case: Reserved keyword table names must be quoted in online rewrite DDL
+-- Adding a column with FK and an index on a table named "order" (reserved keyword).
+
+CREATE TABLE public.tenant (
+    id uuid NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT tenant_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE public."order" (
+    id integer NOT NULL,
+    order_number text NOT NULL,
+    tenant_id uuid CONSTRAINT "FK_order_tenant" REFERENCES public.tenant (id),
+    CONSTRAINT order_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX "IDX_order_tenant_order_number" ON public."order" (tenant_id, order_number);

--- a/testdata/diff/online/issue_286_reserved_keyword_quoting/old.sql
+++ b/testdata/diff/online/issue_286_reserved_keyword_quoting/old.sql
@@ -1,0 +1,14 @@
+-- Test Case: Reserved keyword table names must be quoted in online rewrite DDL
+-- The table "order" is a PostgreSQL reserved keyword and must be quoted everywhere.
+
+CREATE TABLE public.tenant (
+    id uuid NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT tenant_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE public."order" (
+    id integer NOT NULL,
+    order_number text NOT NULL,
+    CONSTRAINT order_pkey PRIMARY KEY (id)
+);

--- a/testdata/diff/online/issue_286_reserved_keyword_quoting/plan.json
+++ b/testdata/diff/online/issue_286_reserved_keyword_quoting/plan.json
@@ -1,0 +1,44 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.7.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "880c2cec11ce10f5b7868bde9b051d7559368a092d2071a5cd68a0b1d5456627"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "ALTER TABLE \"order\"\nADD COLUMN tenant_id uuid CONSTRAINT \"FK_order_tenant\" REFERENCES tenant (id);",
+          "type": "table.column",
+          "operation": "create",
+          "path": "public.order.tenant_id"
+        }
+      ]
+    },
+    {
+      "steps": [
+        {
+          "sql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IDX_order_tenant_order_number\" ON \"order\" (tenant_id, order_number);",
+          "type": "table.index",
+          "operation": "create",
+          "path": "public.order.IDX_order_tenant_order_number"
+        }
+      ]
+    },
+    {
+      "steps": [
+        {
+          "sql": "SELECT \n    COALESCE(i.indisvalid, false) as done,\n    CASE \n        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total\n        ELSE 0\n    END as progress\nFROM pg_class c\nLEFT JOIN pg_index i ON c.oid = i.indexrelid\nLEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid\nWHERE c.relname = 'IDX_order_tenant_order_number';",
+          "directive": {
+            "type": "wait",
+            "message": "Creating index IDX_order_tenant_order_number"
+          },
+          "type": "table.index",
+          "operation": "create",
+          "path": "public.order.IDX_order_tenant_order_number"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/online/issue_286_reserved_keyword_quoting/plan.sql
+++ b/testdata/diff/online/issue_286_reserved_keyword_quoting/plan.sql
@@ -1,0 +1,16 @@
+ALTER TABLE "order"
+ADD COLUMN tenant_id uuid CONSTRAINT "FK_order_tenant" REFERENCES tenant (id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_order_tenant_order_number" ON "order" (tenant_id, order_number);
+
+-- pgschema:wait
+SELECT 
+    COALESCE(i.indisvalid, false) as done,
+    CASE 
+        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total
+        ELSE 0
+    END as progress
+FROM pg_class c
+LEFT JOIN pg_index i ON c.oid = i.indexrelid
+LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
+WHERE c.relname = 'IDX_order_tenant_order_number';

--- a/testdata/diff/online/issue_286_reserved_keyword_quoting/plan.txt
+++ b/testdata/diff/online/issue_286_reserved_keyword_quoting/plan.txt
@@ -1,0 +1,32 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ order
+    + tenant_id (column)
+    + IDX_order_tenant_order_number (index)
+
+DDL to be executed:
+--------------------------------------------------
+
+-- Transaction Group #1
+ALTER TABLE "order"
+ADD COLUMN tenant_id uuid CONSTRAINT "FK_order_tenant" REFERENCES tenant (id);
+
+-- Transaction Group #2
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_order_tenant_order_number" ON "order" (tenant_id, order_number);
+
+-- Transaction Group #3
+-- pgschema:wait
+SELECT 
+    COALESCE(i.indisvalid, false) as done,
+    CASE 
+        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total
+        ELSE 0
+    END as progress
+FROM pg_class c
+LEFT JOIN pg_index i ON c.oid = i.indexrelid
+LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
+WHERE c.relname = 'IDX_order_tenant_order_number';


### PR DESCRIPTION
## Summary

- The `getTableNameWithSchema` helper in `internal/plan/rewrite.go` was returning raw table/schema names without calling `ir.QuoteIdentifier()`, causing reserved keywords like `order` to produce invalid SQL in online rewrite operations (CREATE INDEX CONCURRENTLY, constraint rewrites, FK rewrites, NOT NULL rewrites, identity column rewrites)
- The equivalent function in `internal/diff/diff.go` already quoted correctly, so only the plan rewrite path was affected

Fixes #286

## Test plan

- [x] Added `testdata/diff/online/issue_286_reserved_keyword_quoting/` test case with a table named `order` (reserved keyword) that gets a new column with FK and an index
- [x] Diff test passes: `PGSCHEMA_TEST_FILTER="online/issue_286_reserved_keyword_quoting" go test -v ./internal/diff -run TestDiffFromFiles`
- [x] Plan test passes (including apply verification): `PGSCHEMA_TEST_FILTER="online/issue_286_reserved_keyword_quoting" go test -v ./cmd -run TestPlanAndApply`
- [x] All online tests pass: `PGSCHEMA_TEST_FILTER="online/" go test -v ./cmd -run TestPlanAndApply`
- [x] Full test suite passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)