### PR TITLE
fix: add SET search_path to dump output for non-public schemas (#296)

### DIFF
--- a/internal/dump/formatter.go
+++ b/internal/dump/formatter.go
@@ -165,6 +165,15 @@ func (f *DumpFormatter) generateDumpHeader() string {
 	header.WriteString(fmt.Sprintf("-- Dumped from database version %s\n", f.dbVersion))
 	header.WriteString(fmt.Sprintf("-- Dumped by pgschema version %s\n", version.App()))
 	header.WriteString("\n")
+
+	// For non-public schemas, add SET search_path so the dump is self-contained.
+	// This ensures objects are created in the correct schema when the SQL is applied
+	// directly (e.g., via psql), matching pg_dump conventions.
+	if f.targetSchema != "" && f.targetSchema != "public" {
+		quotedSchema := ir.QuoteIdentifier(f.targetSchema)
+		header.WriteString(fmt.Sprintf("SET search_path TO %s, public;\n", quotedSchema))
+	}
+
 	header.WriteString("\n")
 	return header.String()
 }

--- a/internal/postgres/embedded.go
+++ b/internal/postgres/embedded.go
@@ -206,10 +206,14 @@ func (ep *EmbeddedPostgres) ApplySchema(ctx context.Context, schema string, sql 
 		return fmt.Errorf("failed to set search_path: %w", err)
 	}
 
+	// Strip SET search_path statements from SQL to prevent overriding the temp schema's search_path.
+	// pgschema dump includes SET search_path for non-public schemas to make dumps self-contained.
+	cleanedSQL := stripSetSearchPath(sql)
+
 	// Strip schema qualifications from SQL before applying to temporary schema
 	// This ensures that objects are created in the temporary schema via search_path
 	// rather than being explicitly qualified with the original schema name
-	schemaAgnosticSQL := stripSchemaQualifications(sql, schema)
+	schemaAgnosticSQL := stripSchemaQualifications(cleanedSQL, schema)
 
 	// Replace schema names in ALTER DEFAULT PRIVILEGES statements
 	// These use "IN SCHEMA <schema>" syntax which isn't handled by stripSchemaQualifications


### PR DESCRIPTION
## Summary

- When dumping non-public schemas (e.g., `--schema vehicle`), the output now includes `SET search_path TO <schema>, public;` in the header, making dump files self-contained and ensuring objects are created in the correct schema when applied directly (e.g., via psql)
- Strips `SET search_path` statements from SQL in `ApplySchema()` to prevent dump file headers from overriding the temp schema's search_path during plan generation
- Follows pg_dump conventions for schema-specific output

Fixes #296

## Test plan

- [x] New test `TestDumpCommand_Issue296NonPublicSchemaSearchPath` verifies:
  - SET search_path is present in dump output for non-public schemas
  - SET search_path is NOT present for public schema dumps
- [x] Existing tenant schema test passes (normalizes SET search_path for cross-schema comparison)
- [x] Full test suite passes (`go test -v ./...`)

Run: `go test -v ./cmd/dump -run TestDumpCommand_Issue296`

🤖 Generated with [Claude Code](https://claude.com/claude-code)