### PR TITLE
fix: sort object names in multi-file dump for deterministic include order (#299)

### DIFF
--- a/internal/dump/formatter.go
+++ b/internal/dump/formatter.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/pgplex/pgschema/internal/diff"
@@ -117,8 +118,16 @@ func (f *DumpFormatter) FormatMultiFile(diffs []diff.Diff, outputPath string) er
 				return fmt.Errorf("failed to create directory %s: %w", dirPath, err)
 			}
 
+			// Sort object names for deterministic output (Go maps have random iteration order)
+			objNames := make([]string, 0, len(objects))
+			for objName := range objects {
+				objNames = append(objNames, objName)
+			}
+			sort.Strings(objNames)
+
 			// Create files for each object
-			for objName, objSteps := range objects {
+			for _, objName := range objNames {
+				objSteps := objects[objName]
 				fileName := f.sanitizeFileName(objName) + ".sql"
 				filePath := filepath.Join(dirPath, fileName)
 				relativePath := filepath.Join(dir, fileName)


### PR DESCRIPTION
## Summary

- `pgschema dump --multi-file` iterated a Go map (`map[string][]diff.Diff`) without sorting keys, causing `\i` include lines in `main.sql` to appear in random order across runs
- Sort object names alphabetically within each directory group before generating include statements, ensuring deterministic output

Fixes #299

## Test plan

- [x] Added `TestMultiFileIncludeOrderDeterministic` — creates 4 tables + 2 functions, runs `FormatMultiFile` 20 times, and verifies identical sorted output each time
- [x] Test fails before fix (non-deterministic map iteration detected), passes after
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)