### PR TITLE
fix: defer functions with view dependencies to after view creation (#300)

### DIFF
--- a/testdata/diff/dependency/issue_300_function_table_composite_type/diff.sql
+++ b/testdata/diff/dependency/issue_300_function_table_composite_type/diff.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS activity (
+    id uuid,
+    author_id uuid,
+    CONSTRAINT activity_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS contact (
+    id uuid,
+    name text NOT NULL,
+    CONSTRAINT contact_pkey PRIMARY KEY (id)
+);
+
+CREATE OR REPLACE VIEW actor AS
+ SELECT id,
+    name
+   FROM contact;
+
+CREATE OR REPLACE FUNCTION get_actor(
+    activity activity
+)
+RETURNS SETOF actor
+LANGUAGE sql
+STABLE
+AS $$ SELECT actor.* FROM actor WHERE actor.id = activity.author_id
+$$;

--- a/testdata/diff/dependency/issue_300_function_table_composite_type/new.sql
+++ b/testdata/diff/dependency/issue_300_function_table_composite_type/new.sql
@@ -1,0 +1,25 @@
+-- Table whose composite type is used as a function parameter
+CREATE TABLE public.activity (
+    id uuid PRIMARY KEY,
+    author_id uuid
+);
+
+-- Table used by the view
+CREATE TABLE public.contact (
+    id uuid PRIMARY KEY,
+    name text NOT NULL
+);
+
+-- View referenced in the function's return type
+CREATE OR REPLACE VIEW public.actor AS
+SELECT id, name FROM public.contact;
+
+-- Function that uses the table composite type as a parameter
+-- and references a view in its return type.
+-- This function must be created AFTER:
+--   1. The activity table (for the composite type parameter)
+--   2. The actor view (for RETURNS SETOF actor)
+CREATE OR REPLACE FUNCTION public.get_actor(activity activity)
+    RETURNS SETOF actor ROWS 1
+    LANGUAGE sql STABLE
+    AS $$ SELECT actor.* FROM actor WHERE actor.id = activity.author_id $$;

--- a/testdata/diff/dependency/issue_300_function_table_composite_type/old.sql
+++ b/testdata/diff/dependency/issue_300_function_table_composite_type/old.sql
@@ -1,0 +1,1 @@
+-- Empty schema (no objects)

--- a/testdata/diff/dependency/issue_300_function_table_composite_type/plan.json
+++ b/testdata/diff/dependency/issue_300_function_table_composite_type/plan.json
@@ -1,0 +1,38 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.7.1",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS activity (\n    id uuid,\n    author_id uuid,\n    CONSTRAINT activity_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.activity"
+        },
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS contact (\n    id uuid,\n    name text NOT NULL,\n    CONSTRAINT contact_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.contact"
+        },
+        {
+          "sql": "CREATE OR REPLACE VIEW actor AS\n SELECT id,\n    name\n   FROM contact;",
+          "type": "view",
+          "operation": "create",
+          "path": "public.actor"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION get_actor(\n    activity activity\n)\nRETURNS SETOF actor\nLANGUAGE sql\nSTABLE\nAS $$ SELECT actor.* FROM actor WHERE actor.id = activity.author_id\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.get_actor"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/dependency/issue_300_function_table_composite_type/plan.sql
+++ b/testdata/diff/dependency/issue_300_function_table_composite_type/plan.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS activity (
+    id uuid,
+    author_id uuid,
+    CONSTRAINT activity_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS contact (
+    id uuid,
+    name text NOT NULL,
+    CONSTRAINT contact_pkey PRIMARY KEY (id)
+);
+
+CREATE OR REPLACE VIEW actor AS
+ SELECT id,
+    name
+   FROM contact;
+
+CREATE OR REPLACE FUNCTION get_actor(
+    activity activity
+)
+RETURNS SETOF actor
+LANGUAGE sql
+STABLE
+AS $$ SELECT actor.* FROM actor WHERE actor.id = activity.author_id
+$$;

--- a/testdata/diff/dependency/issue_300_function_table_composite_type/plan.txt
+++ b/testdata/diff/dependency/issue_300_function_table_composite_type/plan.txt
@@ -1,0 +1,45 @@
+Plan: 4 to add.
+
+Summary by type:
+  functions: 1 to add
+  tables: 2 to add
+  views: 1 to add
+
+Functions:
+  + get_actor
+
+Tables:
+  + activity
+  + contact
+
+Views:
+  + actor
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS activity (
+    id uuid,
+    author_id uuid,
+    CONSTRAINT activity_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS contact (
+    id uuid,
+    name text NOT NULL,
+    CONSTRAINT contact_pkey PRIMARY KEY (id)
+);
+
+CREATE OR REPLACE VIEW actor AS
+ SELECT id,
+    name
+   FROM contact;
+
+CREATE OR REPLACE FUNCTION get_actor(
+    activity activity
+)
+RETURNS SETOF actor
+LANGUAGE sql
+STABLE
+AS $$ SELECT actor.* FROM actor WHERE actor.id = activity.author_id
+$$;

--- a/testdata/diff/dependency/issue_300_view_depends_on_view/diff.sql
+++ b/testdata/diff/dependency/issue_300_view_depends_on_view/diff.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS activity_x (
+    id integer,
+    title text NOT NULL,
+    priority_user_id integer,
+    CONSTRAINT activity_x_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS priority (
+    id integer,
+    name text NOT NULL,
+    level integer NOT NULL,
+    CONSTRAINT priority_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS priority_user (
+    id integer,
+    user_id integer NOT NULL,
+    priority_id integer,
+    CONSTRAINT priority_user_pkey PRIMARY KEY (id),
+    CONSTRAINT priority_user_priority_id_fkey FOREIGN KEY (priority_id) REFERENCES priority (id)
+);
+
+CREATE OR REPLACE VIEW priority_expanded AS
+ SELECT pu.id,
+    pu.user_id,
+    p.name AS priority_name,
+    p.level
+   FROM priority_user pu
+     JOIN priority p ON p.id = pu.priority_id;
+
+CREATE OR REPLACE VIEW activity AS
+ SELECT a.id,
+    a.title,
+    upe.priority_name
+   FROM activity_x a
+     JOIN priority_expanded upe ON upe.id = a.priority_user_id;

--- a/testdata/diff/dependency/issue_300_view_depends_on_view/new.sql
+++ b/testdata/diff/dependency/issue_300_view_depends_on_view/new.sql
@@ -1,0 +1,33 @@
+-- Base table
+CREATE TABLE public.priority (
+    id integer PRIMARY KEY,
+    name text NOT NULL,
+    level integer NOT NULL
+);
+
+-- Base table
+CREATE TABLE public.priority_user (
+    id integer PRIMARY KEY,
+    user_id integer NOT NULL,
+    priority_id integer REFERENCES public.priority(id)
+);
+
+-- View that is depended upon (must be created first)
+CREATE OR REPLACE VIEW public.priority_expanded AS
+SELECT pu.id, pu.user_id, p.name AS priority_name, p.level
+FROM public.priority_user pu
+JOIN public.priority p ON p.id = pu.priority_id;
+
+-- Base table for activity
+CREATE TABLE public.activity_x (
+    id integer PRIMARY KEY,
+    title text NOT NULL,
+    priority_user_id integer
+);
+
+-- View that depends on priority_expanded (must be created second)
+-- Alphabetically "activity" comes before "priority_expanded"
+CREATE OR REPLACE VIEW public.activity AS
+SELECT a.id, a.title, upe.priority_name
+FROM public.activity_x a
+JOIN public.priority_expanded upe ON upe.id = a.priority_user_id;

--- a/testdata/diff/dependency/issue_300_view_depends_on_view/old.sql
+++ b/testdata/diff/dependency/issue_300_view_depends_on_view/old.sql
@@ -1,0 +1,1 @@
+-- Empty schema (no objects)

--- a/testdata/diff/dependency/issue_300_view_depends_on_view/plan.json
+++ b/testdata/diff/dependency/issue_300_view_depends_on_view/plan.json
@@ -1,0 +1,44 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.7.1",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS activity_x (\n    id integer,\n    title text NOT NULL,\n    priority_user_id integer,\n    CONSTRAINT activity_x_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.activity_x"
+        },
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS priority (\n    id integer,\n    name text NOT NULL,\n    level integer NOT NULL,\n    CONSTRAINT priority_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.priority"
+        },
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS priority_user (\n    id integer,\n    user_id integer NOT NULL,\n    priority_id integer,\n    CONSTRAINT priority_user_pkey PRIMARY KEY (id),\n    CONSTRAINT priority_user_priority_id_fkey FOREIGN KEY (priority_id) REFERENCES priority (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.priority_user"
+        },
+        {
+          "sql": "CREATE OR REPLACE VIEW priority_expanded AS\n SELECT pu.id,\n    pu.user_id,\n    p.name AS priority_name,\n    p.level\n   FROM priority_user pu\n     JOIN priority p ON p.id = pu.priority_id;",
+          "type": "view",
+          "operation": "create",
+          "path": "public.priority_expanded"
+        },
+        {
+          "sql": "CREATE OR REPLACE VIEW activity AS\n SELECT a.id,\n    a.title,\n    upe.priority_name\n   FROM activity_x a\n     JOIN priority_expanded upe ON upe.id = a.priority_user_id;",
+          "type": "view",
+          "operation": "create",
+          "path": "public.activity"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/dependency/issue_300_view_depends_on_view/plan.sql
+++ b/testdata/diff/dependency/issue_300_view_depends_on_view/plan.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS activity_x (
+    id integer,
+    title text NOT NULL,
+    priority_user_id integer,
+    CONSTRAINT activity_x_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS priority (
+    id integer,
+    name text NOT NULL,
+    level integer NOT NULL,
+    CONSTRAINT priority_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS priority_user (
+    id integer,
+    user_id integer NOT NULL,
+    priority_id integer,
+    CONSTRAINT priority_user_pkey PRIMARY KEY (id),
+    CONSTRAINT priority_user_priority_id_fkey FOREIGN KEY (priority_id) REFERENCES priority (id)
+);
+
+CREATE OR REPLACE VIEW priority_expanded AS
+ SELECT pu.id,
+    pu.user_id,
+    p.name AS priority_name,
+    p.level
+   FROM priority_user pu
+     JOIN priority p ON p.id = pu.priority_id;
+
+CREATE OR REPLACE VIEW activity AS
+ SELECT a.id,
+    a.title,
+    upe.priority_name
+   FROM activity_x a
+     JOIN priority_expanded upe ON upe.id = a.priority_user_id;

--- a/testdata/diff/dependency/issue_300_view_depends_on_view/plan.txt
+++ b/testdata/diff/dependency/issue_300_view_depends_on_view/plan.txt
@@ -1,0 +1,54 @@
+Plan: 5 to add.
+
+Summary by type:
+  tables: 3 to add
+  views: 2 to add
+
+Tables:
+  + activity_x
+  + priority
+  + priority_user
+
+Views:
+  + activity
+  + priority_expanded
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS activity_x (
+    id integer,
+    title text NOT NULL,
+    priority_user_id integer,
+    CONSTRAINT activity_x_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS priority (
+    id integer,
+    name text NOT NULL,
+    level integer NOT NULL,
+    CONSTRAINT priority_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS priority_user (
+    id integer,
+    user_id integer NOT NULL,
+    priority_id integer,
+    CONSTRAINT priority_user_pkey PRIMARY KEY (id),
+    CONSTRAINT priority_user_priority_id_fkey FOREIGN KEY (priority_id) REFERENCES priority (id)
+);
+
+CREATE OR REPLACE VIEW priority_expanded AS
+ SELECT pu.id,
+    pu.user_id,
+    p.name AS priority_name,
+    p.level
+   FROM priority_user pu
+     JOIN priority p ON p.id = pu.priority_id;
+
+CREATE OR REPLACE VIEW activity AS
+ SELECT a.id,
+    a.title,
+    upe.priority_name
+   FROM activity_x a
+     JOIN priority_expanded upe ON upe.id = a.priority_user_id;


### PR DESCRIPTION
## Summary

- Functions that reference views in their return type (e.g., `RETURNS SETOF view_name`) or parameter types were being created before the referenced views, causing `type does not exist` errors during `pgschema apply`
- Split function creation into two phases: functions without view dependencies are created before views (existing behavior), and functions with view dependencies are created after views
- Fixed return type normalization to strip same-schema qualifiers from `SETOF` types (e.g., `SETOF public.actor` → `SETOF actor`) for consistent comparison across different search_path contexts

Fixes #300

## Test plan

- [x] Added `testdata/diff/dependency/issue_300_function_table_composite_type/` — tests a function using a table composite type parameter and a view return type
- [x] Added `testdata/diff/dependency/issue_300_view_depends_on_view/` — confirms view-to-view dependency ordering works correctly (already handled by existing topological sort)
- [x] Run: `PGSCHEMA_TEST_FILTER="dependency/" go test -v ./cmd -run TestPlanAndApply` — all 12 dependency tests pass
- [x] Run: `PGSCHEMA_TEST_FILTER="create_function/" go test -v ./cmd -run TestPlanAndApply` — all function tests pass
- [x] Run: `PGSCHEMA_TEST_FILTER="create_view/" go test -v ./cmd -run TestPlanAndApply` — all view tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)