### PR TITLE
fix: exclude DiffSource interface field from JSON serialization (#305)

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -251,7 +251,7 @@ type Diff struct {
 	Type       DiffType       `json:"type"`
 	Operation  DiffOperation  `json:"operation"` // create, alter, drop, replace
 	Path       string         `json:"path"`
-	Source     DiffSource     `json:"source,omitempty"`
+	Source     DiffSource     `json:"-"` // interface; not JSON-serializable (see #305)
 }
 
 type ddlDiff struct {


### PR DESCRIPTION
## Summary

- Plans generated with `--debug` included the `Diff.Source` field (a `DiffSource` interface) in JSON output. Go's `json.Unmarshal` cannot reconstruct interface types, causing `FromJSON()` to fail when applying debug plans via `pgschema apply --plan plan.json`.
- Changed the JSON tag on `Diff.Source` from `json:"source,omitempty"` to `json:"-"` to exclude it from serialization. All in-memory usage (rewrite logic, display formatting) is unaffected.

Fixes #305

## Test plan

- [ ] New test `TestPlanDebugJSONRoundTrip` verifies debug JSON round-trip: serialize with `ToJSONWithDebug(true)` then deserialize with `FromJSON()`
- [ ] Run: `go test -v ./internal/plan -run TestPlanDebugJSONRoundTrip`
- [ ] All existing plan tests pass: `go test -v ./internal/plan`
- [ ] Full CI suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)