### PR TITLE
fix: preserve dependency order for views in multi-file dump (#307)

### DIFF
--- a/testdata/dump/issue_307_view_dependency_order/manifest.json
+++ b/testdata/dump/issue_307_view_dependency_order/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "issue_307_view_dependency_order",
+  "description": "Test case for view dependency ordering in dump output (GitHub issue #307)",
+  "source": "https://github.com/pgplex/pgschema/issues/307",
+  "notes": [
+    "Reproduces the bug where views are emitted alphabetically instead of by dependency order",
+    "Tests that item_summary is emitted before dashboard (since dashboard depends on item_summary)",
+    "dashboard sorts before item_summary alphabetically, but must come after it in dependency order"
+  ]
+}

--- a/testdata/dump/issue_307_view_dependency_order/pgdump.sql
+++ b/testdata/dump/issue_307_view_dependency_order/pgdump.sql
@@ -1,0 +1,67 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 17.5 (Debian 17.5-1.pgdg120+1)
+-- Dumped by pg_dump version 17.5 (Homebrew)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: base_data; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.base_data (
+    id integer NOT NULL,
+    value text NOT NULL,
+    category text
+);
+
+
+--
+-- Name: item_summary; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.item_summary AS
+ SELECT id,
+    value,
+    category
+   FROM public.base_data
+  WHERE (category IS NOT NULL);
+
+
+--
+-- Name: dashboard; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.dashboard AS
+ SELECT id,
+    value
+   FROM public.item_summary;
+
+
+--
+-- Name: base_data base_data_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.base_data
+    ADD CONSTRAINT base_data_pkey PRIMARY KEY (id);
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/testdata/dump/issue_307_view_dependency_order/pgschema.sql
+++ b/testdata/dump/issue_307_view_dependency_order/pgschema.sql
@@ -1,0 +1,39 @@
+--
+-- pgschema database dump
+--
+
+-- Dumped from database version PostgreSQL 18.0
+-- Dumped by pgschema version 1.7.2
+
+
+--
+-- Name: base_data; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS base_data (
+    id integer,
+    value text NOT NULL,
+    category text,
+    CONSTRAINT base_data_pkey PRIMARY KEY (id)
+);
+
+--
+-- Name: item_summary; Type: VIEW; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE VIEW item_summary AS
+ SELECT id,
+    value,
+    category
+   FROM base_data
+  WHERE category IS NOT NULL;
+
+--
+-- Name: dashboard; Type: VIEW; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE VIEW dashboard AS
+ SELECT id,
+    value
+   FROM item_summary;
+

--- a/testdata/dump/issue_307_view_dependency_order/raw.sql
+++ b/testdata/dump/issue_307_view_dependency_order/raw.sql
@@ -1,0 +1,26 @@
+--
+-- Test case for GitHub issue #307: View dependency ordering
+--
+-- This test reproduces a bug where views are emitted in alphabetical order
+-- instead of dependency order. "dashboard" sorts before "item_summary"
+-- alphabetically, but dashboard depends on item_summary and must come after it.
+--
+
+-- Base table
+CREATE TABLE base_data (
+    id integer PRIMARY KEY,
+    value text NOT NULL,
+    category text
+);
+
+-- View that other views depend on (must be created first)
+CREATE VIEW item_summary AS
+SELECT id, value, category
+FROM base_data
+WHERE category IS NOT NULL;
+
+-- View that depends on item_summary (must be created second)
+-- Alphabetically "dashboard" comes before "item_summary"
+CREATE VIEW dashboard AS
+SELECT id, value
+FROM item_summary;


### PR DESCRIPTION
## Summary

- The `pgschema dump --multi-file` mode was sorting view include directives alphabetically, breaking dependency ordering when a view depended on another view that sorted later in the alphabet (e.g., `dashboard` depends on `item_summary`, but `dashboard.sql` was included before `item_summary.sql`)
- Now preserves the topological ordering from the diff package by tracking insertion order instead of re-sorting alphabetically
- Added dump test case with dependent views verifying both single-file and multi-file dependency ordering

Fixes #307

## Test plan

- [x] `TestDumpCommand_Issue307ViewDependencyOrder` - verifies single-file dump outputs views in dependency order
- [x] `TestDumpCommand_Issue307MultiFileViewDependencyOrder` - verifies multi-file dump include directives are in dependency order (item_summary before dashboard)
- [x] All existing dump tests pass (no regressions)
- [x] All dependency diff tests pass
- [x] All view and materialized view diff tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)