### PR TITLE
fix: quote camelCase column names in online NOT NULL rewrite DDL (#313)

### DIFF
--- a/internal/plan/rewrite.go
+++ b/internal/plan/rewrite.go
@@ -298,9 +298,11 @@ func generateColumnNotNullRewrite(_ *diff.ColumnDiff, path string) []RewriteStep
 	tableName := getTableNameWithSchema(schema, table)
 	constraintName := fmt.Sprintf("%s_not_null", column)
 
+	quotedColumn := ir.QuoteIdentifier(column)
+
 	// Step 1: Add CHECK constraint with NOT VALID
 	addConstraintSQL := fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s CHECK (%s IS NOT NULL) NOT VALID;",
-		tableName, ir.QuoteIdentifier(constraintName), column)
+		tableName, ir.QuoteIdentifier(constraintName), quotedColumn)
 
 	// Step 2: Validate the constraint
 	validateConstraintSQL := fmt.Sprintf("ALTER TABLE %s VALIDATE CONSTRAINT %s;",
@@ -308,7 +310,7 @@ func generateColumnNotNullRewrite(_ *diff.ColumnDiff, path string) []RewriteStep
 
 	// Step 3: Set column to NOT NULL
 	setNotNullSQL := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET NOT NULL;",
-		tableName, column)
+		tableName, quotedColumn)
 
 	// Step 4: Drop CHECK constraint
 	dropConstraintSQL := fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s;",

--- a/testdata/diff/online/issue_313_camelcase_column_not_null/diff.sql
+++ b/testdata/diff/online/issue_313_camelcase_column_not_null/diff.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Planning" ALTER COLUMN "offersValidUntil" SET NOT NULL;

--- a/testdata/diff/online/issue_313_camelcase_column_not_null/new.sql
+++ b/testdata/diff/online/issue_313_camelcase_column_not_null/new.sql
@@ -1,0 +1,5 @@
+CREATE TABLE public."Planning" (
+    id integer NOT NULL,
+    "offersValidUntil" timestamp with time zone NOT NULL,
+    CONSTRAINT "Planning_pkey" PRIMARY KEY (id)
+);

--- a/testdata/diff/online/issue_313_camelcase_column_not_null/old.sql
+++ b/testdata/diff/online/issue_313_camelcase_column_not_null/old.sql
@@ -1,0 +1,5 @@
+CREATE TABLE public."Planning" (
+    id integer NOT NULL,
+    "offersValidUntil" timestamp with time zone,
+    CONSTRAINT "Planning_pkey" PRIMARY KEY (id)
+);

--- a/testdata/diff/online/issue_313_camelcase_column_not_null/plan.json
+++ b/testdata/diff/online/issue_313_camelcase_column_not_null/plan.json
@@ -1,0 +1,38 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.7.2",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "59ecc7fdab924e513eb6acdc93543167379bf64b4c6b5e1fe1d8e98fa48fdb9f"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "ALTER TABLE \"Planning\" ADD CONSTRAINT \"offersValidUntil_not_null\" CHECK (\"offersValidUntil\" IS NOT NULL) NOT VALID;",
+          "type": "table.column",
+          "operation": "alter",
+          "path": "public.Planning.offersValidUntil"
+        },
+        {
+          "sql": "ALTER TABLE \"Planning\" VALIDATE CONSTRAINT \"offersValidUntil_not_null\";",
+          "type": "table.column",
+          "operation": "alter",
+          "path": "public.Planning.offersValidUntil"
+        },
+        {
+          "sql": "ALTER TABLE \"Planning\" ALTER COLUMN \"offersValidUntil\" SET NOT NULL;",
+          "type": "table.column",
+          "operation": "alter",
+          "path": "public.Planning.offersValidUntil"
+        },
+        {
+          "sql": "ALTER TABLE \"Planning\" DROP CONSTRAINT \"offersValidUntil_not_null\";",
+          "type": "table.column",
+          "operation": "alter",
+          "path": "public.Planning.offersValidUntil"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/online/issue_313_camelcase_column_not_null/plan.sql
+++ b/testdata/diff/online/issue_313_camelcase_column_not_null/plan.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "Planning" ADD CONSTRAINT "offersValidUntil_not_null" CHECK ("offersValidUntil" IS NOT NULL) NOT VALID;
+
+ALTER TABLE "Planning" VALIDATE CONSTRAINT "offersValidUntil_not_null";
+
+ALTER TABLE "Planning" ALTER COLUMN "offersValidUntil" SET NOT NULL;
+
+ALTER TABLE "Planning" DROP CONSTRAINT "offersValidUntil_not_null";

--- a/testdata/diff/online/issue_313_camelcase_column_not_null/plan.txt
+++ b/testdata/diff/online/issue_313_camelcase_column_not_null/plan.txt
@@ -1,0 +1,19 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ Planning
+    ~ offersValidUntil (column)
+
+DDL to be executed:
+--------------------------------------------------
+
+ALTER TABLE "Planning" ADD CONSTRAINT "offersValidUntil_not_null" CHECK ("offersValidUntil" IS NOT NULL) NOT VALID;
+
+ALTER TABLE "Planning" VALIDATE CONSTRAINT "offersValidUntil_not_null";
+
+ALTER TABLE "Planning" ALTER COLUMN "offersValidUntil" SET NOT NULL;
+
+ALTER TABLE "Planning" DROP CONSTRAINT "offersValidUntil_not_null";


### PR DESCRIPTION
## Summary

- Fixed missing identifier quoting for column names in the online `SET NOT NULL` rewrite path (`generateColumnNotNullRewrite` in `internal/plan/rewrite.go`)
- Column names with uppercase letters (e.g., `offersValidUntil`) were used unquoted in the generated CHECK constraint expression and `ALTER COLUMN ... SET NOT NULL` statement, causing PostgreSQL to fold them to lowercase and fail with `column "offersvaliduntil" does not exist`
- Added `ir.QuoteIdentifier()` for the column name in the CHECK expression and SET NOT NULL statement

Fixes #313

## Test plan

- Added test case `testdata/diff/online/issue_313_camelcase_column_not_null/` with a table using camelCase column names
- Run: `PGSCHEMA_TEST_FILTER="online/issue_313_camelcase_column_not_null" go test -v ./cmd -run TestPlanAndApply`
- All 14 existing online tests continue to pass: `PGSCHEMA_TEST_FILTER="online/" go test -v ./cmd -run TestPlanAndApply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)