### PR TITLE
fix: scope pg_class joins by relnamespace to prevent cross-schema comment misattribution (#318)

### DIFF
--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -28,10 +28,10 @@ SELECT
     t.table_type,
     COALESCE(d.description, '') AS table_comment
 FROM information_schema.tables t
-LEFT JOIN pg_class c ON c.relname = t.table_name
-LEFT JOIN pg_namespace n ON c.relnamespace = n.oid AND n.nspname = t.table_schema
+LEFT JOIN pg_namespace n ON n.nspname = t.table_schema
+LEFT JOIN pg_class c ON c.relname = t.table_name AND c.relnamespace = n.oid
 LEFT JOIN pg_description d ON d.objoid = c.oid AND d.classoid = 'pg_class'::regclass AND d.objsubid = 0
-WHERE 
+WHERE
     t.table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
     AND t.table_schema NOT LIKE 'pg_temp_%'
     AND t.table_schema NOT LIKE 'pg_toast_temp_%'
@@ -40,16 +40,16 @@ ORDER BY t.table_schema, t.table_name;
 
 -- GetTablesForSchema retrieves all tables in a specific schema with metadata
 -- name: GetTablesForSchema :many
-SELECT 
+SELECT
     t.table_schema,
     t.table_name,
     t.table_type,
     COALESCE(d.description, '') AS table_comment
 FROM information_schema.tables t
-LEFT JOIN pg_class c ON c.relname = t.table_name
-LEFT JOIN pg_namespace n ON c.relnamespace = n.oid AND n.nspname = t.table_schema
+LEFT JOIN pg_namespace n ON n.nspname = t.table_schema
+LEFT JOIN pg_class c ON c.relname = t.table_name AND c.relnamespace = n.oid
 LEFT JOIN pg_description d ON d.objoid = c.oid AND d.classoid = 'pg_class'::regclass AND d.objsubid = 0
-WHERE 
+WHERE
     t.table_schema = $1
     AND t.table_type IN ('BASE TABLE', 'VIEW')
 ORDER BY t.table_name;
@@ -109,8 +109,8 @@ WITH column_base AS (
         ad.adbin,
         ad.adrelid
     FROM information_schema.columns c
-    LEFT JOIN pg_class cl ON cl.relname = c.table_name
-    LEFT JOIN pg_namespace n ON cl.relnamespace = n.oid AND n.nspname = c.table_schema
+    LEFT JOIN pg_namespace n ON n.nspname = c.table_schema
+    LEFT JOIN pg_class cl ON cl.relname = c.table_name AND cl.relnamespace = n.oid
     LEFT JOIN pg_description d ON d.objoid = cl.oid AND d.classoid = 'pg_class'::regclass AND d.objsubid = c.ordinal_position
     LEFT JOIN pg_attribute a ON a.attrelid = cl.oid AND a.attname = c.column_name
     LEFT JOIN pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
@@ -939,8 +939,8 @@ SELECT
     COALESCE(dep_table.relname, col_table.table_name) AS owned_by_table,
     COALESCE(dep_col.attname, col_table.column_name) AS owned_by_column
 FROM pg_sequences s
-LEFT JOIN pg_class c ON c.relname = s.sequencename
-LEFT JOIN pg_namespace n ON c.relnamespace = n.oid AND n.nspname = s.schemaname
+LEFT JOIN pg_namespace n ON n.nspname = s.schemaname
+LEFT JOIN pg_class c ON c.relname = s.sequencename AND c.relnamespace = n.oid
 -- Method 1: Try to find dependency relationship (for proper SERIAL columns)
 LEFT JOIN pg_depend d ON d.objid = c.oid AND d.classid = 'pg_class'::regclass AND d.deptype IN ('a', 'i')
 LEFT JOIN pg_class dep_table ON d.refobjid = dep_table.oid

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -308,8 +308,8 @@ WITH column_base AS (
         ad.adbin,
         ad.adrelid
     FROM information_schema.columns c
-    LEFT JOIN pg_class cl ON cl.relname = c.table_name
-    LEFT JOIN pg_namespace n ON cl.relnamespace = n.oid AND n.nspname = c.table_schema
+    LEFT JOIN pg_namespace n ON n.nspname = c.table_schema
+    LEFT JOIN pg_class cl ON cl.relname = c.table_name AND cl.relnamespace = n.oid
     LEFT JOIN pg_description d ON d.objoid = cl.oid AND d.classoid = 'pg_class'::regclass AND d.objsubid = c.ordinal_position
     LEFT JOIN pg_attribute a ON a.attrelid = cl.oid AND a.attname = c.column_name
     LEFT JOIN pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
@@ -2622,8 +2622,8 @@ SELECT
     COALESCE(dep_table.relname, col_table.table_name) AS owned_by_table,
     COALESCE(dep_col.attname, col_table.column_name) AS owned_by_column
 FROM pg_sequences s
-LEFT JOIN pg_class c ON c.relname = s.sequencename
-LEFT JOIN pg_namespace n ON c.relnamespace = n.oid AND n.nspname = s.schemaname
+LEFT JOIN pg_namespace n ON n.nspname = s.schemaname
+LEFT JOIN pg_class c ON c.relname = s.sequencename AND c.relnamespace = n.oid
 LEFT JOIN pg_depend d ON d.objid = c.oid AND d.classid = 'pg_class'::regclass AND d.deptype IN ('a', 'i')
 LEFT JOIN pg_class dep_table ON d.refobjid = dep_table.oid
 LEFT JOIN pg_attribute dep_col ON dep_col.attrelid = dep_table.oid AND dep_col.attnum = d.refobjsubid
@@ -2702,10 +2702,10 @@ SELECT
     t.table_type,
     COALESCE(d.description, '') AS table_comment
 FROM information_schema.tables t
-LEFT JOIN pg_class c ON c.relname = t.table_name
-LEFT JOIN pg_namespace n ON c.relnamespace = n.oid AND n.nspname = t.table_schema
+LEFT JOIN pg_namespace n ON n.nspname = t.table_schema
+LEFT JOIN pg_class c ON c.relname = t.table_name AND c.relnamespace = n.oid
 LEFT JOIN pg_description d ON d.objoid = c.oid AND d.classoid = 'pg_class'::regclass AND d.objsubid = 0
-WHERE 
+WHERE
     t.table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
     AND t.table_schema NOT LIKE 'pg_temp_%'
     AND t.table_schema NOT LIKE 'pg_toast_temp_%'
@@ -2756,10 +2756,10 @@ SELECT
     t.table_type,
     COALESCE(d.description, '') AS table_comment
 FROM information_schema.tables t
-LEFT JOIN pg_class c ON c.relname = t.table_name
-LEFT JOIN pg_namespace n ON c.relnamespace = n.oid AND n.nspname = t.table_schema
+LEFT JOIN pg_namespace n ON n.nspname = t.table_schema
+LEFT JOIN pg_class c ON c.relname = t.table_name AND c.relnamespace = n.oid
 LEFT JOIN pg_description d ON d.objoid = c.oid AND d.classoid = 'pg_class'::regclass AND d.objsubid = 0
-WHERE 
+WHERE
     t.table_schema = $1
     AND t.table_type IN ('BASE TABLE', 'VIEW')
 ORDER BY t.table_name

--- a/testdata/dump/issue_318_cross_schema_comment/manifest.json
+++ b/testdata/dump/issue_318_cross_schema_comment/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "issue_318_cross_schema_comment",
+  "description": "Test case for wrong table/column comments when same table name exists in multiple schemas (GitHub issue #318)",
+  "source": "https://github.com/pgplex/pgschema/issues/318",
+  "notes": [
+    "Reproduces the bug where pg_class join on relname alone (without relnamespace) causes wrong comment attribution",
+    "Tests that table and column comments are correctly scoped to their own schema when dumping"
+  ]
+}

--- a/testdata/dump/issue_318_cross_schema_comment/setup.sql
+++ b/testdata/dump/issue_318_cross_schema_comment/setup.sql
@@ -1,0 +1,24 @@
+--
+-- Setup: Two schemas with identically-named tables but different comments.
+-- This reproduces GitHub issue #318 where the buggy pg_class join on relname
+-- alone (without relnamespace) can cause wrong comment attribution.
+--
+
+CREATE SCHEMA alpha;
+CREATE SCHEMA beta;
+
+CREATE TABLE alpha.account (
+    id serial PRIMARY KEY,
+    name text NOT NULL
+);
+
+COMMENT ON TABLE alpha.account IS 'Alpha account table';
+COMMENT ON COLUMN alpha.account.name IS 'Alpha account name';
+
+CREATE TABLE beta.account (
+    id serial PRIMARY KEY,
+    name text NOT NULL
+);
+
+COMMENT ON TABLE beta.account IS 'Beta account table';
+COMMENT ON COLUMN beta.account.name IS 'Beta account name';


### PR DESCRIPTION
## Summary

- When a database has tables with identical names in different schemas, the `GetTables`, `GetTablesForSchema`, `GetColumns`, and `GetSequencesForSchema` queries could assign wrong comments because `pg_class` was joined on `relname` alone without filtering by `relnamespace`
- Fixed by joining `pg_namespace` first, then qualifying the `pg_class` join with `relnamespace`, matching the already-correct pattern used by `GetColumnsForSchema`

Fixes #318

## Test plan

- Added `TestDumpCommand_Issue318CrossSchemaComment` integration test that creates two schemas (`alpha`, `beta`) with identically-named `account` tables but different table and column comments, then verifies each schema dumps with its own correct comments
- Run: `go test -v ./cmd/dump -run TestDumpCommand_Issue318CrossSchemaComment`
- Full dump test suite passes (25 tests including the existing multi-schema tenant test)
- Comment diff tests pass (`PGSCHEMA_TEST_FILTER="comment/" go test -v ./internal/diff -run TestDiffFromFiles`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)