### PR TITLE
fix: order REVOKE before GRANT when transitioning between table and column privileges (#324)

### DIFF
--- a/testdata/diff/privilege/issue_324_grant_revoke_order/diff.sql
+++ b/testdata/diff/privilege/issue_324_grant_revoke_order/diff.sql
@@ -1,0 +1,3 @@
+REVOKE UPDATE ON TABLE sometable FROM app_user;
+
+GRANT UPDATE (somecolumn) ON TABLE sometable TO app_user;

--- a/testdata/diff/privilege/issue_324_grant_revoke_order/new.sql
+++ b/testdata/diff/privilege/issue_324_grant_revoke_order/new.sql
@@ -1,0 +1,10 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user') THEN
+        CREATE ROLE app_user;
+    END IF;
+END $$;
+
+CREATE TABLE sometable (somecolumn text);
+
+GRANT UPDATE (somecolumn) ON sometable TO app_user;

--- a/testdata/diff/privilege/issue_324_grant_revoke_order/old.sql
+++ b/testdata/diff/privilege/issue_324_grant_revoke_order/old.sql
@@ -1,0 +1,10 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user') THEN
+        CREATE ROLE app_user;
+    END IF;
+END $$;
+
+CREATE TABLE sometable (somecolumn text);
+
+GRANT UPDATE ON sometable TO app_user;

--- a/testdata/diff/privilege/issue_324_grant_revoke_order/plan.json
+++ b/testdata/diff/privilege/issue_324_grant_revoke_order/plan.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.7.2",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "2f50f8550c48f6ac58cde417097cdd7c293b3ae0d9bd8861b197edb73e80b148"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "REVOKE UPDATE ON TABLE sometable FROM app_user;",
+          "type": "privilege",
+          "operation": "drop",
+          "path": "privileges.TABLE.sometable.app_user"
+        },
+        {
+          "sql": "GRANT UPDATE (somecolumn) ON TABLE sometable TO app_user;",
+          "type": "column_privilege",
+          "operation": "create",
+          "path": "column_privileges.TABLE.sometable.somecolumn.app_user"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/privilege/issue_324_grant_revoke_order/plan.sql
+++ b/testdata/diff/privilege/issue_324_grant_revoke_order/plan.sql
@@ -1,0 +1,3 @@
+REVOKE UPDATE ON TABLE sometable FROM app_user;
+
+GRANT UPDATE (somecolumn) ON TABLE sometable TO app_user;

--- a/testdata/diff/privilege/issue_324_grant_revoke_order/plan.txt
+++ b/testdata/diff/privilege/issue_324_grant_revoke_order/plan.txt
@@ -1,0 +1,18 @@
+Plan: 1 to add, 1 to drop.
+
+Summary by type:
+  privileges: 1 to drop
+  column privileges: 1 to add
+
+Privileges:
+  - app_user
+
+Column privileges:
+  + app_user
+
+DDL to be executed:
+--------------------------------------------------
+
+REVOKE UPDATE ON TABLE sometable FROM app_user;
+
+GRANT UPDATE (somecolumn) ON TABLE sometable TO app_user;

--- a/testdata/diff/privilege/issue_324_modify_grant_to_column/diff.sql
+++ b/testdata/diff/privilege/issue_324_modify_grant_to_column/diff.sql
@@ -1,0 +1,3 @@
+REVOKE UPDATE ON TABLE sometable FROM app_user;
+
+GRANT UPDATE (somecolumn) ON TABLE sometable TO app_user;

--- a/testdata/diff/privilege/issue_324_modify_grant_to_column/new.sql
+++ b/testdata/diff/privilege/issue_324_modify_grant_to_column/new.sql
@@ -1,0 +1,11 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user') THEN
+        CREATE ROLE app_user;
+    END IF;
+END $$;
+
+CREATE TABLE sometable (somecolumn text);
+
+GRANT SELECT ON sometable TO app_user;
+GRANT UPDATE (somecolumn) ON sometable TO app_user;

--- a/testdata/diff/privilege/issue_324_modify_grant_to_column/old.sql
+++ b/testdata/diff/privilege/issue_324_modify_grant_to_column/old.sql
@@ -1,0 +1,10 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user') THEN
+        CREATE ROLE app_user;
+    END IF;
+END $$;
+
+CREATE TABLE sometable (somecolumn text);
+
+GRANT SELECT, UPDATE ON sometable TO app_user;

--- a/testdata/diff/privilege/issue_324_modify_grant_to_column/plan.json
+++ b/testdata/diff/privilege/issue_324_modify_grant_to_column/plan.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.7.2",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "1dec24426019fcb5e34cd89432fe55c1f3128e871f5b770263874c4ada106d6f"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "REVOKE UPDATE ON TABLE sometable FROM app_user;",
+          "type": "privilege",
+          "operation": "alter",
+          "path": "privileges.TABLE.sometable.app_user"
+        },
+        {
+          "sql": "GRANT UPDATE (somecolumn) ON TABLE sometable TO app_user;",
+          "type": "column_privilege",
+          "operation": "create",
+          "path": "column_privileges.TABLE.sometable.somecolumn.app_user"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/privilege/issue_324_modify_grant_to_column/plan.sql
+++ b/testdata/diff/privilege/issue_324_modify_grant_to_column/plan.sql
@@ -1,0 +1,3 @@
+REVOKE UPDATE ON TABLE sometable FROM app_user;
+
+GRANT UPDATE (somecolumn) ON TABLE sometable TO app_user;

--- a/testdata/diff/privilege/issue_324_modify_grant_to_column/plan.txt
+++ b/testdata/diff/privilege/issue_324_modify_grant_to_column/plan.txt
@@ -1,0 +1,18 @@
+Plan: 1 to add, 1 to modify.
+
+Summary by type:
+  privileges: 1 to modify
+  column privileges: 1 to add
+
+Privileges:
+  ~ app_user
+
+Column privileges:
+  + app_user
+
+DDL to be executed:
+--------------------------------------------------
+
+REVOKE UPDATE ON TABLE sometable FROM app_user;
+
+GRANT UPDATE (somecolumn) ON TABLE sometable TO app_user;


### PR DESCRIPTION
## Summary

- When changing from table-level `GRANT` to column-level `GRANT` (e.g., `GRANT UPDATE` → `GRANT UPDATE (col)`), the migration was emitting `GRANT` before `REVOKE`, leaving the user with no permissions
- Root cause: privilege modifications (containing REVOKEs) were in Phase 3 (Modify) while new column grants were in Phase 2 (Create)
- Fix: moved privilege/column-privilege modifications to execute before new privilege creates in the Create phase

Fixes #324

## Test plan

- [ ] `PGSCHEMA_TEST_FILTER="privilege/issue_324" go test -v ./internal/diff -run TestDiffFromFiles` — two new test cases
- [ ] `PGSCHEMA_TEST_FILTER="privilege/" go test -v ./internal/diff -run TestDiffFromFiles` — all 13 privilege diff tests pass
- [ ] `PGSCHEMA_TEST_FILTER="privilege/" go test -v ./cmd -run TestPlanAndApply` — all 13 privilege integration tests pass
- [ ] `PGSCHEMA_TEST_FILTER="default_privilege/" go test -v ./cmd -run TestPlanAndApply` — all 9 default privilege tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)