### PR TITLE
fix: DROP function before CREATE when return type or param names change (#326)

### DIFF
--- a/testdata/diff/create_function/issue_326_param_name_change/diff.sql
+++ b/testdata/diff/create_function/issue_326_param_name_change/diff.sql
@@ -1,0 +1,10 @@
+DROP FUNCTION IF EXISTS somefunction(text);
+
+CREATE OR REPLACE FUNCTION somefunction(
+    new_name text
+)
+RETURNS text
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT new_name;
+$$;

--- a/testdata/diff/create_function/issue_326_param_name_change/new.sql
+++ b/testdata/diff/create_function/issue_326_param_name_change/new.sql
@@ -1,0 +1,5 @@
+CREATE OR REPLACE FUNCTION somefunction(
+    new_name text
+) RETURNS text
+LANGUAGE sql
+AS $$ SELECT new_name; $$;

--- a/testdata/diff/create_function/issue_326_param_name_change/old.sql
+++ b/testdata/diff/create_function/issue_326_param_name_change/old.sql
@@ -1,0 +1,5 @@
+CREATE OR REPLACE FUNCTION somefunction(
+    old_name text
+) RETURNS text
+LANGUAGE sql
+AS $$ SELECT old_name; $$;

--- a/testdata/diff/create_function/issue_326_param_name_change/plan.json
+++ b/testdata/diff/create_function/issue_326_param_name_change/plan.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.7.2",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "d87f2cfffc1d1273ca588466e14557b2698607c55dc7c8a0e44317046e3c95a9"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "DROP FUNCTION IF EXISTS somefunction(text);",
+          "type": "function",
+          "operation": "alter",
+          "path": "public.somefunction"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION somefunction(\n    new_name text\n)\nRETURNS text\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT new_name;\n$$;",
+          "type": "function",
+          "operation": "alter",
+          "path": "public.somefunction"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_function/issue_326_param_name_change/plan.sql
+++ b/testdata/diff/create_function/issue_326_param_name_change/plan.sql
@@ -1,0 +1,10 @@
+DROP FUNCTION IF EXISTS somefunction(text);
+
+CREATE OR REPLACE FUNCTION somefunction(
+    new_name text
+)
+RETURNS text
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT new_name;
+$$;

--- a/testdata/diff/create_function/issue_326_param_name_change/plan.txt
+++ b/testdata/diff/create_function/issue_326_param_name_change/plan.txt
@@ -1,0 +1,21 @@
+Plan: 1 to modify.
+
+Summary by type:
+  functions: 1 to modify
+
+Functions:
+  ~ somefunction
+
+DDL to be executed:
+--------------------------------------------------
+
+DROP FUNCTION IF EXISTS somefunction(text);
+
+CREATE OR REPLACE FUNCTION somefunction(
+    new_name text
+)
+RETURNS text
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT new_name;
+$$;

--- a/testdata/diff/create_function/issue_326_param_type_change/diff.sql
+++ b/testdata/diff/create_function/issue_326_param_type_change/diff.sql
@@ -1,0 +1,10 @@
+DROP FUNCTION IF EXISTS somefunction(text);
+
+CREATE OR REPLACE FUNCTION somefunction(
+    param2 uuid
+)
+RETURNS uuid
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT param2;
+$$;

--- a/testdata/diff/create_function/issue_326_param_type_change/new.sql
+++ b/testdata/diff/create_function/issue_326_param_type_change/new.sql
@@ -1,0 +1,5 @@
+CREATE OR REPLACE FUNCTION somefunction(
+    param2 uuid
+) RETURNS uuid
+LANGUAGE sql
+AS $$ SELECT param2; $$;

--- a/testdata/diff/create_function/issue_326_param_type_change/old.sql
+++ b/testdata/diff/create_function/issue_326_param_type_change/old.sql
@@ -1,0 +1,5 @@
+CREATE OR REPLACE FUNCTION somefunction(
+    param1 text
+) RETURNS text
+LANGUAGE sql
+AS $$ SELECT param1; $$;

--- a/testdata/diff/create_function/issue_326_param_type_change/plan.json
+++ b/testdata/diff/create_function/issue_326_param_type_change/plan.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.7.2",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "59a96fc0ed0cbfa32f92a9d869bbbc6e38359d50afcd5ea6eb4f388717c48135"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "DROP FUNCTION IF EXISTS somefunction(text);",
+          "type": "function",
+          "operation": "drop",
+          "path": "public.somefunction"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION somefunction(\n    param2 uuid\n)\nRETURNS uuid\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT param2;\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.somefunction"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_function/issue_326_param_type_change/plan.sql
+++ b/testdata/diff/create_function/issue_326_param_type_change/plan.sql
@@ -1,0 +1,10 @@
+DROP FUNCTION IF EXISTS somefunction(text);
+
+CREATE OR REPLACE FUNCTION somefunction(
+    param2 uuid
+)
+RETURNS uuid
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT param2;
+$$;

--- a/testdata/diff/create_function/issue_326_param_type_change/plan.txt
+++ b/testdata/diff/create_function/issue_326_param_type_change/plan.txt
@@ -1,0 +1,22 @@
+Plan: 1 to add, 1 to drop.
+
+Summary by type:
+  functions: 1 to add, 1 to drop
+
+Functions:
+  - somefunction
+  + somefunction
+
+DDL to be executed:
+--------------------------------------------------
+
+DROP FUNCTION IF EXISTS somefunction(text);
+
+CREATE OR REPLACE FUNCTION somefunction(
+    param2 uuid
+)
+RETURNS uuid
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT param2;
+$$;

--- a/testdata/diff/create_function/issue_326_return_type_change/diff.sql
+++ b/testdata/diff/create_function/issue_326_return_type_change/diff.sql
@@ -1,0 +1,10 @@
+DROP FUNCTION IF EXISTS somefunction(text);
+
+CREATE OR REPLACE FUNCTION somefunction(
+    param1 text
+)
+RETURNS integer
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT length(param1);
+$$;

--- a/testdata/diff/create_function/issue_326_return_type_change/new.sql
+++ b/testdata/diff/create_function/issue_326_return_type_change/new.sql
@@ -1,0 +1,5 @@
+CREATE OR REPLACE FUNCTION somefunction(
+    param1 text
+) RETURNS integer
+LANGUAGE sql
+AS $$ SELECT length(param1); $$;

--- a/testdata/diff/create_function/issue_326_return_type_change/old.sql
+++ b/testdata/diff/create_function/issue_326_return_type_change/old.sql
@@ -1,0 +1,5 @@
+CREATE OR REPLACE FUNCTION somefunction(
+    param1 text
+) RETURNS text
+LANGUAGE sql
+AS $$ SELECT param1; $$;

--- a/testdata/diff/create_function/issue_326_return_type_change/plan.json
+++ b/testdata/diff/create_function/issue_326_return_type_change/plan.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.7.2",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "59a96fc0ed0cbfa32f92a9d869bbbc6e38359d50afcd5ea6eb4f388717c48135"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "DROP FUNCTION IF EXISTS somefunction(text);",
+          "type": "function",
+          "operation": "alter",
+          "path": "public.somefunction"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION somefunction(\n    param1 text\n)\nRETURNS integer\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT length(param1);\n$$;",
+          "type": "function",
+          "operation": "alter",
+          "path": "public.somefunction"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_function/issue_326_return_type_change/plan.sql
+++ b/testdata/diff/create_function/issue_326_return_type_change/plan.sql
@@ -1,0 +1,10 @@
+DROP FUNCTION IF EXISTS somefunction(text);
+
+CREATE OR REPLACE FUNCTION somefunction(
+    param1 text
+)
+RETURNS integer
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT length(param1);
+$$;

--- a/testdata/diff/create_function/issue_326_return_type_change/plan.txt
+++ b/testdata/diff/create_function/issue_326_return_type_change/plan.txt
@@ -1,0 +1,21 @@
+Plan: 1 to modify.
+
+Summary by type:
+  functions: 1 to modify
+
+Functions:
+  ~ somefunction
+
+DDL to be executed:
+--------------------------------------------------
+
+DROP FUNCTION IF EXISTS somefunction(text);
+
+CREATE OR REPLACE FUNCTION somefunction(
+    param1 text
+)
+RETURNS integer
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT length(param1);
+$$;


### PR DESCRIPTION
## Summary

- When a function's return type or parameter names change (but input parameter types stay the same), PostgreSQL rejects `CREATE OR REPLACE FUNCTION` because it cannot alter these properties
- pgschema now detects these incompatible changes via `functionRequiresRecreate()` and generates `DROP FUNCTION` followed by `CREATE FUNCTION` instead
- Also refactored `generateDropFunctionSQL` into a shared helper to eliminate duplication

Fixes #326

## Test plan

- [ ] `PGSCHEMA_TEST_FILTER="create_function/issue_326" go test -v ./internal/diff -run TestDiffFromFiles` — 3 new test cases (return type change, param type change, param name change)
- [ ] `PGSCHEMA_TEST_FILTER="create_function/" go test -v ./internal/diff -run TestDiffFromFiles` — all 8 function diff tests pass
- [ ] `PGSCHEMA_TEST_FILTER="create_function/" go test -v ./cmd -run TestPlanAndApply` — all 8 function integration tests pass
- [ ] `PGSCHEMA_TEST_FILTER="dependency/" go test -v ./internal/diff -run TestDiffFromFiles` — all 13 dependency tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)