### PR TITLE
feat: support PostgreSQL 18 temporal constraints (WITHOUT OVERLAPS / PERIOD)

### DIFF
--- a/internal/diff/constraint.go
+++ b/internal/diff/constraint.go
@@ -21,18 +21,36 @@ func generateConstraintSQL(constraint *ir.Constraint, targetSchema string) strin
 	switch constraint.Type {
 	case ir.ConstraintTypePrimaryKey:
 		// Always include CONSTRAINT name to be explicit and consistent
-		return fmt.Sprintf("CONSTRAINT %s PRIMARY KEY (%s)", ir.QuoteIdentifier(constraint.Name), strings.Join(getColumnNames(constraint.Columns), ", "))
+		cols := getColumnNames(constraint.Columns)
+		if constraint.IsTemporal && len(cols) > 0 {
+			cols[len(cols)-1] = cols[len(cols)-1] + " WITHOUT OVERLAPS"
+		}
+		return fmt.Sprintf("CONSTRAINT %s PRIMARY KEY (%s)", ir.QuoteIdentifier(constraint.Name), strings.Join(cols, ", "))
 	case ir.ConstraintTypeUnique:
 		// Always include CONSTRAINT name to be explicit and consistent
-		return fmt.Sprintf("CONSTRAINT %s UNIQUE (%s)", ir.QuoteIdentifier(constraint.Name), strings.Join(getColumnNames(constraint.Columns), ", "))
+		cols := getColumnNames(constraint.Columns)
+		if constraint.IsTemporal && len(cols) > 0 {
+			cols[len(cols)-1] = cols[len(cols)-1] + " WITHOUT OVERLAPS"
+		}
+		return fmt.Sprintf("CONSTRAINT %s UNIQUE (%s)", ir.QuoteIdentifier(constraint.Name), strings.Join(cols, ", "))
 	case ir.ConstraintTypeForeignKey:
 		// Always include CONSTRAINT name to preserve explicit FK names
 		// Use QualifyEntityNameWithQuotes to add schema qualifier when referencing tables in other schemas
+		cols := getColumnNames(constraint.Columns)
+		refCols := getColumnNames(constraint.ReferencedColumns)
+		if constraint.IsTemporal {
+			if len(cols) > 0 {
+				cols[len(cols)-1] = "PERIOD " + cols[len(cols)-1]
+			}
+			if len(refCols) > 0 {
+				refCols[len(refCols)-1] = "PERIOD " + refCols[len(refCols)-1]
+			}
+		}
 		qualifiedRefTable := ir.QualifyEntityNameWithQuotes(constraint.ReferencedSchema, constraint.ReferencedTable, targetSchema)
 		stmt := fmt.Sprintf("CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)",
 			ir.QuoteIdentifier(constraint.Name),
-			strings.Join(getColumnNames(constraint.Columns), ", "),
-			qualifiedRefTable, strings.Join(getColumnNames(constraint.ReferencedColumns), ", "))
+			strings.Join(cols, ", "),
+			qualifiedRefTable, strings.Join(refCols, ", "))
 		// Only add ON UPDATE/DELETE if they are not the default "NO ACTION"
 		if constraint.UpdateRule != "" && constraint.UpdateRule != "NO ACTION" {
 			stmt += fmt.Sprintf(" ON UPDATE %s", constraint.UpdateRule)
@@ -147,6 +165,9 @@ func constraintsEqual(old, new *ir.Constraint) bool {
 		return false
 	}
 	if old.InitiallyDeferred != new.InitiallyDeferred {
+		return false
+	}
+	if old.IsTemporal != new.IsTemporal {
 		return false
 	}
 

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -510,6 +510,9 @@ func generateDeferredConstraintsSQL(deferred []*deferredConstraint, targetSchema
 		for _, col := range columns {
 			columnNames = append(columnNames, ir.QuoteIdentifier(col.Name))
 		}
+		if constraint.IsTemporal && len(columnNames) > 0 {
+			columnNames[len(columnNames)-1] = "PERIOD " + columnNames[len(columnNames)-1]
+		}
 
 		tableName := getTableNameWithSchema(item.table.Schema, item.table.Name, targetSchema)
 		sql := fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s FOREIGN KEY (%s) %s;",
@@ -816,6 +819,9 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			for _, col := range columns {
 				columnNames = append(columnNames, ir.QuoteIdentifier(col.Name))
 			}
+			if constraint.IsTemporal && len(columnNames) > 0 {
+				columnNames[len(columnNames)-1] = columnNames[len(columnNames)-1] + " WITHOUT OVERLAPS"
+			}
 			tableName := getTableNameWithSchema(td.Table.Schema, td.Table.Name, targetSchema)
 			sql := fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s UNIQUE (%s);",
 				tableName, ir.QuoteIdentifier(constraint.Name), strings.Join(columnNames, ", "))
@@ -852,6 +858,9 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			for _, col := range columns {
 				columnNames = append(columnNames, ir.QuoteIdentifier(col.Name))
 			}
+			if constraint.IsTemporal && len(columnNames) > 0 {
+				columnNames[len(columnNames)-1] = "PERIOD " + columnNames[len(columnNames)-1]
+			}
 
 			tableName := getTableNameWithSchema(td.Table.Schema, td.Table.Name, targetSchema)
 			canonicalSQL := fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s FOREIGN KEY (%s) %s;",
@@ -874,6 +883,9 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			var columnNames []string
 			for _, col := range columns {
 				columnNames = append(columnNames, ir.QuoteIdentifier(col.Name))
+			}
+			if constraint.IsTemporal && len(columnNames) > 0 {
+				columnNames[len(columnNames)-1] = columnNames[len(columnNames)-1] + " WITHOUT OVERLAPS"
 			}
 			tableName := getTableNameWithSchema(td.Table.Schema, td.Table.Name, targetSchema)
 			sql := fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s PRIMARY KEY (%s);",
@@ -930,6 +942,9 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			for _, col := range columns {
 				columnNames = append(columnNames, ir.QuoteIdentifier(col.Name))
 			}
+			if constraint.IsTemporal && len(columnNames) > 0 {
+				columnNames[len(columnNames)-1] = columnNames[len(columnNames)-1] + " WITHOUT OVERLAPS"
+			}
 			addSQL = fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s UNIQUE (%s);",
 				tableName, ir.QuoteIdentifier(constraint.Name), strings.Join(columnNames, ", "))
 
@@ -945,6 +960,9 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			for _, col := range columns {
 				columnNames = append(columnNames, ir.QuoteIdentifier(col.Name))
 			}
+			if constraint.IsTemporal && len(columnNames) > 0 {
+				columnNames[len(columnNames)-1] = "PERIOD " + columnNames[len(columnNames)-1]
+			}
 
 			addSQL = fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s FOREIGN KEY (%s) %s;",
 				tableName, ir.QuoteIdentifier(constraint.Name),
@@ -957,6 +975,9 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			var columnNames []string
 			for _, col := range columns {
 				columnNames = append(columnNames, ir.QuoteIdentifier(col.Name))
+			}
+			if constraint.IsTemporal && len(columnNames) > 0 {
+				columnNames[len(columnNames)-1] = columnNames[len(columnNames)-1] + " WITHOUT OVERLAPS"
 			}
 			addSQL = fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s PRIMARY KEY (%s);",
 				tableName, ir.QuoteIdentifier(constraint.Name), strings.Join(columnNames, ", "))
@@ -1461,6 +1482,9 @@ func generateForeignKeyClause(constraint *ir.Constraint, targetSchema string, in
 			var refColumnNames []string
 			for _, col := range refColumns {
 				refColumnNames = append(refColumnNames, col.Name)
+			}
+			if constraint.IsTemporal && len(refColumnNames) > 0 {
+				refColumnNames[len(refColumnNames)-1] = "PERIOD " + refColumnNames[len(refColumnNames)-1]
 			}
 			clause += fmt.Sprintf(" (%s)", strings.Join(refColumnNames, ", "))
 		}

--- a/internal/plan/rewrite.go
+++ b/internal/plan/rewrite.go
@@ -236,10 +236,16 @@ func generateForeignKeyRewrite(constraint *ir.Constraint) []RewriteStep {
 	for _, col := range constraint.Columns {
 		columnNames = append(columnNames, col.Name)
 	}
+	if constraint.IsTemporal && len(columnNames) > 0 {
+		columnNames[len(columnNames)-1] = "PERIOD " + columnNames[len(columnNames)-1]
+	}
 
 	var refColumnNames []string
 	for _, col := range constraint.ReferencedColumns {
 		refColumnNames = append(refColumnNames, col.Name)
+	}
+	if constraint.IsTemporal && len(refColumnNames) > 0 {
+		refColumnNames[len(refColumnNames)-1] = "PERIOD " + refColumnNames[len(refColumnNames)-1]
 	}
 
 	refTableName := getTableNameWithSchema(constraint.ReferencedSchema, constraint.ReferencedTable)

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -482,11 +482,12 @@ func (i *Inspector) buildConstraints(ctx context.Context, schema *IR, targetSche
 			}
 
 			c = &Constraint{
-				Schema:  schemaName,
-				Table:   tableName,
-				Name:    constraintName,
-				Type:    cType,
-				Columns: []*ConstraintColumn{},
+				Schema:     schemaName,
+				Table:      tableName,
+				Name:       constraintName,
+				Type:       cType,
+				Columns:    []*ConstraintColumn{},
+				IsTemporal: constraint.IsPeriod, // PG18 temporal constraint (WITHOUT OVERLAPS / PERIOD)
 			}
 
 			// Handle foreign key references

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -222,6 +222,7 @@ type Constraint struct {
 	Deferrable          bool                `json:"deferrable,omitempty"`
 	InitiallyDeferred   bool                `json:"initially_deferred,omitempty"`
 	IsValid             bool                `json:"is_valid,omitempty"`
+	IsTemporal          bool                `json:"is_temporal,omitempty"` // PG18: temporal constraint (WITHOUT OVERLAPS on PK/UNIQUE, PERIOD on FK)
 	Comment             string              `json:"comment,omitempty"`
 }
 

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -337,7 +337,8 @@ SELECT
     END AS update_rule,
     c.condeferrable AS deferrable,
     c.condeferred AS initially_deferred,
-    c.convalidated AS is_valid
+    c.convalidated AS is_valid,
+    COALESCE((to_jsonb(c) ->> 'conperiod')::boolean, false) AS is_period
 FROM pg_constraint c
 JOIN pg_class cl ON c.conrelid = cl.oid
 JOIN pg_namespace n ON cl.relnamespace = n.oid
@@ -913,7 +914,8 @@ SELECT
     END AS update_rule,
     c.condeferrable AS deferrable,
     c.condeferred AS initially_deferred,
-    c.convalidated AS is_valid
+    c.convalidated AS is_valid,
+    COALESCE((to_jsonb(c) ->> 'conperiod')::boolean, false) AS is_period
 FROM pg_constraint c
 JOIN pg_class cl ON c.conrelid = cl.oid
 JOIN pg_namespace n ON cl.relnamespace = n.oid

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -796,7 +796,8 @@ SELECT
     END AS update_rule,
     c.condeferrable AS deferrable,
     c.condeferred AS initially_deferred,
-    c.convalidated AS is_valid
+    c.convalidated AS is_valid,
+    COALESCE((to_jsonb(c) ->> 'conperiod')::boolean, false) AS is_period
 FROM pg_constraint c
 JOIN pg_class cl ON c.conrelid = cl.oid
 JOIN pg_namespace n ON cl.relnamespace = n.oid
@@ -828,6 +829,7 @@ type GetConstraintsRow struct {
 	Deferrable             bool           `db:"deferrable" json:"deferrable"`
 	InitiallyDeferred      bool           `db:"initially_deferred" json:"initially_deferred"`
 	IsValid                bool           `db:"is_valid" json:"is_valid"`
+	IsPeriod               bool           `db:"is_period" json:"is_period"`
 }
 
 // GetConstraints retrieves all table constraints
@@ -858,6 +860,7 @@ func (q *Queries) GetConstraints(ctx context.Context) ([]GetConstraintsRow, erro
 			&i.Deferrable,
 			&i.InitiallyDeferred,
 			&i.IsValid,
+			&i.IsPeriod,
 		); err != nil {
 			return nil, err
 		}
@@ -911,7 +914,8 @@ SELECT
     END AS update_rule,
     c.condeferrable AS deferrable,
     c.condeferred AS initially_deferred,
-    c.convalidated AS is_valid
+    c.convalidated AS is_valid,
+    COALESCE((to_jsonb(c) ->> 'conperiod')::boolean, false) AS is_period
 FROM pg_constraint c
 JOIN pg_class cl ON c.conrelid = cl.oid
 JOIN pg_namespace n ON cl.relnamespace = n.oid
@@ -941,6 +945,7 @@ type GetConstraintsForSchemaRow struct {
 	Deferrable             bool           `db:"deferrable" json:"deferrable"`
 	InitiallyDeferred      bool           `db:"initially_deferred" json:"initially_deferred"`
 	IsValid                bool           `db:"is_valid" json:"is_valid"`
+	IsPeriod               bool           `db:"is_period" json:"is_period"`
 }
 
 // GetConstraintsForSchema retrieves all table constraints for a specific schema
@@ -971,6 +976,7 @@ func (q *Queries) GetConstraintsForSchema(ctx context.Context, dollar_1 sql.Null
 			&i.Deferrable,
 			&i.InitiallyDeferred,
 			&i.IsValid,
+			&i.IsPeriod,
 		); err != nil {
 			return nil, err
 		}

--- a/testdata/diff/create_table/add_fk/diff.sql
+++ b/testdata/diff/create_table/add_fk/diff.sql
@@ -16,6 +16,9 @@ ADD CONSTRAINT orders_manager_id_fkey FOREIGN KEY (manager_id) REFERENCES manage
 ALTER TABLE orders
 ADD CONSTRAINT orders_product_id_fkey FOREIGN KEY (product_id) REFERENCES products (id) ON DELETE CASCADE;
 
+ALTER TABLE price_adjustments
+ADD CONSTRAINT price_adjustments_product_fkey FOREIGN KEY (product_id, PERIOD adjustment_period) REFERENCES price_history (product_id, PERIOD valid_period);
+
 ALTER TABLE products
 ADD CONSTRAINT products_category_code_fkey FOREIGN KEY (category_code) REFERENCES categories (code) ON UPDATE CASCADE;
 

--- a/testdata/diff/create_table/add_fk/new.sql
+++ b/testdata/diff/create_table/add_fk/new.sql
@@ -115,3 +115,20 @@ CREATE TABLE public.orders (
     CONSTRAINT orders_product_id_fkey FOREIGN KEY (product_id) REFERENCES public.products(id) ON DELETE CASCADE,
     CONSTRAINT orders_manager_id_fkey FOREIGN KEY (manager_id) REFERENCES public.managers(id) ON DELETE SET NULL
 );
+
+-- Temporal FK case (PG18+)
+CREATE TABLE public.price_history (
+    product_id integer NOT NULL,
+    valid_period tsrange NOT NULL,
+    price numeric(10,2) NOT NULL,
+    CONSTRAINT price_history_pkey PRIMARY KEY (product_id, valid_period WITHOUT OVERLAPS)
+);
+
+CREATE TABLE public.price_adjustments (
+    id integer NOT NULL,
+    product_id integer NOT NULL,
+    adjustment_period tsrange NOT NULL,
+    adjustment_pct numeric(5,2) NOT NULL,
+    CONSTRAINT price_adjustments_pkey PRIMARY KEY (id),
+    CONSTRAINT price_adjustments_product_fkey FOREIGN KEY (product_id, PERIOD adjustment_period) REFERENCES public.price_history (product_id, PERIOD valid_period)
+);

--- a/testdata/diff/create_table/add_fk/old.sql
+++ b/testdata/diff/create_table/add_fk/old.sql
@@ -105,3 +105,19 @@ CREATE TABLE public.orders (
     manager_id integer,
     CONSTRAINT orders_pkey PRIMARY KEY (id)
 );
+
+-- Temporal FK case (PG18+)
+CREATE TABLE public.price_history (
+    product_id integer NOT NULL,
+    valid_period tsrange NOT NULL,
+    price numeric(10,2) NOT NULL,
+    CONSTRAINT price_history_pkey PRIMARY KEY (product_id, valid_period WITHOUT OVERLAPS)
+);
+
+CREATE TABLE public.price_adjustments (
+    id integer NOT NULL,
+    product_id integer NOT NULL,
+    adjustment_period tsrange NOT NULL,
+    adjustment_pct numeric(5,2) NOT NULL,
+    CONSTRAINT price_adjustments_pkey PRIMARY KEY (id)
+);

--- a/testdata/diff/create_table/add_fk/plan.json
+++ b/testdata/diff/create_table/add_fk/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.7.4",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "a7fd4cf11997deb34dc75aeec37ffbc008d32d80dba2188a1dc1611fe5b5d710"
+    "hash": "a87e375f3503287f664096a6591ae4eb902b5fc5bcef6f8578df2e3d7f206a48"
   },
   "groups": [
     {
@@ -79,6 +79,18 @@
           "type": "table.constraint",
           "operation": "create",
           "path": "public.orders.orders_product_id_fkey"
+        },
+        {
+          "sql": "ALTER TABLE price_adjustments\nADD CONSTRAINT price_adjustments_product_fkey FOREIGN KEY (product_id, PERIOD adjustment_period) REFERENCES price_history (product_id, PERIOD valid_period) NOT VALID;",
+          "type": "table.constraint",
+          "operation": "create",
+          "path": "public.price_adjustments.price_adjustments_product_fkey"
+        },
+        {
+          "sql": "ALTER TABLE price_adjustments VALIDATE CONSTRAINT price_adjustments_product_fkey;",
+          "type": "table.constraint",
+          "operation": "create",
+          "path": "public.price_adjustments.price_adjustments_product_fkey"
         },
         {
           "sql": "ALTER TABLE products\nADD CONSTRAINT products_category_code_fkey FOREIGN KEY (category_code) REFERENCES categories (code) ON UPDATE CASCADE NOT VALID;",

--- a/testdata/diff/create_table/add_fk/plan.sql
+++ b/testdata/diff/create_table/add_fk/plan.sql
@@ -28,6 +28,11 @@ ADD CONSTRAINT orders_product_id_fkey FOREIGN KEY (product_id) REFERENCES produc
 
 ALTER TABLE orders VALIDATE CONSTRAINT orders_product_id_fkey;
 
+ALTER TABLE price_adjustments
+ADD CONSTRAINT price_adjustments_product_fkey FOREIGN KEY (product_id, PERIOD adjustment_period) REFERENCES price_history (product_id, PERIOD valid_period) NOT VALID;
+
+ALTER TABLE price_adjustments VALIDATE CONSTRAINT price_adjustments_product_fkey;
+
 ALTER TABLE products
 ADD CONSTRAINT products_category_code_fkey FOREIGN KEY (category_code) REFERENCES categories (code) ON UPDATE CASCADE NOT VALID;
 

--- a/testdata/diff/create_table/add_fk/plan.txt
+++ b/testdata/diff/create_table/add_fk/plan.txt
@@ -1,7 +1,7 @@
-Plan: 8 to modify.
+Plan: 9 to modify.
 
 Summary by type:
-  tables: 8 to modify
+  tables: 9 to modify
 
 Tables:
   ~ books
@@ -14,6 +14,8 @@ Tables:
     + orders_customer_id_fkey (constraint)
     + orders_manager_id_fkey (constraint)
     + orders_product_id_fkey (constraint)
+  ~ price_adjustments
+    + price_adjustments_product_fkey (constraint)
   ~ products
     + products_category_code_fkey (constraint)
   ~ projects
@@ -55,6 +57,11 @@ ALTER TABLE orders
 ADD CONSTRAINT orders_product_id_fkey FOREIGN KEY (product_id) REFERENCES products (id) ON DELETE CASCADE NOT VALID;
 
 ALTER TABLE orders VALIDATE CONSTRAINT orders_product_id_fkey;
+
+ALTER TABLE price_adjustments
+ADD CONSTRAINT price_adjustments_product_fkey FOREIGN KEY (product_id, PERIOD adjustment_period) REFERENCES price_history (product_id, PERIOD valid_period) NOT VALID;
+
+ALTER TABLE price_adjustments VALIDATE CONSTRAINT price_adjustments_product_fkey;
 
 ALTER TABLE products
 ADD CONSTRAINT products_category_code_fkey FOREIGN KEY (category_code) REFERENCES categories (code) ON UPDATE CASCADE NOT VALID;

--- a/testdata/diff/create_table/add_fk/setup.sql
+++ b/testdata/diff/create_table/add_fk/setup.sql
@@ -1,0 +1,2 @@
+-- btree_gist is required for WITHOUT OVERLAPS on non-range/multirange types
+CREATE EXTENSION IF NOT EXISTS btree_gist;

--- a/testdata/diff/create_table/add_pk/diff.sql
+++ b/testdata/diff/create_table/add_pk/diff.sql
@@ -7,6 +7,9 @@ ADD COLUMN id serial CONSTRAINT orders_pkey PRIMARY KEY;
 ALTER TABLE products
 ADD COLUMN id integer GENERATED ALWAYS AS IDENTITY CONSTRAINT products_pkey PRIMARY KEY;
 
+ALTER TABLE reservations
+ADD CONSTRAINT reservations_pkey PRIMARY KEY (id, valid_period WITHOUT OVERLAPS);
+
 ALTER TABLE sessions
 ADD COLUMN id uuid CONSTRAINT sessions_pkey PRIMARY KEY;
 

--- a/testdata/diff/create_table/add_pk/new.sql
+++ b/testdata/diff/create_table/add_pk/new.sql
@@ -46,3 +46,11 @@ CREATE TABLE public.categories (
     description text,
     CONSTRAINT categories_pkey PRIMARY KEY (code)
 );
+
+-- Temporal PK case (PG18+)
+CREATE TABLE public.reservations (
+    id integer NOT NULL,
+    valid_period tsrange NOT NULL,
+    description text,
+    CONSTRAINT reservations_pkey PRIMARY KEY (id, valid_period WITHOUT OVERLAPS)
+);

--- a/testdata/diff/create_table/add_pk/old.sql
+++ b/testdata/diff/create_table/add_pk/old.sql
@@ -35,3 +35,10 @@ CREATE TABLE public.categories (
     name text NOT NULL,
     description text
 );
+
+-- Temporal PK case (PG18+)
+CREATE TABLE public.reservations (
+    id integer NOT NULL,
+    valid_period tsrange NOT NULL,
+    description text
+);

--- a/testdata/diff/create_table/add_pk/plan.json
+++ b/testdata/diff/create_table/add_pk/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.7.4",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "c455204dbf5b6719964c1e26ff7ad6874ae2dda16e7f14be51b2fa082c6e7342"
+    "hash": "aa2ee5caf6ab616cedd6523e73c94e4acadf4435da3f5f31f9a89c08ac17b289"
   },
   "groups": [
     {
@@ -25,6 +25,12 @@
           "type": "table.column",
           "operation": "create",
           "path": "public.products.id"
+        },
+        {
+          "sql": "ALTER TABLE reservations\nADD CONSTRAINT reservations_pkey PRIMARY KEY (id, valid_period WITHOUT OVERLAPS);",
+          "type": "table.constraint",
+          "operation": "create",
+          "path": "public.reservations.reservations_pkey"
         },
         {
           "sql": "ALTER TABLE sessions\nADD COLUMN id uuid CONSTRAINT sessions_pkey PRIMARY KEY;",

--- a/testdata/diff/create_table/add_pk/plan.sql
+++ b/testdata/diff/create_table/add_pk/plan.sql
@@ -7,6 +7,9 @@ ADD COLUMN id serial CONSTRAINT orders_pkey PRIMARY KEY;
 ALTER TABLE products
 ADD COLUMN id integer GENERATED ALWAYS AS IDENTITY CONSTRAINT products_pkey PRIMARY KEY;
 
+ALTER TABLE reservations
+ADD CONSTRAINT reservations_pkey PRIMARY KEY (id, valid_period WITHOUT OVERLAPS);
+
 ALTER TABLE sessions
 ADD COLUMN id uuid CONSTRAINT sessions_pkey PRIMARY KEY;
 

--- a/testdata/diff/create_table/add_pk/plan.txt
+++ b/testdata/diff/create_table/add_pk/plan.txt
@@ -1,7 +1,7 @@
-Plan: 6 to modify.
+Plan: 7 to modify.
 
 Summary by type:
-  tables: 6 to modify
+  tables: 7 to modify
 
 Tables:
   ~ categories
@@ -10,6 +10,8 @@ Tables:
     + id (column)
   ~ products
     + id (column)
+  ~ reservations
+    + reservations_pkey (constraint)
   ~ sessions
     + id (column)
   ~ user_permissions
@@ -28,6 +30,9 @@ ADD COLUMN id serial CONSTRAINT orders_pkey PRIMARY KEY;
 
 ALTER TABLE products
 ADD COLUMN id integer GENERATED ALWAYS AS IDENTITY CONSTRAINT products_pkey PRIMARY KEY;
+
+ALTER TABLE reservations
+ADD CONSTRAINT reservations_pkey PRIMARY KEY (id, valid_period WITHOUT OVERLAPS);
 
 ALTER TABLE sessions
 ADD COLUMN id uuid CONSTRAINT sessions_pkey PRIMARY KEY;

--- a/testdata/diff/create_table/add_pk/setup.sql
+++ b/testdata/diff/create_table/add_pk/setup.sql
@@ -1,0 +1,2 @@
+-- btree_gist is required for WITHOUT OVERLAPS on non-range/multirange types
+CREATE EXTENSION IF NOT EXISTS btree_gist;

--- a/testutil/skip_list.go
+++ b/testutil/skip_list.go
@@ -69,10 +69,22 @@ var skipListPG14 = []string{
 	"create_index/add_index",
 }
 
+// skipListPG14_17 defines test cases that should be skipped for PostgreSQL 14-17.
+//
+// Reason for skipping:
+// These tests use features not available before PostgreSQL 18
+// (e.g., temporal constraints with WITHOUT OVERLAPS / PERIOD require pg_constraint.conperiod).
+var skipListPG14_17 = []string{
+	"create_table/add_pk",
+	"create_table/add_fk",
+}
+
 // skipListForVersion maps PostgreSQL major versions to their skip lists.
 var skipListForVersion = map[int][]string{
-	14: append(append([]string(nil), skipListPG14_15...), skipListPG14...),
-	15: skipListPG14_15,
+	14: append(append(append([]string(nil), skipListPG14_17...), skipListPG14_15...), skipListPG14...),
+	15: append(append([]string(nil), skipListPG14_17...), skipListPG14_15...),
+	16: skipListPG14_17,
+	17: skipListPG14_17,
 }
 
 // ShouldSkipTest checks if a test should be skipped for the given PostgreSQL major version.


### PR DESCRIPTION
Closes #364

## Summary

- Add support for PostgreSQL 18 temporal primary keys (`WITHOUT OVERLAPS`) and temporal foreign keys (`PERIOD`)
- Read `pg_constraint.conperiod` from the catalog to detect temporal constraints
- Preserve `WITHOUT OVERLAPS` and `PERIOD` clauses in both `plan` and `dump` output

## Changes

| File | Change |
|------|--------|
| `ir/queries/queries.sql` | Add `COALESCE((to_jsonb(c) ->> 'conperiod')::boolean, false) AS is_period` to `GetConstraints` and `GetConstraintsForSchema` queries. Uses `to_jsonb` to safely handle PG14-17 where the `conperiod` column does not exist |
| `ir/queries/queries.sql.go` | Add `IsPeriod bool` field to result structs and update `Scan` calls |
| `ir/ir.go` | Add `IsTemporal bool` field to `Constraint` struct. This single flag drives both `WITHOUT OVERLAPS` (PK/UNIQUE) and `PERIOD` (FK) output |
| `ir/inspector.go` | Set `IsTemporal` from `constraint.IsPeriod` when building constraints |
| `internal/diff/constraint.go` | Emit `WITHOUT OVERLAPS` for PK/UNIQUE and `PERIOD` for FK when `IsTemporal` is true; add comparison in `constraintsEqual` |
| `internal/diff/table.go` | Add temporal support to all `ALTER TABLE ADD CONSTRAINT` paths (PK, UNIQUE, FK) including deferred constraints |
| `internal/plan/rewrite.go` | Add `PERIOD` support to `generateForeignKeyRewrite` for `NOT VALID` constraint path |
| `testdata/diff/create_table/add_pk/` | Add temporal PK test case (`WITHOUT OVERLAPS`) with `setup.sql` for `btree_gist` |
| `testdata/diff/create_table/add_fk/` | Add temporal FK test case (`PERIOD`) with `setup.sql` for `btree_gist` |
| `testutil/skip_list.go` | Skip `add_pk`/`add_fk` tests on PG14-17 (temporal constraints require PG18+) |

## Backward Compatibility

- Uses `COALESCE((to_jsonb(c) ->> 'conperiod')::boolean, false)` so the query works on PostgreSQL 14-17 where the `conperiod` column does not exist. Unlike `COALESCE(c.conperiod, false)`, `to_jsonb` avoids the parse-time column-not-found error by converting the entire row to JSON and extracting the key
- Non-temporal constraints are unaffected (`IsTemporal` defaults to `false`)

## Testing

Temporal constraint coverage is provided via integration test fixtures in the existing `add_pk` and `add_fk` test suites:

```bash
# Diff tests
PGSCHEMA_TEST_FILTER="create_table/add_pk" go test -v ./internal/diff -run TestDiffFromFiles
PGSCHEMA_TEST_FILTER="create_table/add_fk" go test -v ./internal/diff -run TestDiffFromFiles

# Plan and apply integration tests
PGSCHEMA_TEST_FILTER="create_table/add_pk" go test -v ./cmd -run TestPlanAndApply
PGSCHEMA_TEST_FILTER="create_table/add_fk" go test -v ./cmd -run TestPlanAndApply
```

These tests are skipped on PG14-17 via `skipListPG14_17` since `WITHOUT OVERLAPS` / `PERIOD` syntax requires PG18+.

### Manual verification with PostgreSQL 18.3

**`plan` output** (empty DB → desired state with temporal constraints):

```sql
CONSTRAINT contacts_pkey PRIMARY KEY (id, valid_period WITHOUT OVERLAPS)
CONSTRAINT conversations_contact_id_valid_period_fkey FOREIGN KEY (contact_id, PERIOD valid_period) REFERENCES contacts (id, PERIOD valid_period)
```

**`dump` output** (existing DB with temporal constraints applied):

```sql
CONSTRAINT contacts_pkey PRIMARY KEY (id, valid_period WITHOUT OVERLAPS)
CONSTRAINT conversations_contact_id_valid_period_fkey FOREIGN KEY (contact_id, PERIOD valid_period) REFERENCES contacts (id, PERIOD valid_period)
```

Both correctly preserve `WITHOUT OVERLAPS` and `PERIOD` clauses.

## Known Limitation

When a temporal PK is combined with partitioned tables, `sortPrimaryKeyColumnsForPartitionedTable` may reorder columns and move the period column away from the last position. The current implementation applies `WITHOUT OVERLAPS` to the last column, which could be incorrect in this edge case. Temporal constraints on partitioned tables are an uncommon combination, and this can be addressed in a follow-up if needed.