### PR TITLE
fix: skip constraint drop when DROP COLUMN already removes it

### DIFF
--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -545,8 +545,14 @@ func generateModifyTablesSQL(diffs []*tableDiff, droppedTables []*ir.Table, targ
 
 	// Diffs are already sorted by the Diff operation
 	for _, diff := range diffs {
+		// Build a set of columns being dropped (DROP COLUMN will remove dependent constraints)
+		droppedColumnSet := make(map[string]bool, len(diff.DroppedColumns))
+		for _, column := range diff.DroppedColumns {
+			droppedColumnSet[column.Name] = true
+		}
+
 		// Pass collector to generateAlterTableStatements to collect with proper context
-		diff.generateAlterTableStatements(targetSchema, collector, droppedTableSet)
+		diff.generateAlterTableStatements(targetSchema, collector, droppedTableSet, droppedColumnSet)
 	}
 }
 
@@ -657,14 +663,38 @@ func shouldDeferConstraint(table *ir.Table, constraint *ir.Constraint, currentKe
 	return true
 }
 
+// constraintDroppedWithColumns reports whether dropping any column in droppedColumnSet
+// will implicitly remove the constraint. PostgreSQL drops dependent constraints as part
+// of ALTER TABLE ... DROP COLUMN, so emitting an explicit DROP CONSTRAINT would be redundant.
+func constraintDroppedWithColumns(constraint *ir.Constraint, droppedColumnSet map[string]bool) bool {
+	if constraint == nil || len(droppedColumnSet) == 0 {
+		return false
+	}
+
+	for _, column := range constraint.Columns {
+		if droppedColumnSet[column.Name] {
+			return true
+		}
+	}
+
+	return false
+}
+
 // generateAlterTableStatements generates SQL statements for table modifications
 // Note: DroppedTriggers are skipped here because they are already processed in the DROP phase
 // (see generateDropTriggersFromModifiedTables in trigger.go)
 // droppedTableSet contains "schema.table" keys for tables being dropped with CASCADE;
 // FK constraints referencing these tables are skipped since CASCADE already removes them.
-func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector *diffCollector, droppedTableSet map[string]bool) {
+// droppedColumnSet contains column names being dropped from this table; constraints that
+// depend on those columns are skipped because DROP COLUMN already removes them. (#384)
+func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector *diffCollector, droppedTableSet map[string]bool, droppedColumnSet map[string]bool) {
 	// Drop constraints first (before dropping columns) - already sorted by the Diff operation
 	for _, constraint := range td.DroppedConstraints {
+		// Skip constraints already removed by a dropped column. (#384)
+		if constraintDroppedWithColumns(constraint, droppedColumnSet) {
+			continue
+		}
+
 		// Skip FK constraints whose referenced table is being dropped with CASCADE,
 		// since the CASCADE will already remove the constraint. (#382)
 		if constraint.Type == ir.ConstraintTypeForeignKey && constraint.ReferencedTable != "" {
@@ -944,16 +974,18 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 		tableName := getTableNameWithSchema(td.Table.Schema, td.Table.Name, targetSchema)
 		constraint := ConstraintDiff.New
 
-		// Step 1: Drop the old constraint
-		dropSQL := fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s;", tableName, ir.QuoteIdentifier(ConstraintDiff.Old.Name))
-		dropContext := &diffContext{
-			Type:                DiffTypeTableConstraint,
-			Operation:           DiffOperationDrop,
-			Path:                fmt.Sprintf("%s.%s.%s", td.Table.Schema, td.Table.Name, ConstraintDiff.Old.Name),
-			Source:              ConstraintDiff.Old,
-			CanRunInTransaction: true,
+		// Step 1: Drop the old constraint unless a dropped column already removes it. (#384)
+		if !constraintDroppedWithColumns(ConstraintDiff.Old, droppedColumnSet) {
+			dropSQL := fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s;", tableName, ir.QuoteIdentifier(ConstraintDiff.Old.Name))
+			dropContext := &diffContext{
+				Type:                DiffTypeTableConstraint,
+				Operation:           DiffOperationDrop,
+				Path:                fmt.Sprintf("%s.%s.%s", td.Table.Schema, td.Table.Name, ConstraintDiff.Old.Name),
+				Source:              ConstraintDiff.Old,
+				CanRunInTransaction: true,
+			}
+			collector.collect(dropContext, dropSQL)
 		}
-		collector.collect(dropContext, dropSQL)
 
 		// Step 2: Add new constraint
 		var addSQL string

--- a/testdata/diff/create_table/issue_384_rename_column_constraint/diff.sql
+++ b/testdata/diff/create_table/issue_384_rename_column_constraint/diff.sql
@@ -1,0 +1,6 @@
+ALTER TABLE a DROP COLUMN revision;
+
+ALTER TABLE a ADD COLUMN current_revision bigint;
+
+ALTER TABLE a
+ADD CONSTRAINT a_revision_fkey FOREIGN KEY (current_revision) REFERENCES b (id);

--- a/testdata/diff/create_table/issue_384_rename_column_constraint/new.sql
+++ b/testdata/diff/create_table/issue_384_rename_column_constraint/new.sql
@@ -1,0 +1,5 @@
+CREATE TABLE a (id bigint PRIMARY KEY, current_revision bigint);
+
+CREATE TABLE b (id bigint PRIMARY KEY);
+
+ALTER TABLE a ADD CONSTRAINT "a_revision_fkey" FOREIGN KEY ("current_revision") REFERENCES "b" ("id");

--- a/testdata/diff/create_table/issue_384_rename_column_constraint/old.sql
+++ b/testdata/diff/create_table/issue_384_rename_column_constraint/old.sql
@@ -1,0 +1,5 @@
+CREATE TABLE a (id bigint PRIMARY KEY, revision bigint);
+
+CREATE TABLE b (id bigint PRIMARY KEY);
+
+ALTER TABLE a ADD CONSTRAINT "a_revision_fkey" FOREIGN KEY ("revision") REFERENCES "b" ("id");

--- a/testdata/diff/create_table/issue_384_rename_column_constraint/plan.json
+++ b/testdata/diff/create_table/issue_384_rename_column_constraint/plan.json
@@ -1,0 +1,38 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.8.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "251d2787a7d16b63a39420098fe2212492459ff06bbfe371537e54ddf4794f23"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "ALTER TABLE a DROP COLUMN revision;",
+          "type": "table.column",
+          "operation": "drop",
+          "path": "public.a.revision"
+        },
+        {
+          "sql": "ALTER TABLE a ADD COLUMN current_revision bigint;",
+          "type": "table.column",
+          "operation": "create",
+          "path": "public.a.current_revision"
+        },
+        {
+          "sql": "ALTER TABLE a\nADD CONSTRAINT a_revision_fkey FOREIGN KEY (current_revision) REFERENCES b (id) NOT VALID;",
+          "type": "table.constraint",
+          "operation": "create",
+          "path": "public.a.a_revision_fkey"
+        },
+        {
+          "sql": "ALTER TABLE a VALIDATE CONSTRAINT a_revision_fkey;",
+          "type": "table.constraint",
+          "operation": "create",
+          "path": "public.a.a_revision_fkey"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_table/issue_384_rename_column_constraint/plan.sql
+++ b/testdata/diff/create_table/issue_384_rename_column_constraint/plan.sql
@@ -1,0 +1,8 @@
+ALTER TABLE a DROP COLUMN revision;
+
+ALTER TABLE a ADD COLUMN current_revision bigint;
+
+ALTER TABLE a
+ADD CONSTRAINT a_revision_fkey FOREIGN KEY (current_revision) REFERENCES b (id) NOT VALID;
+
+ALTER TABLE a VALIDATE CONSTRAINT a_revision_fkey;

--- a/testdata/diff/create_table/issue_384_rename_column_constraint/plan.txt
+++ b/testdata/diff/create_table/issue_384_rename_column_constraint/plan.txt
@@ -1,0 +1,22 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ a
+    + current_revision (column)
+    - revision (column)
+    + a_revision_fkey (constraint)
+
+DDL to be executed:
+--------------------------------------------------
+
+ALTER TABLE a DROP COLUMN revision;
+
+ALTER TABLE a ADD COLUMN current_revision bigint;
+
+ALTER TABLE a
+ADD CONSTRAINT a_revision_fkey FOREIGN KEY (current_revision) REFERENCES b (id) NOT VALID;
+
+ALTER TABLE a VALIDATE CONSTRAINT a_revision_fkey;


### PR DESCRIPTION
When renaming a column by dropping the old column and adding a new one, PostgreSQL implicitly removes constraints that depend on the dropped column. The diff generator was still emitting explicit ALTER TABLE ... DROP CONSTRAINT for those same constraints, causing apply to fail with `constraint "..."" does not exist`.

The fix threads dropped-column context into generateAlterTableStatements and skips constraint drops when the old constraint is already removed by DROP COLUMN.

Fixes #384.

(Cribbed largely from #383, with assistance from OpenAI Codex)