### PR TITLE
fix: support CHECK constraints without columns and NO INHERIT modifier (#386)

### DIFF
--- a/internal/diff/constraint.go
+++ b/internal/diff/constraint.go
@@ -72,10 +72,13 @@ func generateConstraintSQL(constraint *ir.Constraint, targetSchema string) strin
 		}
 		return stmt
 	case ir.ConstraintTypeCheck:
-		// Generate CHECK constraint with proper NOT VALID placement
-		// The CheckClause is normalized to exclude NOT VALID (stripped in normalize.go)
-		// We append NOT VALID based on IsValid field, mimicking pg_dump behavior
+		// Generate CHECK constraint with proper NOT VALID / NO INHERIT placement
+		// The CheckClause is normalized to exclude NOT VALID and NO INHERIT (stripped in normalize.go)
+		// We append them based on IsValid/NoInherit fields, mimicking pg_dump behavior
 		result := fmt.Sprintf("CONSTRAINT %s %s", ir.QuoteIdentifier(constraint.Name), constraint.CheckClause)
+		if constraint.NoInherit {
+			result += " NO INHERIT"
+		}
 		if !constraint.IsValid {
 			result += " NOT VALID"
 		}
@@ -148,6 +151,9 @@ func constraintsEqual(old, new *ir.Constraint) bool {
 		return false
 	}
 	if old.CheckClause != new.CheckClause {
+		return false
+	}
+	if old.NoInherit != new.NoInherit {
 		return false
 	}
 	if old.ExclusionDefinition != new.ExclusionDefinition {

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -892,8 +892,12 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			// Ensure CHECK clause has outer parentheses around the full expression
 			tableName := getTableNameWithSchema(td.Table.Schema, td.Table.Name, targetSchema)
 			clause := ensureCheckClauseParens(constraint.CheckClause)
-			canonicalSQL := fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s %s;",
-				tableName, ir.QuoteIdentifier(constraint.Name), clause)
+			suffix := ""
+			if constraint.NoInherit {
+				suffix += " NO INHERIT"
+			}
+			canonicalSQL := fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s %s%s;",
+				tableName, ir.QuoteIdentifier(constraint.Name), clause, suffix)
 
 			context := &diffContext{
 				Type:                DiffTypeTableConstraint,
@@ -1005,8 +1009,12 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 
 		case ir.ConstraintTypeCheck:
 			// Add CHECK constraint with ensured outer parentheses
-			addSQL = fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s %s;",
-				tableName, ir.QuoteIdentifier(constraint.Name), ensureCheckClauseParens(constraint.CheckClause))
+			suffix := ""
+			if constraint.NoInherit {
+				suffix += " NO INHERIT"
+			}
+			addSQL = fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s %s%s;",
+				tableName, ir.QuoteIdentifier(constraint.Name), ensureCheckClauseParens(constraint.CheckClause), suffix)
 
 		case ir.ConstraintTypeForeignKey:
 			// Sort columns by position

--- a/internal/plan/rewrite.go
+++ b/internal/plan/rewrite.go
@@ -210,8 +210,12 @@ func generateIndexChangeRewrite(indexDiff *diff.IndexDiff) []RewriteStep {
 func generateConstraintRewrite(constraint *ir.Constraint) []RewriteStep {
 	tableName := getTableNameWithSchema(constraint.Schema, constraint.Table)
 
-	notValidSQL := fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s %s NOT VALID;",
-		tableName, ir.QuoteIdentifier(constraint.Name), constraint.CheckClause)
+	noInheritSuffix := ""
+	if constraint.NoInherit {
+		noInheritSuffix = " NO INHERIT"
+	}
+	notValidSQL := fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s %s%s NOT VALID;",
+		tableName, ir.QuoteIdentifier(constraint.Name), constraint.CheckClause, noInheritSuffix)
 	validateSQL := fmt.Sprintf("ALTER TABLE %s VALIDATE CONSTRAINT %s;",
 		tableName, ir.QuoteIdentifier(constraint.Name))
 

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -453,7 +453,11 @@ func (i *Inspector) buildConstraints(ctx context.Context, schema *IR, targetSche
 		}
 
 		if columnName == "" || columnName == "<nil>" {
-			continue // Skip constraints without columns
+			// CHECK and EXCLUDE constraints may have no columns (e.g., CHECK (FALSE))
+			// Only skip non-CHECK/EXCLUDE constraints without columns
+			if constraintType != "CHECK" && constraintType != "EXCLUDE" {
+				continue
+			}
 		}
 
 		key := constraintKey{
@@ -487,6 +491,7 @@ func (i *Inspector) buildConstraints(ctx context.Context, schema *IR, targetSche
 				Name:       constraintName,
 				Type:       cType,
 				Columns:    []*ConstraintColumn{},
+				NoInherit:  constraint.NoInherit,
 				IsTemporal: constraint.IsPeriod, // PG18 temporal constraint (WITHOUT OVERLAPS / PERIOD)
 			}
 
@@ -537,52 +542,55 @@ func (i *Inspector) buildConstraints(ctx context.Context, schema *IR, targetSche
 			constraintGroups[key] = c
 		}
 
-		// Get column position in constraint
-		position := i.getConstraintColumnPosition(ctx, schemaName, constraintName, columnName)
+		// Add column to constraint (skip for column-less constraints like CHECK (FALSE))
+		if columnName != "" && columnName != "<nil>" {
+			// Get column position in constraint
+			position := i.getConstraintColumnPosition(ctx, schemaName, constraintName, columnName)
 
-		// Check if column already exists in constraint to avoid duplicates
-		columnExists := false
-		for _, existingCol := range c.Columns {
-			if existingCol.Name == columnName {
-				columnExists = true
-				break
-			}
-		}
-
-		// Add column to constraint only if it doesn't exist
-		if !columnExists {
-			constraintCol := &ConstraintColumn{
-				Name:     columnName,
-				Position: position,
-			}
-			c.Columns = append(c.Columns, constraintCol)
-		}
-
-		// Handle foreign key referenced columns
-		if c.Type == ConstraintTypeForeignKey {
-			if refColumnName := i.safeInterfaceToString(constraint.ForeignColumnName); refColumnName != "" && refColumnName != "<nil>" {
-				// Check if referenced column already exists to avoid duplicates
-				refColumnExists := false
-				for _, existingRefCol := range c.ReferencedColumns {
-					if existingRefCol.Name == refColumnName {
-						refColumnExists = true
-						break
-					}
+			// Check if column already exists in constraint to avoid duplicates
+			columnExists := false
+			for _, existingCol := range c.Columns {
+				if existingCol.Name == columnName {
+					columnExists = true
+					break
 				}
+			}
 
-				// Add referenced column only if it doesn't exist
-				if !refColumnExists {
-					// Use the local column's constraint position for the referenced column.
-					// The local and referenced columns are paired together in the FK definition,
-					// so they must have the same position to maintain correct ordering.
-					// Note: ForeignOrdinalPosition from the query is fa.attnum (column position
-					// in the foreign table's definition), which is wrong - we need the constraint
-					// array position, which is the same as the local column's position.
-					refConstraintCol := &ConstraintColumn{
-						Name:     refColumnName,
-						Position: position, // Use local column's constraint position
+			// Add column to constraint only if it doesn't exist
+			if !columnExists {
+				constraintCol := &ConstraintColumn{
+					Name:     columnName,
+					Position: position,
+				}
+				c.Columns = append(c.Columns, constraintCol)
+			}
+
+			// Handle foreign key referenced columns
+			if c.Type == ConstraintTypeForeignKey {
+				if refColumnName := i.safeInterfaceToString(constraint.ForeignColumnName); refColumnName != "" && refColumnName != "<nil>" {
+					// Check if referenced column already exists to avoid duplicates
+					refColumnExists := false
+					for _, existingRefCol := range c.ReferencedColumns {
+						if existingRefCol.Name == refColumnName {
+							refColumnExists = true
+							break
+						}
 					}
-					c.ReferencedColumns = append(c.ReferencedColumns, refConstraintCol)
+
+					// Add referenced column only if it doesn't exist
+					if !refColumnExists {
+						// Use the local column's constraint position for the referenced column.
+						// The local and referenced columns are paired together in the FK definition,
+						// so they must have the same position to maintain correct ordering.
+						// Note: ForeignOrdinalPosition from the query is fa.attnum (column position
+						// in the foreign table's definition), which is wrong - we need the constraint
+						// array position, which is the same as the local column's position.
+						refConstraintCol := &ConstraintColumn{
+							Name:     refColumnName,
+							Position: position, // Use local column's constraint position
+						}
+						c.ReferencedColumns = append(c.ReferencedColumns, refConstraintCol)
+					}
 				}
 			}
 		}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -222,6 +222,7 @@ type Constraint struct {
 	Deferrable          bool                `json:"deferrable,omitempty"`
 	InitiallyDeferred   bool                `json:"initially_deferred,omitempty"`
 	IsValid             bool                `json:"is_valid,omitempty"`
+	NoInherit           bool                `json:"no_inherit,omitempty"` // CHECK constraint NO INHERIT modifier
 	IsTemporal          bool                `json:"is_temporal,omitempty"` // PG18: temporal constraint (WITHOUT OVERLAPS on PK/UNIQUE, PERIOD on FK)
 	Comment             string              `json:"comment,omitempty"`
 }

--- a/ir/normalize.go
+++ b/ir/normalize.go
@@ -1158,6 +1158,8 @@ func normalizeConstraint(constraint *Constraint) {
 	// Only normalize CHECK and EXCLUDE constraints - other constraint types are already consistent
 	if constraint.Type == ConstraintTypeCheck && constraint.CheckClause != "" {
 		constraint.CheckClause = normalizeCheckClause(constraint.CheckClause)
+		// pg_get_constraintdef may include NO INHERIT suffix — strip it and use the NoInherit field instead
+		// (NoInherit is already set from connoinherit in the query)
 	}
 	if constraint.Type == ConstraintTypeExclusion && constraint.ExclusionDefinition != "" {
 		constraint.ExclusionDefinition = normalizeExclusionDefinition(constraint.ExclusionDefinition)
@@ -1179,10 +1181,14 @@ func normalizeExclusionDefinition(definition string) string {
 // now come from the same PostgreSQL version via pg_get_constraintdef(), they produce identical
 // output. We only need basic cleanup for PostgreSQL internal representations.
 func normalizeCheckClause(checkClause string) string {
-	// Strip " NOT VALID" suffix if present (mimicking pg_dump behavior)
-	// PostgreSQL's pg_get_constraintdef may include NOT VALID at the end,
-	// but we want to control its placement via the IsValid field
+	// Strip " NOT VALID" and " NO INHERIT" suffixes if present
+	// PostgreSQL's pg_get_constraintdef may include these at the end,
+	// but we control their placement via the IsValid and NoInherit fields
 	clause := strings.TrimSpace(checkClause)
+	if strings.HasSuffix(clause, " NO INHERIT") {
+		clause = strings.TrimSuffix(clause, " NO INHERIT")
+		clause = strings.TrimSpace(clause)
+	}
 	if strings.HasSuffix(clause, " NOT VALID") {
 		clause = strings.TrimSuffix(clause, " NOT VALID")
 		clause = strings.TrimSpace(clause)

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -338,7 +338,8 @@ SELECT
     c.condeferrable AS deferrable,
     c.condeferred AS initially_deferred,
     c.convalidated AS is_valid,
-    COALESCE((to_jsonb(c) ->> 'conperiod')::boolean, false) AS is_period
+    COALESCE((to_jsonb(c) ->> 'conperiod')::boolean, false) AS is_period,
+    c.connoinherit AS no_inherit
 FROM pg_constraint c
 JOIN pg_class cl ON c.conrelid = cl.oid
 JOIN pg_namespace n ON cl.relnamespace = n.oid
@@ -917,7 +918,8 @@ SELECT
     c.condeferrable AS deferrable,
     c.condeferred AS initially_deferred,
     c.convalidated AS is_valid,
-    COALESCE((to_jsonb(c) ->> 'conperiod')::boolean, false) AS is_period
+    COALESCE((to_jsonb(c) ->> 'conperiod')::boolean, false) AS is_period,
+    c.connoinherit AS no_inherit
 FROM pg_constraint c
 JOIN pg_class cl ON c.conrelid = cl.oid
 JOIN pg_namespace n ON cl.relnamespace = n.oid

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -797,7 +797,8 @@ SELECT
     c.condeferrable AS deferrable,
     c.condeferred AS initially_deferred,
     c.convalidated AS is_valid,
-    COALESCE((to_jsonb(c) ->> 'conperiod')::boolean, false) AS is_period
+    COALESCE((to_jsonb(c) ->> 'conperiod')::boolean, false) AS is_period,
+    c.connoinherit AS no_inherit
 FROM pg_constraint c
 JOIN pg_class cl ON c.conrelid = cl.oid
 JOIN pg_namespace n ON cl.relnamespace = n.oid
@@ -830,6 +831,7 @@ type GetConstraintsRow struct {
 	InitiallyDeferred      bool           `db:"initially_deferred" json:"initially_deferred"`
 	IsValid                bool           `db:"is_valid" json:"is_valid"`
 	IsPeriod               bool           `db:"is_period" json:"is_period"`
+	NoInherit              bool           `db:"no_inherit" json:"no_inherit"`
 }
 
 // GetConstraints retrieves all table constraints
@@ -861,6 +863,7 @@ func (q *Queries) GetConstraints(ctx context.Context) ([]GetConstraintsRow, erro
 			&i.InitiallyDeferred,
 			&i.IsValid,
 			&i.IsPeriod,
+			&i.NoInherit,
 		); err != nil {
 			return nil, err
 		}
@@ -915,7 +918,8 @@ SELECT
     c.condeferrable AS deferrable,
     c.condeferred AS initially_deferred,
     c.convalidated AS is_valid,
-    COALESCE((to_jsonb(c) ->> 'conperiod')::boolean, false) AS is_period
+    COALESCE((to_jsonb(c) ->> 'conperiod')::boolean, false) AS is_period,
+    c.connoinherit AS no_inherit
 FROM pg_constraint c
 JOIN pg_class cl ON c.conrelid = cl.oid
 JOIN pg_namespace n ON cl.relnamespace = n.oid
@@ -946,6 +950,7 @@ type GetConstraintsForSchemaRow struct {
 	InitiallyDeferred      bool           `db:"initially_deferred" json:"initially_deferred"`
 	IsValid                bool           `db:"is_valid" json:"is_valid"`
 	IsPeriod               bool           `db:"is_period" json:"is_period"`
+	NoInherit              bool           `db:"no_inherit" json:"no_inherit"`
 }
 
 // GetConstraintsForSchema retrieves all table constraints for a specific schema
@@ -977,6 +982,7 @@ func (q *Queries) GetConstraintsForSchema(ctx context.Context, dollar_1 sql.Null
 			&i.InitiallyDeferred,
 			&i.IsValid,
 			&i.IsPeriod,
+			&i.NoInherit,
 		); err != nil {
 			return nil, err
 		}

--- a/testdata/diff/comment/add_column_comments/plan.json
+++ b/testdata/diff/comment/add_column_comments/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "395a31ea82eaee99933280fdb3f320487dd7dabef2dd772729c7e5f3b8ceff9e"
+    "hash": "1351e4ca7db945af39a49da2b23273d5b33a8b1b9bd3b6a45f3cb4cf2cfce1a2"
   },
   "groups": [
     {

--- a/testdata/diff/comment/add_index_comment/plan.json
+++ b/testdata/diff/comment/add_index_comment/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "d5424ad774c4a220725ab96071453230e0817f6ed77df1c3d427be4c28d1d3e5"
+    "hash": "a859ebafe82f0638592346ffb79d2bb11c1f0748d86308a87ff66c51abb68592"
   },
   "groups": [
     {

--- a/testdata/diff/comment/add_table_comment/plan.json
+++ b/testdata/diff/comment/add_table_comment/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "ecf6d758d162c619907a2ab40f21478757d500dcc5885194afc013992e700339"
+    "hash": "f2623b8934b586c1ae51649bdfdcc295015334ce0d0cd6b7f4d6e2bc077030b3"
   },
   "groups": [
     {

--- a/testdata/diff/comment/alter_table_comment/plan.json
+++ b/testdata/diff/comment/alter_table_comment/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "8a4456790d31384951589e1a5cfcdb72c2c13db9aa651fa67f69dd210a4df0f5"
+    "hash": "1f242a84c8de680321c9fc75dcc5a06760ac51cc74d2e6b6affe524e341745f9"
   },
   "groups": [
     {

--- a/testdata/diff/comment/drop_table_comment/plan.json
+++ b/testdata/diff/comment/drop_table_comment/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "22213fffa77d3732ce0dd017e5f6f54c8c1da4c2b052a2c82e06a119a491614f"
+    "hash": "2ae68cfa8f7248d127b54e8c0ba366176b4e6ba698ed57883686f134a287ef16"
   },
   "groups": [
     {

--- a/testdata/diff/comment/mixed_comments/plan.json
+++ b/testdata/diff/comment/mixed_comments/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "4f1b7baaff86b8f65e5ed747a064727e12fb0aeedff84f6f74439d1e20759dad"
+    "hash": "84e9a9b7c080fc6d686f528f11d070d030b1ab82e66a2ad98050868d66d2f98a"
   },
   "groups": [
     {

--- a/testdata/diff/comment/noop_column_comments/plan.json
+++ b/testdata/diff/comment/noop_column_comments/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "0f6266823ea77f5c0d7e8fe9d4b61bc9a40e38d6e25e26dfdf99944e5c4be0d9"
+    "hash": "06d2c3351398ca9ab591c3985cf2791ac3ff5b960eadac98470abbc0b611734a"
   },
   "groups": null
 }

--- a/testdata/diff/create_function/issue_354_empty_search_path/plan.json
+++ b/testdata/diff/create_function/issue_354_empty_search_path/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "742d612cedabf2d80d87df6c7d9fac8911e008b29ef8e15d16a32d2edf43ddd9"
+    "hash": "29f02983bf9ecf6f5f1ec38377f7209ec60f4fe4051d371227ace7d93bddf381"
   },
   "groups": [
     {

--- a/testdata/diff/create_materialized_view/add_materialized_view/plan.json
+++ b/testdata/diff/create_materialized_view/add_materialized_view/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "f787a47486736a59da932aa3fc0cb21e0fc423cfa56d1b2d3de2b529ccae64b9"
+    "hash": "c080880eeed5c864d9039e5087e56335177c19b37ace103267da30a2ef36775b"
   },
   "groups": [
     {

--- a/testdata/diff/create_materialized_view/alter_materialized_view/plan.json
+++ b/testdata/diff/create_materialized_view/alter_materialized_view/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "f0ac3bb964fd207775142c2f9119442b29f04e10c74de4162cf6e468335e5835"
+    "hash": "d7265cc266dac8551a3b9f37cf2293f45c601b13dafb6bb301915976389a3927"
   },
   "groups": [
     {

--- a/testdata/diff/create_materialized_view/drop_materialized_view/plan.json
+++ b/testdata/diff/create_materialized_view/drop_materialized_view/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "6ab6529bbf7c84fb6b639938bdaa3ca5af18b75b3de3637421b43469e4342865"
+    "hash": "a90a90090750b18a9aaffb6de253bd12234fe30ccf9cfc35b82c34ac834f1360"
   },
   "groups": [
     {

--- a/testdata/diff/create_policy/add_policy/plan.json
+++ b/testdata/diff/create_policy/add_policy/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "261f1966678419184a6d17b5ad2c09d590b77fff9dbe01fd56849d53f3079c8e"
+    "hash": "476200c6123d04c01b912d2935ac4ec2d355278cc5d67529af8ab8ad1c7d2af0"
   },
   "groups": [
     {

--- a/testdata/diff/create_policy/alter_policy_command/plan.json
+++ b/testdata/diff/create_policy/alter_policy_command/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "4dde0e257ba5ac0a0ad55c5be408409192726dd6029e431a68742a993f705d3c"
+    "hash": "829d5dbe4a19b9f96927bfa221e10199ebe0f41d70fdaec9004f1ef8b8c9c73f"
   },
   "groups": [
     {

--- a/testdata/diff/create_policy/alter_policy_name/plan.json
+++ b/testdata/diff/create_policy/alter_policy_name/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "4dde0e257ba5ac0a0ad55c5be408409192726dd6029e431a68742a993f705d3c"
+    "hash": "829d5dbe4a19b9f96927bfa221e10199ebe0f41d70fdaec9004f1ef8b8c9c73f"
   },
   "groups": [
     {

--- a/testdata/diff/create_policy/alter_policy_roles/plan.json
+++ b/testdata/diff/create_policy/alter_policy_roles/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "a5fcd005530df97b095b020e1a8c2fb12333baf056c3a2318bc34f2157893877"
+    "hash": "ca023a9b3035810c567ac9399fe047ac2a2ac322d00351fe13e143d26bad1b9b"
   },
   "groups": [
     {

--- a/testdata/diff/create_policy/alter_policy_using/plan.json
+++ b/testdata/diff/create_policy/alter_policy_using/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "b23d70f93fe88b9bfcf8d05f46e3faa60d54cf469813e2ead871e9c9d9231ab7"
+    "hash": "d7858c54fa0b38bfa63c613f6bba0eaaa5827388d53e4548bd9ff419ea357046"
   },
   "groups": [
     {

--- a/testdata/diff/create_policy/disable_rls/plan.json
+++ b/testdata/diff/create_policy/disable_rls/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "a5fcd005530df97b095b020e1a8c2fb12333baf056c3a2318bc34f2157893877"
+    "hash": "ca023a9b3035810c567ac9399fe047ac2a2ac322d00351fe13e143d26bad1b9b"
   },
   "groups": [
     {

--- a/testdata/diff/create_policy/drop_policy/plan.json
+++ b/testdata/diff/create_policy/drop_policy/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "a5fcd005530df97b095b020e1a8c2fb12333baf056c3a2318bc34f2157893877"
+    "hash": "ca023a9b3035810c567ac9399fe047ac2a2ac322d00351fe13e143d26bad1b9b"
   },
   "groups": [
     {

--- a/testdata/diff/create_policy/enable_rls/plan.json
+++ b/testdata/diff/create_policy/enable_rls/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "ae66d4f64657d2848aa1c075994ef2916aab28fa5a94765a4937081b4ea3e780"
+    "hash": "bc1c9e0c7cb35d93e4a07f8f1490f1fa8ca27e9f7de430d271ab0caa7b4e1690"
   },
   "groups": [
     {

--- a/testdata/diff/create_policy/force_rls/plan.json
+++ b/testdata/diff/create_policy/force_rls/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "f26c6614d22a712e9314414c386efca5bb723c12064c63e173483f718716f193"
+    "hash": "4301e0e8cbfb9465b41874d81220ea76d6b7696c79dd0f79b94fee7cb75ca372"
   },
   "groups": [
     {

--- a/testdata/diff/create_policy/issue_377_nested_function_in_policy/plan.json
+++ b/testdata/diff/create_policy/issue_377_nested_function_in_policy/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "37d3ebdd423c5db41ba042431c6328705f50593fe2c8f5163de497aa4eee08b8"
+    "hash": "e5af492401964f08c79bb81cc010968b0ed2bd2f12081e194ed15e579dea2aff"
   },
   "groups": [
     {

--- a/testdata/diff/create_policy/remove_force_rls/plan.json
+++ b/testdata/diff/create_policy/remove_force_rls/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "6d556186d2ea5db5c7aebfd47e9a7d91430bbed6f2c9052964d2d17424b6984d"
+    "hash": "7c4d36f4b642982defe19b82256148413f32e6dd9c9d11bfe350bf0beb2375e3"
   },
   "groups": [
     {

--- a/testdata/diff/create_table/add_check/plan.json
+++ b/testdata/diff/create_table/add_check/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "151a72608ba307985f8a690775347ce7046befc96fd44144dbb4c0c14c598739"
+    "hash": "3b417f67f91d6a00681d82fa91a44bc786c781d4e45fa945af95bd8185f2e750"
   },
   "groups": [
     {

--- a/testdata/diff/create_table/add_column_cross_schema_custom_type/plan.json
+++ b/testdata/diff/create_table/add_column_cross_schema_custom_type/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "3fb7c0ad6f90724c66d94dacefe4e744a618f2fdc0f2bd53ad48c309a397de5b"
+    "hash": "0d7287d9b46eed0ab41e966b5101db966c24ad8f09f5b52f20c5c04a2132ea64"
   },
   "groups": [
     {

--- a/testdata/diff/create_table/add_default_not_null/plan.json
+++ b/testdata/diff/create_table/add_default_not_null/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "a5614a0f5b8d53ba131811b4a89cd3eddb434b6bd0398b7ec180199c8fba880d"
+    "hash": "01cf16fec8a51600f8cb61a4e18fb339de480aaa256c4203a10ce9448584d25d"
   },
   "groups": [
     {

--- a/testdata/diff/create_table/add_fk/plan.json
+++ b/testdata/diff/create_table/add_fk/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "a87e375f3503287f664096a6591ae4eb902b5fc5bcef6f8578df2e3d7f206a48"
+    "hash": "9b85e377059726a1c480a565f28fa2caf1e39ba1512de5c1adc8efbabc669dc1"
   },
   "groups": [
     {

--- a/testdata/diff/create_table/composite_fk_column_order/plan.json
+++ b/testdata/diff/create_table/composite_fk_column_order/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "1948e0ca8413d527d01353e9a8b4f4581198c99a5b994959bda5e05beb462153"
+    "hash": "4a1d5994bf17ba1a92365f4aa2ee445bcd47f70f4f2f03ac0c92e1eea98e8628"
   },
   "groups": [
     {

--- a/testdata/diff/create_table/issue_281_exclude_constraint/plan.json
+++ b/testdata/diff/create_table/issue_281_exclude_constraint/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "4fbb3d8c221ccc65b31f81678cb19ac44eccc901628273d00cc3e124a6ee6877"
+    "hash": "8c02dcded896566d3e27f6ce69aea524eed71de4ee798e3bc5e0e21dda5be9d6"
   },
   "groups": [
     {

--- a/testdata/diff/create_table/issue_283_function_default_schema_qualifier/plan.json
+++ b/testdata/diff/create_table/issue_283_function_default_schema_qualifier/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "0915a8651243d1249ecffcf4938383a65f0a0fb644f189f372e3719f2a46f13f"
+    "hash": "420f93fc4d28a108b8b2b941d4745546a8620946e502e07311b540803d2bff1f"
   },
   "groups": null
 }

--- a/testdata/diff/create_table/issue_382_drop_table_cascade_constraint/plan.json
+++ b/testdata/diff/create_table/issue_382_drop_table_cascade_constraint/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "62dd4ce9d3f9c6521a16cdbf81cf9511ce4c5a18c65272f5dfa306bfe476cad3"
+    "hash": "0a32199426efead5dff4059c2fcb9eb77a49677202c5d381c43f98c2d73e54d9"
   },
   "groups": [
     {

--- a/testdata/diff/create_table/issue_384_rename_column_constraint/plan.json
+++ b/testdata/diff/create_table/issue_384_rename_column_constraint/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "251d2787a7d16b63a39420098fe2212492459ff06bbfe371537e54ddf4794f23"
+    "hash": "7fcec59d1a0d260fce77ca55af1cad30ebc8768996825647c4002962d1a8f8ee"
   },
   "groups": [
     {

--- a/testdata/diff/create_trigger/add_trigger/plan.json
+++ b/testdata/diff/create_trigger/add_trigger/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "a099356e267a2e28a40672b8d007db5082d1399d9239faa7fcdc194842027381"
+    "hash": "71591928eb9f4b89bfdb9fd291db500f36cf140bf6002a62c89de4a6c4d016be"
   },
   "groups": [
     {

--- a/testdata/diff/create_trigger/add_trigger_constraint/plan.json
+++ b/testdata/diff/create_trigger/add_trigger_constraint/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "78dc0b05e73aa55e80425103b0d8fb983f32eb26cae6db2f6c293661b8b60f18"
+    "hash": "a47459950b6b41998921f1284295631251e890d54891c8ab378c1d3c7c7abff4"
   },
   "groups": [
     {

--- a/testdata/diff/create_trigger/add_trigger_old_table/plan.json
+++ b/testdata/diff/create_trigger/add_trigger_old_table/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "fdad24e9951fe452a5564a5b7b9de8f12531310dd442f752cc393e3fc9a28c85"
+    "hash": "c72c98ff78c98bf6d04e41698ea8be67e045350586e0286ec945980d70cf72f3"
   },
   "groups": [
     {

--- a/testdata/diff/create_trigger/add_trigger_system_catalog/plan.json
+++ b/testdata/diff/create_trigger/add_trigger_system_catalog/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "b12c4184141eaba7448393d463064658c09818c4be2d97bbd9a28cd0567ff9c8"
+    "hash": "43d9524fe7d4f30f7e7dc91616162b92fb4833343be7ac06d3c35f9cb60ccc40"
   },
   "groups": [
     {

--- a/testdata/diff/create_trigger/add_trigger_when_distinct/plan.json
+++ b/testdata/diff/create_trigger/add_trigger_when_distinct/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "ad4075d6c365b628b72e784861c986b1bed0f7c395266c5acc4f52aab3f3fed9"
+    "hash": "29cdffe034879897517bf2048a11e13b3fb93bd0247072f19ab67cff58cd4ae5"
   },
   "groups": [
     {

--- a/testdata/diff/create_trigger/alter_trigger/plan.json
+++ b/testdata/diff/create_trigger/alter_trigger/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "8b7fc5c8f9c2fa7fd736a73a16990926fcbcbefc216e72bdceb76150f6374127"
+    "hash": "e80a9a1556e42c582c28840b5597b70cc7ee51f34627e869efd7b5d1ed2a2c49"
   },
   "groups": [
     {

--- a/testdata/diff/create_trigger/drop_trigger/plan.json
+++ b/testdata/diff/create_trigger/drop_trigger/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "8b7fc5c8f9c2fa7fd736a73a16990926fcbcbefc216e72bdceb76150f6374127"
+    "hash": "e80a9a1556e42c582c28840b5597b70cc7ee51f34627e869efd7b5d1ed2a2c49"
   },
   "groups": [
     {

--- a/testdata/diff/create_view/add_view/plan.json
+++ b/testdata/diff/create_view/add_view/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "d8927a4f1a355b7082959da316da682f9455931dc9dc575e3e00f31b4e691221"
+    "hash": "cee0753877527b3ec8028ecd1b41ab73dae6c726a91f3efdde66d8569e6fb103"
   },
   "groups": [
     {

--- a/testdata/diff/create_view/add_view_join/plan.json
+++ b/testdata/diff/create_view/add_view_join/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "685ac778b403f5c2ed531013d11acb145defbe7c071c68b236359d342c640ff4"
+    "hash": "13b0da782fac53005595f43139ce2283283f1bc1fa326ee2c92c4629875253c6"
   },
   "groups": [
     {

--- a/testdata/diff/create_view/alter_view/plan.json
+++ b/testdata/diff/create_view/alter_view/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "c19a9770ce221783099768139e373f972b1e180103d51e663961f38bb6e92194"
+    "hash": "e416c57a7e97843652d92d544f409ff025128ce45358273b5bffd768c6f29cc7"
   },
   "groups": [
     {

--- a/testdata/diff/create_view/drop_view/plan.json
+++ b/testdata/diff/create_view/drop_view/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "51c0c66c5b170a5edf5aa05d24de36669e89212b0f178a1b611ead263e15448d"
+    "hash": "5bddbd174fba7e0c39fb1ffbea0f8ca185f676b54286b18d5cf7350d81c4224a"
   },
   "groups": [
     {

--- a/testdata/diff/create_view/issue_350_view_options/plan.json
+++ b/testdata/diff/create_view/issue_350_view_options/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "3dd9c8d5398e477d3a0cf9ac459cb7241f0c3cb02931512dc1a27b431dbc31fa"
+    "hash": "360832e875cab1bfc83c551db1100fc7c3ba71d034ded73495053fb63adfbc83"
   },
   "groups": [
     {

--- a/testdata/diff/default_privilege/auto_grant_idempotent/plan.json
+++ b/testdata/diff/default_privilege/auto_grant_idempotent/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "16119adc01274eb2d4d4fdb177740d5176d82ff4330f7605e3c08a5926b8e734"
+    "hash": "bc57a912a491b0def11bf6e4b9b4de9d1b27fed796bf0988e1ed492cadd64493"
   },
   "groups": null
 }

--- a/testdata/diff/dependency/function_to_trigger/plan.json
+++ b/testdata/diff/dependency/function_to_trigger/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "0929968f1e1a008059219136dead74e2a38c04764800b78ec16f30dd9b0db645"
+    "hash": "e1ad9e7efedd98f518dfa2edbb6f5b4f7d2b5f4ddfee9cfe0f99cc1c2a866eb4"
   },
   "groups": [
     {

--- a/testdata/diff/dependency/issue_308_view_select_star_column_reorder/plan.json
+++ b/testdata/diff/dependency/issue_308_view_select_star_column_reorder/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "5286641907331c5566ca08272365dcd0be588ae72a7c17176a7c73b8cc1c1a23"
+    "hash": "584e78ed59cc9fc48eae0b3f7fb8951623a81775c011bafcb4c27e781ed5f170"
   },
   "groups": [
     {

--- a/testdata/diff/dependency/table_to_materialized_view/plan.json
+++ b/testdata/diff/dependency/table_to_materialized_view/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "71e22b38d379c8253b2d30e24ea3001d3dd852bc24a363cb9251721eae354e0e"
+    "hash": "f9203703a19466fbbef2ce5a7e5d63422c831ab0b28aee0ee5b52331ea50bd27"
   },
   "groups": [
     {

--- a/testdata/diff/dependency/table_to_view/plan.json
+++ b/testdata/diff/dependency/table_to_view/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "2bbf94e4c07fcfaf9eb9b9dedf281aef14449bcc388f5875cb6e7e1cd5594c36"
+    "hash": "edd3e06b150f88d743bd989d71daa0fd24b834c4a9e901aed640fa0fd19462dc"
   },
   "groups": [
     {

--- a/testdata/diff/migrate/v2/plan.json
+++ b/testdata/diff/migrate/v2/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "852c7be0c064cc61b61c0c0aa4d6bf4ceea14b8de4ba659a6b0820025804974d"
+    "hash": "b6ae92653cfa9d3b3e5ac5c0415518e81b96326b5236a9c8829e278a62b89efb"
   },
   "groups": [
     {

--- a/testdata/diff/migrate/v3/plan.json
+++ b/testdata/diff/migrate/v3/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "18238a8541ab881b44763d9ad42b42a5386a62bef58764711e6bd1ed696f5d13"
+    "hash": "9e37fb057af32b98c899ee94f42f4916403b6ddf361b29beccb9b657b58abc1f"
   },
   "groups": [
     {

--- a/testdata/diff/migrate/v4/plan.json
+++ b/testdata/diff/migrate/v4/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "01d5713f309088f07625f75edecdde8016b424a5e2b25fc5c5b6011052bdc6b2"
+    "hash": "bdbae04ce681eb5be9912131759a7b327273fb07c3d1ad5648fd160cda572454"
   },
   "groups": [
     {

--- a/testdata/diff/migrate/v5/plan.json
+++ b/testdata/diff/migrate/v5/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "d35c347ef96d6e64cb3745559d649fda2b4f2a4b16ffc3bc6a40d10d216c823a"
+    "hash": "1bdbd0c7d1e5902ba4bab0e98b09d3ec89efaa6286d785c96c8803befd111941"
   },
   "groups": [
     {

--- a/testdata/diff/online/add_fk/plan.json
+++ b/testdata/diff/online/add_fk/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "d694b29e56c5eee996f8ea5dc58525a625b4c7d0e18196578ca27fe2aa390542"
+    "hash": "e67f1222093d3d30328f364981301ac4aa2c0c7678df5494fbf07bd3a01096ff"
   },
   "groups": [
     {

--- a/testdata/diff/online/alter_fk/plan.json
+++ b/testdata/diff/online/alter_fk/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "ad9af0eeaeb21df3d1e0fea0e61b060e89a0b7cfcdd347df2e4a65d2b82afce3"
+    "hash": "eb60afcd651f636a432f85e7ec5571c6f9074518bc06d3a5fbc87df688e534ca"
   },
   "groups": [
     {

--- a/testdata/diff/online/issue_286_reserved_keyword_quoting/plan.json
+++ b/testdata/diff/online/issue_286_reserved_keyword_quoting/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "880c2cec11ce10f5b7868bde9b051d7559368a092d2071a5cd68a0b1d5456627"
+    "hash": "7f1a921c5f4e77dff3078b3834e0a0e64270239601847f586817ce981b3f3d14"
   },
   "groups": [
     {

--- a/testdata/diff/online/issue_313_camelcase_column_not_null/plan.json
+++ b/testdata/diff/online/issue_313_camelcase_column_not_null/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "59ecc7fdab924e513eb6acdc93543167379bf64b4c6b5e1fe1d8e98fa48fdb9f"
+    "hash": "c151d6b38e413e2a0fea4628892eb22ff76c48f1b933d03143cc3b0fde97e4f8"
   },
   "groups": [
     {

--- a/testdata/diff/online/issue_386_check_no_inherit/diff.sql
+++ b/testdata/diff/online/issue_386_check_no_inherit/diff.sql
@@ -1,0 +1,2 @@
+ALTER TABLE parent_base
+ADD CONSTRAINT no_direct_insert CHECK (false) NO INHERIT;

--- a/testdata/diff/online/issue_386_check_no_inherit/new.sql
+++ b/testdata/diff/online/issue_386_check_no_inherit/new.sql
@@ -1,0 +1,6 @@
+CREATE TABLE public.parent_base (
+    id uuid NOT NULL,
+    name text NOT NULL,
+    CONSTRAINT parent_base_pkey PRIMARY KEY (id),
+    CONSTRAINT no_direct_insert CHECK (false) NO INHERIT
+);

--- a/testdata/diff/online/issue_386_check_no_inherit/old.sql
+++ b/testdata/diff/online/issue_386_check_no_inherit/old.sql
@@ -1,0 +1,7 @@
+CREATE TABLE public.parent_base (
+    id uuid NOT NULL,
+    name text NOT NULL
+);
+
+ALTER TABLE public.parent_base
+ADD CONSTRAINT parent_base_pkey PRIMARY KEY (id);

--- a/testdata/diff/online/issue_386_check_no_inherit/plan.json
+++ b/testdata/diff/online/issue_386_check_no_inherit/plan.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.8.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "7a986c71ded1858e3a4c287f6f6b08f08719008f237eff921df9b3b52371867b"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "ALTER TABLE parent_base\nADD CONSTRAINT no_direct_insert CHECK (false) NO INHERIT NOT VALID;",
+          "type": "table.constraint",
+          "operation": "create",
+          "path": "public.parent_base.no_direct_insert"
+        },
+        {
+          "sql": "ALTER TABLE parent_base VALIDATE CONSTRAINT no_direct_insert;",
+          "type": "table.constraint",
+          "operation": "create",
+          "path": "public.parent_base.no_direct_insert"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/online/issue_386_check_no_inherit/plan.sql
+++ b/testdata/diff/online/issue_386_check_no_inherit/plan.sql
@@ -1,0 +1,4 @@
+ALTER TABLE parent_base
+ADD CONSTRAINT no_direct_insert CHECK (false) NO INHERIT NOT VALID;
+
+ALTER TABLE parent_base VALIDATE CONSTRAINT no_direct_insert;

--- a/testdata/diff/online/issue_386_check_no_inherit/plan.txt
+++ b/testdata/diff/online/issue_386_check_no_inherit/plan.txt
@@ -1,0 +1,16 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ parent_base
+    + no_direct_insert (constraint)
+
+DDL to be executed:
+--------------------------------------------------
+
+ALTER TABLE parent_base
+ADD CONSTRAINT no_direct_insert CHECK (false) NO INHERIT NOT VALID;
+
+ALTER TABLE parent_base VALIDATE CONSTRAINT no_direct_insert;

--- a/testdata/diff/privilege/alter_privilege/plan.json
+++ b/testdata/diff/privilege/alter_privilege/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "37a83f6528ef1727418deb17421226e68badb29f678e5ea7ba1a0947f51e220c"
+    "hash": "ce677037813532390cc0179dd03fa2e40961ec4dbbb86c957b83322744ab5a46"
   },
   "groups": [
     {

--- a/testdata/diff/privilege/grant_table_multiple/plan.json
+++ b/testdata/diff/privilege/grant_table_multiple/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "b58434507a24c7e16d958486d79ce94453f9a249af1f3f4bc2f4d3479d22ae0d"
+    "hash": "ed31ba27099edeef640871532dbf79cc408e417a5e1feeecc43df88c21447f53"
   },
   "groups": [
     {

--- a/testdata/diff/privilege/grant_table_select/plan.json
+++ b/testdata/diff/privilege/grant_table_select/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "930412dd8d3510344c8498a09f757a5e375ae4d2e101eae2c14808fea7dd3594"
+    "hash": "61c520955d9df95c9d233b93c7500d90fe0a5aabed7dbe61ab394a02cef98940"
   },
   "groups": [
     {

--- a/testdata/diff/privilege/grant_with_grant_option/plan.json
+++ b/testdata/diff/privilege/grant_with_grant_option/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "1cc2abbffadb0f96d897c60ddc96681b9a3d629a25e905e5ca208d98cd4d7a22"
+    "hash": "ebd29a0231408c46d6b2733a4671e806b669cb4d27d79a4e7afb81db15f12445"
   },
   "groups": [
     {

--- a/testdata/diff/privilege/revoke_grant_option/plan.json
+++ b/testdata/diff/privilege/revoke_grant_option/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "64ecb0bdec360cdb69238817cc218b0efe5a06b2c34c56e922b0beb2cafbd45c"
+    "hash": "06cc802df43a14a2fb3c8ae79646ae78edca7e87ec1e1267bc2591c73973e2b2"
   },
   "groups": [
     {

--- a/testdata/diff/privilege/revoke_table_privilege/plan.json
+++ b/testdata/diff/privilege/revoke_table_privilege/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.8.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "98ec3c4723e9dcc7194e1ecdf00bc3c1b7a54a1cbe638a8e2531da763900580e"
+    "hash": "645f57ade0670f1bd4b95964bd9e0b5b04facb355b66cd4fb675256aeaf35c5b"
   },
   "groups": [
     {


### PR DESCRIPTION
## Summary
- Column-less CHECK constraints (e.g., `CHECK (FALSE) NO INHERIT`) were silently dropped during introspection because the LEFT JOIN on `pg_attribute` produced NULL for `attname`, triggering the `columnName==""` guard
- The `NO INHERIT` modifier was not tracked anywhere in the IR, queries, or DDL output
- Added `connoinherit` to constraint queries, `NoInherit` field to IR, and `NO INHERIT` output in diff/plan/rewrite code paths

Fixes #386

## Test plan
- [x] New test case: `testdata/diff/online/issue_386_check_no_inherit/` with `CHECK (false) NO INHERIT`
- [x] All online diff tests pass (`PGSCHEMA_TEST_FILTER="online/" go test -v ./internal/diff -run TestDiffFromFiles`)
- [x] All integration tests pass (`go test ./cmd -run TestPlanAndApply`)
- [x] All dump tests pass (`go test ./cmd/dump`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)