### PR TITLE
fix: plan fails with schema-qualified references in function bodies (#399)

### DIFF
--- a/internal/postgres/desired_state.go
+++ b/internal/postgres/desired_state.go
@@ -104,6 +104,11 @@ func stripSchemaQualifications(sql string, schemaName string) string {
 	// Schema qualifiers inside function/procedure bodies (dollar-quoted blocks)
 	// must be preserved — the user may need them when search_path doesn't include
 	// the function's schema (e.g., SET search_path = ''). (Issue #354)
+	//
+	// To avoid type-identity mismatches between stripped parameter types and
+	// unstripped body references (Issue #399), callers should disable function
+	// body validation with SET check_function_bodies = off before executing
+	// the resulting SQL.
 	segments := splitDollarQuotedSegments(sql)
 	var result strings.Builder
 	result.Grow(len(sql))

--- a/internal/postgres/embedded.go
+++ b/internal/postgres/embedded.go
@@ -220,6 +220,15 @@ func (ep *EmbeddedPostgres) ApplySchema(ctx context.Context, schema string, sql 
 		return fmt.Errorf("failed to set search_path: %w", err)
 	}
 
+	// Disable function body validation to avoid type-identity mismatches (issue #399).
+	// Schema qualifications inside dollar-quoted function bodies are preserved (issue #354),
+	// but parameter types are stripped. For SQL-language functions, PostgreSQL validates the
+	// body at creation time, which can fail when body references use the original schema's
+	// types while parameters reference the temporary schema's types.
+	if _, err := util.ExecContextWithLogging(ctx, conn, "SET check_function_bodies = off", "disable function body validation for desired state"); err != nil {
+		return fmt.Errorf("failed to disable check_function_bodies: %w", err)
+	}
+
 	// Strip schema qualifications from SQL before applying to temporary schema
 	// This ensures that objects are created in the temporary schema via search_path
 	// rather than being explicitly qualified with the original schema name

--- a/internal/postgres/external.go
+++ b/internal/postgres/external.go
@@ -131,6 +131,15 @@ func (ed *ExternalDatabase) ApplySchema(ctx context.Context, schema string, sql 
 		return fmt.Errorf("failed to set search_path: %w", err)
 	}
 
+	// Disable function body validation to avoid type-identity mismatches (issue #399).
+	// Schema qualifications inside dollar-quoted function bodies are preserved (issue #354),
+	// but parameter types are stripped. For SQL-language functions, PostgreSQL validates the
+	// body at creation time, which can fail when body references use the original schema's
+	// types while parameters reference the temporary schema's types.
+	if _, err := util.ExecContextWithLogging(ctx, conn, "SET check_function_bodies = off", "disable function body validation for desired state"); err != nil {
+		return fmt.Errorf("failed to disable check_function_bodies: %w", err)
+	}
+
 	// Strip schema qualifications from SQL before applying to temporary schema
 	// This ensures that objects are created in the temporary schema via search_path
 	// rather than being explicitly qualified with the original schema name

--- a/testdata/diff/create_function/issue_399_schema_qualified_body/diff.sql
+++ b/testdata/diff/create_function/issue_399_schema_qualified_body/diff.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE FUNCTION role_has_cap(
+    p_role role_type,
+    p_cap text
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM public.role_caps rc
+        WHERE rc.role = p_role
+          AND rc.capability = p_cap
+    );
+$$;

--- a/testdata/diff/create_function/issue_399_schema_qualified_body/new.sql
+++ b/testdata/diff/create_function/issue_399_schema_qualified_body/new.sql
@@ -1,0 +1,22 @@
+CREATE TYPE public.role_type AS ENUM ('OWNER', 'MEMBER');
+
+CREATE TABLE public.role_caps (
+    role public.role_type NOT NULL,
+    capability text NOT NULL,
+    PRIMARY KEY (role, capability)
+);
+
+CREATE OR REPLACE FUNCTION public.role_has_cap(
+    p_role public.role_type,
+    p_cap text
+) RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM public.role_caps rc
+        WHERE rc.role = p_role
+          AND rc.capability = p_cap
+    );
+$$;

--- a/testdata/diff/create_function/issue_399_schema_qualified_body/old.sql
+++ b/testdata/diff/create_function/issue_399_schema_qualified_body/old.sql
@@ -1,0 +1,7 @@
+CREATE TYPE role_type AS ENUM ('OWNER', 'MEMBER');
+
+CREATE TABLE role_caps (
+    role role_type NOT NULL,
+    capability text NOT NULL,
+    PRIMARY KEY (role, capability)
+);

--- a/testdata/diff/create_function/issue_399_schema_qualified_body/plan.json
+++ b/testdata/diff/create_function/issue_399_schema_qualified_body/plan.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.9.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "eb148b37b7b6325bdd5f0c1c120dfe0bd71a062ce69951aa946c452aff2dc662"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE OR REPLACE FUNCTION role_has_cap(\n    p_role role_type,\n    p_cap text\n)\nRETURNS boolean\nLANGUAGE sql\nSTABLE\nAS $$\n    SELECT EXISTS (\n        SELECT 1\n        FROM public.role_caps rc\n        WHERE rc.role = p_role\n          AND rc.capability = p_cap\n    );\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.role_has_cap"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_function/issue_399_schema_qualified_body/plan.sql
+++ b/testdata/diff/create_function/issue_399_schema_qualified_body/plan.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE FUNCTION role_has_cap(
+    p_role role_type,
+    p_cap text
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM public.role_caps rc
+        WHERE rc.role = p_role
+          AND rc.capability = p_cap
+    );
+$$;

--- a/testdata/diff/create_function/issue_399_schema_qualified_body/plan.txt
+++ b/testdata/diff/create_function/issue_399_schema_qualified_body/plan.txt
@@ -1,0 +1,26 @@
+Plan: 1 to add.
+
+Summary by type:
+  functions: 1 to add
+
+Functions:
+  + role_has_cap
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE OR REPLACE FUNCTION role_has_cap(
+    p_role role_type,
+    p_cap text
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM public.role_caps rc
+        WHERE rc.role = p_role
+          AND rc.capability = p_cap
+    );
+$$;


### PR DESCRIPTION
## Summary

- When a SQL-language function has schema-qualified references inside its `$$`-delimited body (e.g., `FROM public.role_caps`), `pgschema plan` fails with `operator does not exist` because parameter types are stripped to the temporary schema while body references still point to the original schema
- Fix: disable function body validation (`SET check_function_bodies = off`) when applying desired state SQL to temporary schemas during plan generation — the body is only needed for IR extraction, not execution
- This preserves the existing behavior of keeping dollar-quoted bodies intact (#354) while avoiding the type-identity mismatch

Fixes #399

## Test plan
- [x] Added test case `testdata/diff/create_function/issue_399_schema_qualified_body/` reproducing the bug
- [x] Verified test fails before fix, passes after
- [x] All existing tests pass including `issue_354_empty_search_path` (no regression)
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)