### PR TITLE
fix: name-typed columns dumped as char[]

### DIFF
--- a/cmd/dump/dump_integration_test.go
+++ b/cmd/dump/dump_integration_test.go
@@ -144,6 +144,45 @@ func TestDumpCommand_Issue191FunctionProcedureOverload(t *testing.T) {
 	runExactMatchTest(t, "issue_191_function_procedure_overload")
 }
 
+// Reproduces a bug where a column declared as `name` is dumped as `char[]`.
+// The inspector classifies any base type with pg_type.typelem <> 0 as an array,
+// but the `name` type has typelem = 18 (the OID of "char") despite not being an array.
+func TestDumpCommand_NameTypeNotDumpedAsCharArray(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	embeddedPG := testutil.SetupPostgres(t)
+	defer embeddedPG.Stop()
+
+	conn, host, port, dbname, user, password := testutil.ConnectToPostgres(t, embeddedPG)
+	defer conn.Close()
+
+	_, err := conn.ExecContext(context.Background(), `CREATE TABLE pgschema_name_repro (n name);`)
+	if err != nil {
+		t.Fatalf("Failed to create table: %v", err)
+	}
+
+	output, err := ExecuteDump(&DumpConfig{
+		Host:     host,
+		Port:     port,
+		DB:       dbname,
+		User:     user,
+		Password: password,
+		Schema:   "public",
+	})
+	if err != nil {
+		t.Fatalf("Dump command failed: %v", err)
+	}
+
+	if strings.Contains(output, "char[]") {
+		t.Errorf("Dump output should not contain char[] for a name column.\nOutput:\n%s", output)
+	}
+	if !strings.Contains(output, "n name") {
+		t.Errorf("Dump output should contain `n name` column declaration.\nOutput:\n%s", output)
+	}
+}
+
 func TestDumpCommand_Issue318CrossSchemaComment(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -492,7 +492,7 @@ func (i *Inspector) buildConstraints(ctx context.Context, schema *IR, targetSche
 				Type:       cType,
 				Columns:    []*ConstraintColumn{},
 				NoInherit:  constraint.NoInherit,
-				IsTemporal: constraint.IsPeriod, // PG18 temporal constraint (WITHOUT OVERLAPS / PERIOD)
+				IsTemporal: constraint.IsPeriod.Bool, // PG18 temporal constraint (WITHOUT OVERLAPS / PERIOD)
 			}
 
 			// Handle foreign key references

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -79,8 +79,10 @@ WITH column_base AS (
                 CASE WHEN dn.nspname = c.table_schema THEN dt.typname
                      ELSE dn.nspname || '.' || dt.typname
                 END
-            WHEN dt.typtype = 'b' AND dt.typelem <> 0 THEN
+            WHEN dt.typtype = 'b' AND dt.typcategory = 'A' THEN
                 -- Array types: apply same schema qualification logic to element type
+                -- Use typcategory = 'A' rather than typelem <> 0; the latter is true
+                -- for non-array fixed-length types like name (typelem points to char).
                 CASE
                     WHEN en.nspname = 'pg_catalog' THEN et.typname || '[]'
                     WHEN en.nspname = c.table_schema THEN et.typname || '[]'
@@ -195,8 +197,10 @@ WITH column_base AS (
                 CASE WHEN dn.nspname = c.table_schema THEN dt.typname
                      ELSE dn.nspname || '.' || dt.typname
                 END
-            WHEN dt.typtype = 'b' AND dt.typelem <> 0 THEN
+            WHEN dt.typtype = 'b' AND dt.typcategory = 'A' THEN
                 -- Array types: apply same schema qualification logic to element type
+                -- Use typcategory = 'A' rather than typelem <> 0; the latter is true
+                -- for non-array fixed-length types like name (typelem points to char).
                 CASE
                     WHEN en.nspname = 'pg_catalog' THEN et.typname || '[]'
                     WHEN en.nspname = c.table_schema THEN et.typname || '[]'

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -278,8 +278,10 @@ WITH column_base AS (
                 CASE WHEN dn.nspname = c.table_schema THEN dt.typname
                      ELSE dn.nspname || '.' || dt.typname
                 END
-            WHEN dt.typtype = 'b' AND dt.typelem <> 0 THEN
+            WHEN dt.typtype = 'b' AND dt.typcategory = 'A' THEN
                 -- Array types: apply same schema qualification logic to element type
+                -- Use typcategory = 'A' rather than typelem <> 0; the latter is true
+                -- for non-array fixed-length types like name (typelem points to char).
                 CASE
                     WHEN en.nspname = 'pg_catalog' THEN et.typname || '[]'
                     WHEN en.nspname = c.table_schema THEN et.typname || '[]'
@@ -466,8 +468,10 @@ WITH column_base AS (
                 CASE WHEN dn.nspname = c.table_schema THEN dt.typname
                      ELSE dn.nspname || '.' || dt.typname
                 END
-            WHEN dt.typtype = 'b' AND dt.typelem <> 0 THEN
+            WHEN dt.typtype = 'b' AND dt.typcategory = 'A' THEN
                 -- Array types: apply same schema qualification logic to element type
+                -- Use typcategory = 'A' rather than typelem <> 0; the latter is true
+                -- for non-array fixed-length types like name (typelem points to char).
                 CASE
                     WHEN en.nspname = 'pg_catalog' THEN et.typname || '[]'
                     WHEN en.nspname = c.table_schema THEN et.typname || '[]'

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -830,7 +830,7 @@ type GetConstraintsRow struct {
 	Deferrable             bool           `db:"deferrable" json:"deferrable"`
 	InitiallyDeferred      bool           `db:"initially_deferred" json:"initially_deferred"`
 	IsValid                bool           `db:"is_valid" json:"is_valid"`
-	IsPeriod               bool           `db:"is_period" json:"is_period"`
+	IsPeriod               sql.NullBool   `db:"is_period" json:"is_period"`
 	NoInherit              bool           `db:"no_inherit" json:"no_inherit"`
 }
 
@@ -949,7 +949,7 @@ type GetConstraintsForSchemaRow struct {
 	Deferrable             bool           `db:"deferrable" json:"deferrable"`
 	InitiallyDeferred      bool           `db:"initially_deferred" json:"initially_deferred"`
 	IsValid                bool           `db:"is_valid" json:"is_valid"`
-	IsPeriod               bool           `db:"is_period" json:"is_period"`
+	IsPeriod               sql.NullBool   `db:"is_period" json:"is_period"`
 	NoInherit              bool           `db:"no_inherit" json:"no_inherit"`
 }
 
@@ -1372,6 +1372,65 @@ func (q *Queries) GetEnumValuesForSchema(ctx context.Context, dollar_1 sql.NullS
 			&i.TypeName,
 			&i.EnumValue,
 			&i.EnumOrder,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getFunctionDependencies = `-- name: GetFunctionDependencies :many
+SELECT
+    dependent_ns.nspname AS dependent_schema,
+    dependent_proc.proname AS dependent_name,
+    pg_get_function_identity_arguments(dependent_proc.oid) AS dependent_args,
+    referenced_ns.nspname AS referenced_schema,
+    referenced_proc.proname AS referenced_name,
+    pg_get_function_identity_arguments(referenced_proc.oid) AS referenced_args
+FROM pg_depend d
+JOIN pg_proc dependent_proc ON d.objid = dependent_proc.oid
+JOIN pg_namespace dependent_ns ON dependent_proc.pronamespace = dependent_ns.oid
+JOIN pg_proc referenced_proc ON d.refobjid = referenced_proc.oid
+JOIN pg_namespace referenced_ns ON referenced_proc.pronamespace = referenced_ns.oid
+WHERE d.classid = 'pg_proc'::regclass
+  AND d.refclassid = 'pg_proc'::regclass
+  AND d.deptype = 'n'
+  AND dependent_ns.nspname = $1
+`
+
+type GetFunctionDependenciesRow struct {
+	DependentSchema  string         `db:"dependent_schema" json:"dependent_schema"`
+	DependentName    string         `db:"dependent_name" json:"dependent_name"`
+	DependentArgs    sql.NullString `db:"dependent_args" json:"dependent_args"`
+	ReferencedSchema string         `db:"referenced_schema" json:"referenced_schema"`
+	ReferencedName   string         `db:"referenced_name" json:"referenced_name"`
+	ReferencedArgs   sql.NullString `db:"referenced_args" json:"referenced_args"`
+}
+
+// GetFunctionDependencies retrieves function-to-function dependencies for topological sorting
+func (q *Queries) GetFunctionDependencies(ctx context.Context, dollar_1 sql.NullString) ([]GetFunctionDependenciesRow, error) {
+	rows, err := q.db.QueryContext(ctx, getFunctionDependencies, dollar_1)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetFunctionDependenciesRow
+	for rows.Next() {
+		var i GetFunctionDependenciesRow
+		if err := rows.Scan(
+			&i.DependentSchema,
+			&i.DependentName,
+			&i.DependentArgs,
+			&i.ReferencedSchema,
+			&i.ReferencedName,
+			&i.ReferencedArgs,
 		); err != nil {
 			return nil, err
 		}
@@ -2783,7 +2842,7 @@ func (q *Queries) GetTables(ctx context.Context) ([]GetTablesRow, error) {
 }
 
 const getTablesForSchema = `-- name: GetTablesForSchema :many
-SELECT 
+SELECT
     t.table_schema,
     t.table_name,
     t.table_type,
@@ -3270,65 +3329,6 @@ func (q *Queries) GetViewsForSchema(ctx context.Context, dollar_1 sql.NullString
 			&i.ViewComment,
 			&i.IsMaterialized,
 			pq.Array(&i.Reloptions),
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const getFunctionDependencies = `-- name: GetFunctionDependencies :many
-SELECT
-    dependent_ns.nspname AS dependent_schema,
-    dependent_proc.proname AS dependent_name,
-    pg_get_function_identity_arguments(dependent_proc.oid) AS dependent_args,
-    referenced_ns.nspname AS referenced_schema,
-    referenced_proc.proname AS referenced_name,
-    pg_get_function_identity_arguments(referenced_proc.oid) AS referenced_args
-FROM pg_depend d
-JOIN pg_proc dependent_proc ON d.objid = dependent_proc.oid
-JOIN pg_namespace dependent_ns ON dependent_proc.pronamespace = dependent_ns.oid
-JOIN pg_proc referenced_proc ON d.refobjid = referenced_proc.oid
-JOIN pg_namespace referenced_ns ON referenced_proc.pronamespace = referenced_ns.oid
-WHERE d.classid = 'pg_proc'::regclass
-  AND d.refclassid = 'pg_proc'::regclass
-  AND d.deptype = 'n'
-  AND dependent_ns.nspname = $1
-`
-
-type GetFunctionDependenciesRow struct {
-	DependentSchema  string         `db:"dependent_schema" json:"dependent_schema"`
-	DependentName    string         `db:"dependent_name" json:"dependent_name"`
-	DependentArgs    sql.NullString `db:"dependent_args" json:"dependent_args"`
-	ReferencedSchema string         `db:"referenced_schema" json:"referenced_schema"`
-	ReferencedName   string         `db:"referenced_name" json:"referenced_name"`
-	ReferencedArgs   sql.NullString `db:"referenced_args" json:"referenced_args"`
-}
-
-// GetFunctionDependencies retrieves function-to-function dependencies for topological sorting
-func (q *Queries) GetFunctionDependencies(ctx context.Context, dollar_1 sql.NullString) ([]GetFunctionDependenciesRow, error) {
-	rows, err := q.db.QueryContext(ctx, getFunctionDependencies, dollar_1)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []GetFunctionDependenciesRow
-	for rows.Next() {
-		var i GetFunctionDependenciesRow
-		if err := rows.Scan(
-			&i.DependentSchema,
-			&i.DependentName,
-			&i.DependentArgs,
-			&i.ReferencedSchema,
-			&i.ReferencedName,
-			&i.ReferencedArgs,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Columns declared as `name` are incorrectly dumped as `char[]` because the inspector classifies any base type with `pg_type.typelem <> 0` as an array. This changes it to use `typcategory = 'A'` instead which is a more narrow type check ([docs](https://www.postgresql.org/docs/current/catalog-pg-type.html#CATALOG-TYPCATEGORY-TABLE)).

Fixes #410 

Running sqlc locally for me seems to have a slightly different output, I suspect this is because previous edits to the file have been done by LLMs rather than by running sqlc itself? I kept that output in a separate commit for clarity.