### PR TITLE
fix: preserve schema-qualified functions in RLS policy expressions (#427)

### DIFF
--- a/ir/normalize_test.go
+++ b/ir/normalize_test.go
@@ -378,6 +378,24 @@ func TestNormalizePolicyExpression(t *testing.T) {
 			tableSchema: "public",
 			expected:    "(id IN ( SELECT unnest(get_user_assigned_projects()) AS unnest))",
 		},
+		{
+			name:        "cross-schema function call preserved (Issue #427)",
+			expr:        "(owner_id = ( SELECT auth.uid() AS uid))",
+			tableSchema: "public",
+			expected:    "(owner_id = ( SELECT auth.uid() AS uid))",
+		},
+		{
+			name:        "cross-schema auth.role() preserved (Issue #427)",
+			expr:        "(auth.role() = 'authenticated'::text)",
+			tableSchema: "public",
+			expected:    "(auth.role() = 'authenticated')",
+		},
+		{
+			name:        "multiple cross-schema functions preserved (Issue #427)",
+			expr:        "(owner_id = auth.uid() AND auth.role() = 'admin'::text)",
+			tableSchema: "pgschema_poc",
+			expected:    "(owner_id = auth.uid() AND auth.role() = 'admin')",
+		},
 	}
 
 	for _, tt := range tests {

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -762,22 +762,65 @@ WHERE
 ORDER BY n.nspname, c.relname;
 
 -- GetRLSPolicies retrieves all row level security policies
+-- IMPORTANT: Uses LATERAL join with set_config to temporarily set search_path to empty.
+-- This ensures pg_get_expr() includes schema qualifiers for function calls in policy
+-- expressions (e.g., auth.uid() instead of uid()), matching pg_dump's behavior and
+-- preventing failures when applying policies in environments with different search_path. (Issue #427)
 -- name: GetRLSPolicies :many
-SELECT 
-    schemaname,
-    tablename,
-    policyname,
-    permissive,
-    roles,
-    cmd,
-    qual,
-    with_check
-FROM pg_policies
-WHERE 
-    schemaname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
-    AND schemaname NOT LIKE 'pg_temp_%'
-    AND schemaname NOT LIKE 'pg_toast_temp_%'
-ORDER BY schemaname, tablename, policyname;
+WITH policy_base AS (
+    SELECT
+        N.nspname AS schemaname,
+        C.relname AS tablename,
+        pol.polname AS policyname,
+        CASE
+            WHEN pol.polpermissive THEN 'PERMISSIVE'
+            ELSE 'RESTRICTIVE'
+        END AS permissive,
+        CASE
+            WHEN pol.polroles = '{0}' THEN
+                string_to_array('public', '')
+            ELSE
+                ARRAY(
+                    SELECT rolname
+                    FROM pg_catalog.pg_authid
+                    WHERE oid = ANY(pol.polroles) ORDER BY 1
+                )
+        END AS roles,
+        CASE pol.polcmd
+            WHEN 'r' THEN 'SELECT'
+            WHEN 'a' THEN 'INSERT'
+            WHEN 'w' THEN 'UPDATE'
+            WHEN 'd' THEN 'DELETE'
+            WHEN '*' THEN 'ALL'
+        END AS cmd,
+        pol.polqual,
+        pol.polwithcheck,
+        pol.polrelid
+    FROM pg_catalog.pg_policy pol
+    JOIN pg_catalog.pg_class C ON (C.oid = pol.polrelid)
+    LEFT JOIN pg_catalog.pg_namespace N ON (N.oid = C.relnamespace)
+    WHERE
+        N.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
+        AND N.nspname NOT LIKE 'pg_temp_%'
+        AND N.nspname NOT LIKE 'pg_toast_temp_%'
+)
+SELECT
+    pb.schemaname,
+    pb.tablename,
+    pb.policyname,
+    pb.permissive,
+    pb.roles,
+    pb.cmd,
+    sp.qual,
+    sp.with_check
+FROM policy_base pb
+CROSS JOIN LATERAL (
+    SELECT
+        set_config('search_path', '', true) as dummy,
+        pg_catalog.pg_get_expr(pb.polqual, pb.polrelid) AS qual,
+        pg_catalog.pg_get_expr(pb.polwithcheck, pb.polrelid) AS with_check
+) sp
+ORDER BY pb.schemaname, pb.tablename, pb.policyname;
 
 -- GetRLSTablesForSchema retrieves tables with row level security enabled for a specific schema
 -- name: GetRLSTablesForSchema :many
@@ -795,20 +838,63 @@ WHERE
 ORDER BY n.nspname, c.relname;
 
 -- GetRLSPoliciesForSchema retrieves all row level security policies for a specific schema
+-- IMPORTANT: Uses LATERAL join with set_config to temporarily set search_path to empty.
+-- This ensures pg_get_expr() includes schema qualifiers for function calls in policy
+-- expressions (e.g., auth.uid() instead of uid()), matching pg_dump's behavior and
+-- preventing failures when applying policies in environments with different search_path. (Issue #427)
 -- name: GetRLSPoliciesForSchema :many
-SELECT 
-    schemaname,
-    tablename,
-    policyname,
-    permissive,
-    roles,
-    cmd,
-    qual,
-    with_check
-FROM pg_policies
-WHERE 
-    schemaname = $1
-ORDER BY schemaname, tablename, policyname;
+WITH policy_base AS (
+    SELECT
+        N.nspname AS schemaname,
+        C.relname AS tablename,
+        pol.polname AS policyname,
+        CASE
+            WHEN pol.polpermissive THEN 'PERMISSIVE'
+            ELSE 'RESTRICTIVE'
+        END AS permissive,
+        CASE
+            WHEN pol.polroles = '{0}' THEN
+                string_to_array('public', '')
+            ELSE
+                ARRAY(
+                    SELECT rolname
+                    FROM pg_catalog.pg_authid
+                    WHERE oid = ANY(pol.polroles) ORDER BY 1
+                )
+        END AS roles,
+        CASE pol.polcmd
+            WHEN 'r' THEN 'SELECT'
+            WHEN 'a' THEN 'INSERT'
+            WHEN 'w' THEN 'UPDATE'
+            WHEN 'd' THEN 'DELETE'
+            WHEN '*' THEN 'ALL'
+        END AS cmd,
+        pol.polqual,
+        pol.polwithcheck,
+        pol.polrelid
+    FROM pg_catalog.pg_policy pol
+    JOIN pg_catalog.pg_class C ON (C.oid = pol.polrelid)
+    LEFT JOIN pg_catalog.pg_namespace N ON (N.oid = C.relnamespace)
+    WHERE
+        N.nspname = $1
+)
+SELECT
+    pb.schemaname,
+    pb.tablename,
+    pb.policyname,
+    pb.permissive,
+    pb.roles,
+    pb.cmd,
+    sp.qual,
+    sp.with_check
+FROM policy_base pb
+CROSS JOIN LATERAL (
+    SELECT
+        set_config('search_path', '', true) as dummy,
+        pg_catalog.pg_get_expr(pb.polqual, pb.polrelid) AS qual,
+        pg_catalog.pg_get_expr(pb.polwithcheck, pb.polrelid) AS with_check
+) sp
+ORDER BY pb.schemaname, pb.tablename, pb.policyname;
 
 -- GetDomains retrieves all user-defined domains
 -- name: GetDomains :many

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -2286,21 +2286,60 @@ func (q *Queries) GetProceduresForSchema(ctx context.Context, dollar_1 sql.NullS
 }
 
 const getRLSPolicies = `-- name: GetRLSPolicies :many
-SELECT 
-    schemaname,
-    tablename,
-    policyname,
-    permissive,
-    roles,
-    cmd,
-    qual,
-    with_check
-FROM pg_policies
-WHERE 
-    schemaname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
-    AND schemaname NOT LIKE 'pg_temp_%'
-    AND schemaname NOT LIKE 'pg_toast_temp_%'
-ORDER BY schemaname, tablename, policyname
+WITH policy_base AS (
+    SELECT
+        N.nspname AS schemaname,
+        C.relname AS tablename,
+        pol.polname AS policyname,
+        CASE
+            WHEN pol.polpermissive THEN 'PERMISSIVE'
+            ELSE 'RESTRICTIVE'
+        END AS permissive,
+        CASE
+            WHEN pol.polroles = '{0}' THEN
+                string_to_array('public', '')
+            ELSE
+                ARRAY(
+                    SELECT rolname
+                    FROM pg_catalog.pg_authid
+                    WHERE oid = ANY(pol.polroles) ORDER BY 1
+                )
+        END AS roles,
+        CASE pol.polcmd
+            WHEN 'r' THEN 'SELECT'
+            WHEN 'a' THEN 'INSERT'
+            WHEN 'w' THEN 'UPDATE'
+            WHEN 'd' THEN 'DELETE'
+            WHEN '*' THEN 'ALL'
+        END AS cmd,
+        pol.polqual,
+        pol.polwithcheck,
+        pol.polrelid
+    FROM pg_catalog.pg_policy pol
+    JOIN pg_catalog.pg_class C ON (C.oid = pol.polrelid)
+    LEFT JOIN pg_catalog.pg_namespace N ON (N.oid = C.relnamespace)
+    WHERE
+        N.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
+        AND N.nspname NOT LIKE 'pg_temp_%'
+        AND N.nspname NOT LIKE 'pg_toast_temp_%'
+)
+SELECT
+    pb.schemaname,
+    pb.tablename,
+    pb.policyname,
+    pb.permissive,
+    pb.roles,
+    pb.cmd,
+    sp.qual,
+    sp.with_check
+FROM policy_base pb
+CROSS JOIN LATERAL (
+    SELECT
+        set_config('search_path', '', true) as dummy,
+        pg_catalog.pg_get_expr(pb.polqual, pb.polrelid) AS qual,
+        pg_catalog.pg_get_expr(pb.polwithcheck, pb.polrelid) AS with_check
+) sp
+ORDER BY pb.schemaname, pb.tablename, pb.policyname
 `
 
 type GetRLSPoliciesRow struct {
@@ -2348,19 +2387,58 @@ func (q *Queries) GetRLSPolicies(ctx context.Context) ([]GetRLSPoliciesRow, erro
 }
 
 const getRLSPoliciesForSchema = `-- name: GetRLSPoliciesForSchema :many
-SELECT 
-    schemaname,
-    tablename,
-    policyname,
-    permissive,
-    roles,
-    cmd,
-    qual,
-    with_check
-FROM pg_policies
-WHERE 
-    schemaname = $1
-ORDER BY schemaname, tablename, policyname
+WITH policy_base AS (
+    SELECT
+        N.nspname AS schemaname,
+        C.relname AS tablename,
+        pol.polname AS policyname,
+        CASE
+            WHEN pol.polpermissive THEN 'PERMISSIVE'
+            ELSE 'RESTRICTIVE'
+        END AS permissive,
+        CASE
+            WHEN pol.polroles = '{0}' THEN
+                string_to_array('public', '')
+            ELSE
+                ARRAY(
+                    SELECT rolname
+                    FROM pg_catalog.pg_authid
+                    WHERE oid = ANY(pol.polroles) ORDER BY 1
+                )
+        END AS roles,
+        CASE pol.polcmd
+            WHEN 'r' THEN 'SELECT'
+            WHEN 'a' THEN 'INSERT'
+            WHEN 'w' THEN 'UPDATE'
+            WHEN 'd' THEN 'DELETE'
+            WHEN '*' THEN 'ALL'
+        END AS cmd,
+        pol.polqual,
+        pol.polwithcheck,
+        pol.polrelid
+    FROM pg_catalog.pg_policy pol
+    JOIN pg_catalog.pg_class C ON (C.oid = pol.polrelid)
+    LEFT JOIN pg_catalog.pg_namespace N ON (N.oid = C.relnamespace)
+    WHERE
+        N.nspname = $1
+)
+SELECT
+    pb.schemaname,
+    pb.tablename,
+    pb.policyname,
+    pb.permissive,
+    pb.roles,
+    pb.cmd,
+    sp.qual,
+    sp.with_check
+FROM policy_base pb
+CROSS JOIN LATERAL (
+    SELECT
+        set_config('search_path', '', true) as dummy,
+        pg_catalog.pg_get_expr(pb.polqual, pb.polrelid) AS qual,
+        pg_catalog.pg_get_expr(pb.polwithcheck, pb.polrelid) AS with_check
+) sp
+ORDER BY pb.schemaname, pb.tablename, pb.policyname
 `
 
 type GetRLSPoliciesForSchemaRow struct {

--- a/testdata/diff/create_policy/issue_427_cross_schema_function_in_policy/diff.sql
+++ b/testdata/diff/create_policy/issue_427_cross_schema_function_in_policy/diff.sql
@@ -1,0 +1,2 @@
+CREATE POLICY admin_all_items ON items TO authenticated USING (auth.role() = 'admin');
+CREATE POLICY select_own_items ON items FOR SELECT TO authenticated USING (owner_id = ( SELECT auth.uid() AS uid));

--- a/testdata/diff/create_policy/issue_427_cross_schema_function_in_policy/new.sql
+++ b/testdata/diff/create_policy/issue_427_cross_schema_function_in_policy/new.sql
@@ -1,0 +1,21 @@
+CREATE TABLE items (
+    id BIGSERIAL PRIMARY KEY,
+    owner_id uuid NOT NULL,
+    name text NOT NULL
+);
+
+ALTER TABLE items ENABLE ROW LEVEL SECURITY;
+
+-- Policy using auth.uid()
+CREATE POLICY select_own_items
+ON items
+FOR SELECT
+TO authenticated
+USING (owner_id = (SELECT auth.uid()));
+
+-- Policy using auth.role()
+CREATE POLICY admin_all_items
+ON items
+FOR ALL
+TO authenticated
+USING (auth.role() = 'admin');

--- a/testdata/diff/create_policy/issue_427_cross_schema_function_in_policy/old.sql
+++ b/testdata/diff/create_policy/issue_427_cross_schema_function_in_policy/old.sql
@@ -1,0 +1,7 @@
+CREATE TABLE items (
+    id BIGSERIAL PRIMARY KEY,
+    owner_id uuid NOT NULL,
+    name text NOT NULL
+);
+
+ALTER TABLE items ENABLE ROW LEVEL SECURITY;

--- a/testdata/diff/create_policy/issue_427_cross_schema_function_in_policy/plan.json
+++ b/testdata/diff/create_policy/issue_427_cross_schema_function_in_policy/plan.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.9.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "e39e4e9411faeeb94cd2dfc1f6a2da48b6ff924528de3955abfd15f97b39ab62"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE POLICY admin_all_items ON items TO authenticated USING (auth.role() = 'admin');",
+          "type": "table.policy",
+          "operation": "create",
+          "path": "public.items.admin_all_items"
+        },
+        {
+          "sql": "CREATE POLICY select_own_items ON items FOR SELECT TO authenticated USING (owner_id = ( SELECT auth.uid() AS uid));",
+          "type": "table.policy",
+          "operation": "create",
+          "path": "public.items.select_own_items"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_policy/issue_427_cross_schema_function_in_policy/plan.sql
+++ b/testdata/diff/create_policy/issue_427_cross_schema_function_in_policy/plan.sql
@@ -1,0 +1,3 @@
+CREATE POLICY admin_all_items ON items TO authenticated USING (auth.role() = 'admin');
+
+CREATE POLICY select_own_items ON items FOR SELECT TO authenticated USING (owner_id = ( SELECT auth.uid() AS uid));

--- a/testdata/diff/create_policy/issue_427_cross_schema_function_in_policy/plan.txt
+++ b/testdata/diff/create_policy/issue_427_cross_schema_function_in_policy/plan.txt
@@ -1,0 +1,16 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ items
+    + admin_all_items (policy)
+    + select_own_items (policy)
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE POLICY admin_all_items ON items TO authenticated USING (auth.role() = 'admin');
+
+CREATE POLICY select_own_items ON items FOR SELECT TO authenticated USING (owner_id = ( SELECT auth.uid() AS uid));

--- a/testdata/diff/create_policy/issue_427_cross_schema_function_in_policy/setup.sql
+++ b/testdata/diff/create_policy/issue_427_cross_schema_function_in_policy/setup.sql
@@ -1,0 +1,30 @@
+-- Setup: Simulate Supabase auth schema with auth.uid() and auth.role()
+-- This reproduces GitHub Issue #427 where cross-schema function references
+-- in RLS policy expressions lose their schema qualification.
+--
+-- When search_path includes the auth schema, pg_get_expr() omits the
+-- "auth." prefix from function calls, resulting in broken expressions
+-- like "uid()" instead of "auth.uid()".
+
+-- Create auth schema (simulating Supabase)
+DROP SCHEMA IF EXISTS auth CASCADE;
+CREATE SCHEMA auth;
+
+-- Create auth.uid() function (simulating Supabase)
+CREATE FUNCTION auth.uid() RETURNS uuid
+    LANGUAGE sql STABLE
+    AS $$ SELECT '00000000-0000-0000-0000-000000000000'::uuid; $$;
+
+-- Create auth.role() function (simulating Supabase)
+CREATE FUNCTION auth.role() RETURNS text
+    LANGUAGE sql STABLE
+    AS $$ SELECT 'authenticated'::text; $$;
+
+-- Create authenticated role (simulating Supabase)
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+        CREATE ROLE authenticated;
+    END IF;
+END
+$$;


### PR DESCRIPTION
This PR fixes #427 by ensuring RLS policy expressions retain their schema qualifiers. It aligns the RLS policy inspection with the existing pattern used for columns and indexes. Included unit and integration tests.