### PR TITLE
feat: add constraints in .pgschemaignore

### DIFF
--- a/cmd/util/ignoreloader.go
+++ b/cmd/util/ignoreloader.go
@@ -81,8 +81,8 @@ type DefaultPrivilegeIgnoreConfig struct {
 	Patterns []string `toml:"patterns,omitempty"`
 }
 
-// ConstraintsIgnoreConfig represents default privilege-specific ignore configuration
-// Patterns match on grantee role names
+// ConstraintsIgnoreConfig represents constraint-specific ignore configuration
+// Patterns match constraint names, including optionally qualified names
 type ConstraintsIgnoreConfig struct {
 	Patterns []string `toml:"patterns,omitempty"`
 }

--- a/cmd/util/ignoreloader.go
+++ b/cmd/util/ignoreloader.go
@@ -37,6 +37,7 @@ type TomlConfig struct {
 	Privileges        PrivilegeIgnoreConfig        `toml:"privileges,omitempty"`
 	DefaultPrivileges DefaultPrivilegeIgnoreConfig `toml:"default_privileges,omitempty"`
 	Constraints       ConstraintIgnoreConfig       `toml:"constraints,omitempty"`
+	ConstraintsFK     ConstraintFKIgnoreConfig     `toml:"constraints_fk,omitempty"`
 }
 
 // TableIgnoreConfig represents table-specific ignore configuration
@@ -87,6 +88,12 @@ type ConstraintIgnoreConfig struct {
 	Patterns []string `toml:"patterns,omitempty"`
 }
 
+// ConstraintFKIgnoreConfig represents foreign key constraint-specific ignore configuration
+// Patterns match constraint names, including optionally qualified names
+type ConstraintFKIgnoreConfig struct {
+	Patterns []string `toml:"patterns,omitempty"`
+}
+
 // LoadIgnoreFileWithStructure loads the .pgschemaignore file using the structured TOML format
 // and converts it to the simple IgnoreConfig structure
 func LoadIgnoreFileWithStructure() (*ir.IgnoreConfig, error) {
@@ -121,6 +128,7 @@ func LoadIgnoreFileWithStructureFromPath(filePath string) (*ir.IgnoreConfig, err
 		Privileges:        tomlConfig.Privileges.Patterns,
 		DefaultPrivileges: tomlConfig.DefaultPrivileges.Patterns,
 		Constraints:       tomlConfig.Constraints.Patterns,
+		ConstraintsFK:     tomlConfig.ConstraintsFK.Patterns,
 	}
 
 	return config, nil

--- a/cmd/util/ignoreloader.go
+++ b/cmd/util/ignoreloader.go
@@ -36,7 +36,7 @@ type TomlConfig struct {
 	Sequences         SequenceIgnoreConfig         `toml:"sequences,omitempty"`
 	Privileges        PrivilegeIgnoreConfig        `toml:"privileges,omitempty"`
 	DefaultPrivileges DefaultPrivilegeIgnoreConfig `toml:"default_privileges,omitempty"`
-	Constraints       ConstraintsIgnoreConfig      `toml:"constraints,omitempty"`
+	Constraints       ConstraintIgnoreConfig       `toml:"constraints,omitempty"`
 }
 
 // TableIgnoreConfig represents table-specific ignore configuration
@@ -81,9 +81,9 @@ type DefaultPrivilegeIgnoreConfig struct {
 	Patterns []string `toml:"patterns,omitempty"`
 }
 
-// ConstraintsIgnoreConfig represents constraint-specific ignore configuration
+// ConstraintIgnoreConfig represents constraint-specific ignore configuration
 // Patterns match constraint names, including optionally qualified names
-type ConstraintsIgnoreConfig struct {
+type ConstraintIgnoreConfig struct {
 	Patterns []string `toml:"patterns,omitempty"`
 }
 

--- a/cmd/util/ignoreloader.go
+++ b/cmd/util/ignoreloader.go
@@ -36,6 +36,7 @@ type TomlConfig struct {
 	Sequences         SequenceIgnoreConfig         `toml:"sequences,omitempty"`
 	Privileges        PrivilegeIgnoreConfig        `toml:"privileges,omitempty"`
 	DefaultPrivileges DefaultPrivilegeIgnoreConfig `toml:"default_privileges,omitempty"`
+	Constraints       ConstraintsIgnoreConfig      `toml:"constraints,omitempty"`
 }
 
 // TableIgnoreConfig represents table-specific ignore configuration
@@ -80,6 +81,12 @@ type DefaultPrivilegeIgnoreConfig struct {
 	Patterns []string `toml:"patterns,omitempty"`
 }
 
+// ConstraintsIgnoreConfig represents default privilege-specific ignore configuration
+// Patterns match on grantee role names
+type ConstraintsIgnoreConfig struct {
+	Patterns []string `toml:"patterns,omitempty"`
+}
+
 // LoadIgnoreFileWithStructure loads the .pgschemaignore file using the structured TOML format
 // and converts it to the simple IgnoreConfig structure
 func LoadIgnoreFileWithStructure() (*ir.IgnoreConfig, error) {
@@ -113,6 +120,7 @@ func LoadIgnoreFileWithStructureFromPath(filePath string) (*ir.IgnoreConfig, err
 		Sequences:         tomlConfig.Sequences.Patterns,
 		Privileges:        tomlConfig.Privileges.Patterns,
 		DefaultPrivileges: tomlConfig.DefaultPrivileges.Patterns,
+		Constraints:       tomlConfig.Constraints.Patterns,
 	}
 
 	return config, nil

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -359,7 +359,7 @@ type viewDiff struct {
 	CommentChanged   bool
 	OldComment       string
 	NewComment       string
-	OptionsChanged   bool // View options (reloptions) changed
+	OptionsChanged   bool           // View options (reloptions) changed
 	AddedIndexes     []*ir.Index    // For materialized views
 	DroppedIndexes   []*ir.Index    // For materialized views
 	ModifiedIndexes  []*IndexDiff   // For materialized views

--- a/ir/ignore.go
+++ b/ir/ignore.go
@@ -24,6 +24,7 @@ type IgnoreConfig struct {
 	Sequences         []string `toml:"sequences,omitempty"`
 	Privileges        []string `toml:"privileges,omitempty"`
 	DefaultPrivileges []string `toml:"default_privileges,omitempty"`
+	Constraints       []string `toml:"constraints,omitempty"`
 }
 
 // ShouldIgnoreTable checks if a table should be ignored based on the patterns
@@ -112,6 +113,14 @@ func (c *IgnoreConfig) ShouldIgnoreDefaultPrivilege(grantee string) bool {
 		return false
 	}
 	return c.shouldIgnore(grantee, c.DefaultPrivileges)
+}
+
+// ShouldIgnoreConstraints checks if constraints should be ignored based on the patterns
+func (c *IgnoreConfig) ShouldIgnoreConstraints(constraintName string) bool {
+	if c == nil {
+		return false
+	}
+	return c.shouldIgnore(constraintName, c.Constraints)
 }
 
 // shouldIgnore checks if a name should be ignored based on the patterns

--- a/ir/ignore.go
+++ b/ir/ignore.go
@@ -25,6 +25,7 @@ type IgnoreConfig struct {
 	Privileges        []string `toml:"privileges,omitempty"`
 	DefaultPrivileges []string `toml:"default_privileges,omitempty"`
 	Constraints       []string `toml:"constraints,omitempty"`
+	ConstraintsFK     []string `toml:"constraints_fk,omitempty"`
 }
 
 // ShouldIgnoreTable checks if a table should be ignored based on the patterns
@@ -121,6 +122,14 @@ func (c *IgnoreConfig) ShouldIgnoreConstraint(constraintName string) bool {
 		return false
 	}
 	return c.shouldIgnore(constraintName, c.Constraints)
+}
+
+// ShouldIgnoreConstraintFK checks if a foreign key constraint should be ignored based on the patterns
+func (c *IgnoreConfig) ShouldIgnoreConstraintFK(constraintName string) bool {
+	if c == nil {
+		return false
+	}
+	return c.shouldIgnore(constraintName, c.ConstraintsFK)
 }
 
 // shouldIgnore checks if a name should be ignored based on the patterns

--- a/ir/ignore.go
+++ b/ir/ignore.go
@@ -115,8 +115,8 @@ func (c *IgnoreConfig) ShouldIgnoreDefaultPrivilege(grantee string) bool {
 	return c.shouldIgnore(grantee, c.DefaultPrivileges)
 }
 
-// ShouldIgnoreConstraints checks if constraints should be ignored based on the patterns
-func (c *IgnoreConfig) ShouldIgnoreConstraints(constraintName string) bool {
+// ShouldIgnoreConstraint checks if a constraint should be ignored based on the patterns
+func (c *IgnoreConfig) ShouldIgnoreConstraint(constraintName string) bool {
 	if c == nil {
 		return false
 	}

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -447,6 +447,11 @@ func (i *Inspector) buildConstraints(ctx context.Context, schema *IR, targetSche
 			constraintType = constraint.ConstraintType.String
 		}
 
+		// Check if constraint should be ignored
+		if i.ignoreConfig != nil && i.ignoreConfig.ShouldIgnoreConstraints(constraintName) {
+			continue
+		}
+
 		// Extract column name from sql.NullString
 		columnName := ""
 		if constraint.ColumnName.Valid {

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -448,7 +448,7 @@ func (i *Inspector) buildConstraints(ctx context.Context, schema *IR, targetSche
 		}
 
 		// Check if constraint should be ignored
-		if i.ignoreConfig != nil && i.ignoreConfig.ShouldIgnoreConstraints(constraintName) {
+		if i.ignoreConfig != nil && i.ignoreConfig.ShouldIgnoreConstraint(constraintName) {
 			continue
 		}
 

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -511,6 +511,18 @@ func (i *Inspector) buildConstraints(ctx context.Context, schema *IR, targetSche
 
 			// Handle foreign key references
 			if cType == ConstraintTypeForeignKey {
+				// Check if constraint should be ignored. Prefer a fully qualified
+				// identifier to avoid unintentionally ignoring same-named constraints
+				// on unrelated tables, while still supporting bare constraint-name
+				// matching for backwards compatibility.
+				if i.ignoreConfig != nil {
+					qualifiedConstraintName := fmt.Sprintf("%s.%s.%s", schemaName, tableName, constraintName)
+					if i.ignoreConfig.ShouldIgnoreConstraintFK(qualifiedConstraintName) ||
+						i.ignoreConfig.ShouldIgnoreConstraintFK(constraintName) {
+						continue
+					}
+				}
+
 				if refSchema := i.safeInterfaceToString(constraint.ForeignTableSchema); refSchema != "" && refSchema != "<nil>" {
 					c.ReferencedSchema = refSchema
 				}

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -447,9 +447,16 @@ func (i *Inspector) buildConstraints(ctx context.Context, schema *IR, targetSche
 			constraintType = constraint.ConstraintType.String
 		}
 
-		// Check if constraint should be ignored
-		if i.ignoreConfig != nil && i.ignoreConfig.ShouldIgnoreConstraint(constraintName) {
-			continue
+		// Check if constraint should be ignored. Prefer a fully qualified
+		// identifier to avoid unintentionally ignoring same-named constraints
+		// on unrelated tables, while still supporting bare constraint-name
+		// matching for backwards compatibility.
+		if i.ignoreConfig != nil {
+			qualifiedConstraintName := fmt.Sprintf("%s.%s.%s", schemaName, tableName, constraintName)
+			if i.ignoreConfig.ShouldIgnoreConstraint(qualifiedConstraintName) ||
+				i.ignoreConfig.ShouldIgnoreConstraint(constraintName) {
+				continue
+			}
 		}
 
 		// Extract column name from sql.NullString


### PR DESCRIPTION
This PR a scenario where the system is separated into large modules, each module has a separate schema, but there are foreign keys between these schemas, making it impossible to use pgschema for migrations.

Issue #429 