### PR TITLE
feat: Column Rename Detection

### DIFF
--- a/internal/diff/column.go
+++ b/internal/diff/column.go
@@ -138,6 +138,72 @@ func needsUsingClause(oldType, newType string) bool {
 	return false
 }
 
+// columnsMatchForRename checks if two columns are the same column with a different name.
+// Both position AND all properties (except name and comment) must match for a rename to be detected.
+func columnsMatchForRename(old, new *ir.Column, targetSchema string) bool {
+	// Names must differ (otherwise it's not a rename)
+	if old.Name == new.Name {
+		return false
+	}
+
+	// Position must match
+	if old.Position != new.Position {
+		return false
+	}
+
+	// Data type must match (normalize schema prefix)
+	oldType := stripSchemaPrefix(old.DataType, targetSchema)
+	newType := stripSchemaPrefix(new.DataType, targetSchema)
+	if oldType != newType {
+		return false
+	}
+
+	// Nullability must match
+	if old.IsNullable != new.IsNullable {
+		return false
+	}
+
+	// Default values must match
+	if (old.DefaultValue == nil) != (new.DefaultValue == nil) {
+		return false
+	}
+	if old.DefaultValue != nil && new.DefaultValue != nil && *old.DefaultValue != *new.DefaultValue {
+		return false
+	}
+
+	// Max length must match
+	if (old.MaxLength == nil) != (new.MaxLength == nil) {
+		return false
+	}
+	if old.MaxLength != nil && new.MaxLength != nil && *old.MaxLength != *new.MaxLength {
+		return false
+	}
+
+	// Identity must match
+	if (old.Identity == nil) != (new.Identity == nil) {
+		return false
+	}
+	if old.Identity != nil && new.Identity != nil {
+		if old.Identity.Generation != new.Identity.Generation {
+			return false
+		}
+	}
+
+	// Generated column must match
+	if old.IsGenerated != new.IsGenerated {
+		return false
+	}
+	if (old.GeneratedExpr == nil) != (new.GeneratedExpr == nil) {
+		return false
+	}
+	if old.GeneratedExpr != nil && new.GeneratedExpr != nil && *old.GeneratedExpr != *new.GeneratedExpr {
+		return false
+	}
+
+	// Comment changes are OK — rename still applies, comment change emitted separately
+	return true
+}
+
 // columnsEqual compares two columns for equality
 // targetSchema is used to normalize type names before comparison
 func columnsEqual(old, new *ir.Column, targetSchema string) bool {

--- a/internal/diff/column_test.go
+++ b/internal/diff/column_test.go
@@ -1,0 +1,84 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/pgplex/pgschema/ir"
+)
+
+func TestColumnsMatchForRename(t *testing.T) {
+	boolDefault := "false"
+
+	tests := []struct {
+		name     string
+		old      *ir.Column
+		new      *ir.Column
+		schema   string
+		expected bool
+	}{
+		{
+			name:     "same type and position, different name = match",
+			old:      &ir.Column{Name: "active", Position: 3, DataType: "boolean", IsNullable: false},
+			new:      &ir.Column{Name: "active_n", Position: 3, DataType: "boolean", IsNullable: false},
+			expected: true,
+		},
+		{
+			name:     "different type = no match",
+			old:      &ir.Column{Name: "active", Position: 3, DataType: "boolean", IsNullable: false},
+			new:      &ir.Column{Name: "active_n", Position: 3, DataType: "integer", IsNullable: false},
+			expected: false,
+		},
+		{
+			name:     "different position = no match",
+			old:      &ir.Column{Name: "active", Position: 3, DataType: "boolean", IsNullable: false},
+			new:      &ir.Column{Name: "active_n", Position: 4, DataType: "boolean", IsNullable: false},
+			expected: false,
+		},
+		{
+			name:     "different nullability = no match",
+			old:      &ir.Column{Name: "active", Position: 3, DataType: "boolean", IsNullable: false},
+			new:      &ir.Column{Name: "active_n", Position: 3, DataType: "boolean", IsNullable: true},
+			expected: false,
+		},
+		{
+			name:     "same name = no match (not a rename)",
+			old:      &ir.Column{Name: "active", Position: 3, DataType: "boolean", IsNullable: false},
+			new:      &ir.Column{Name: "active", Position: 3, DataType: "boolean", IsNullable: false},
+			expected: false,
+		},
+		{
+			name:     "with matching defaults = match",
+			old:      &ir.Column{Name: "old_col", Position: 2, DataType: "boolean", DefaultValue: &boolDefault},
+			new:      &ir.Column{Name: "new_col", Position: 2, DataType: "boolean", DefaultValue: &boolDefault},
+			expected: true,
+		},
+		{
+			name: "with matching identity = match",
+			old:  &ir.Column{Name: "old_id", Position: 1, DataType: "integer", Identity: &ir.Identity{Generation: "ALWAYS"}},
+			new:  &ir.Column{Name: "new_id", Position: 1, DataType: "integer", Identity: &ir.Identity{Generation: "ALWAYS"}},
+			expected: true,
+		},
+		{
+			name: "different identity generation = no match",
+			old:  &ir.Column{Name: "old_id", Position: 1, DataType: "integer", Identity: &ir.Identity{Generation: "ALWAYS"}},
+			new:  &ir.Column{Name: "new_id", Position: 1, DataType: "integer", Identity: &ir.Identity{Generation: "BY DEFAULT"}},
+			expected: false,
+		},
+		{
+			name:     "schema-qualified type normalized = match",
+			old:      &ir.Column{Name: "old_col", Position: 1, DataType: "public.my_type"},
+			new:      &ir.Column{Name: "new_col", Position: 1, DataType: "my_type"},
+			schema:   "public",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := columnsMatchForRename(tt.old, tt.new, tt.schema)
+			if result != tt.expected {
+				t.Errorf("columnsMatchForRename() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/diff/constraint.go
+++ b/internal/diff/constraint.go
@@ -223,3 +223,34 @@ func constraintsEqual(old, new *ir.Constraint) bool {
 
 	return true
 }
+
+// applyRenameMapToConstraint returns a shallow copy of the constraint with
+// column names updated according to the rename map. This is used to compare
+// constraints after column renames — PostgreSQL automatically updates constraint
+// column references when a column is renamed.
+func applyRenameMapToConstraint(c *ir.Constraint, renameMap map[string]string) *ir.Constraint {
+	needsUpdate := false
+	for _, col := range c.Columns {
+		if _, ok := renameMap[col.Name]; ok {
+			needsUpdate = true
+			break
+		}
+	}
+	if !needsUpdate {
+		return c
+	}
+
+	// Shallow copy the constraint and update column names
+	copy := *c
+	copy.Columns = make([]*ir.ConstraintColumn, len(c.Columns))
+	for i, col := range c.Columns {
+		if newName, ok := renameMap[col.Name]; ok {
+			colCopy := *col
+			colCopy.Name = newName
+			copy.Columns[i] = &colCopy
+		} else {
+			copy.Columns[i] = col
+		}
+	}
+	return &copy
+}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -25,6 +25,7 @@ const (
 	DiffTypeTableColumnComment
 	DiffTypeTableIndexComment
 	DiffTypeTablePersistence
+	DiffTypeTableColumnRename
 	DiffTypeView
 	DiffTypeViewTrigger
 	DiffTypeViewComment
@@ -69,6 +70,8 @@ func (d DiffType) String() string {
 		return "table.index.comment"
 	case DiffTypeTablePersistence:
 		return "table.persistence"
+	case DiffTypeTableColumnRename:
+		return "table.column_rename"
 	case DiffTypeView:
 		return "view"
 	case DiffTypeViewTrigger:
@@ -143,6 +146,8 @@ func (d *DiffType) UnmarshalJSON(data []byte) error {
 		*d = DiffTypeTableIndexComment
 	case "table.persistence":
 		*d = DiffTypeTablePersistence
+	case "table.column_rename":
+		*d = DiffTypeTableColumnRename
 	case "view":
 		*d = DiffTypeView
 	case "view.trigger":
@@ -375,6 +380,7 @@ type tableDiff struct {
 	AddedColumns        []*ir.Column
 	DroppedColumns      []*ir.Column
 	ModifiedColumns     []*ColumnDiff
+	RenamedColumns      []*ColumnRename
 	AddedConstraints    []*ir.Constraint
 	DroppedConstraints  []*ir.Constraint
 	ModifiedConstraints []*ConstraintDiff
@@ -396,6 +402,12 @@ type tableDiff struct {
 
 // ColumnDiff represents changes to a column
 type ColumnDiff struct {
+	Old *ir.Column
+	New *ir.Column
+}
+
+// ColumnRename represents a column that was renamed
+type ColumnRename struct {
 	Old *ir.Column
 	New *ir.Column
 }
@@ -1857,6 +1869,10 @@ func sortTableObjects(tables []*tableDiff) {
 		sort.Slice(tableDiff.ModifiedColumns, func(i, j int) bool {
 			return tableDiff.ModifiedColumns[i].New.Position < tableDiff.ModifiedColumns[j].New.Position
 		})
+
+		sort.Slice(tableDiff.RenamedColumns, func(i, j int) bool {
+			return tableDiff.RenamedColumns[i].Old.Position < tableDiff.RenamedColumns[j].Old.Position
+		})
 	}
 }
 
@@ -2166,6 +2182,7 @@ func (d *triggerDiff) GetObjectName() string    { return d.New.Name }
 func (d *viewDiff) GetObjectName() string       { return d.New.Name }
 func (d *tableDiff) GetObjectName() string      { return d.Table.Name }
 func (d *ColumnDiff) GetObjectName() string     { return d.New.Name }
+func (d *ColumnRename) GetObjectName() string   { return d.New.Name }
 func (d *ConstraintDiff) GetObjectName() string { return d.New.Name }
 func (d *IndexDiff) GetObjectName() string      { return d.New.Name }
 func (d *policyDiff) GetObjectName() string     { return d.New.Name }

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -119,6 +119,7 @@ func diffTables(oldTable, newTable *ir.Table, targetSchema string) *tableDiff {
 		AddedColumns:        []*ir.Column{},
 		DroppedColumns:      []*ir.Column{},
 		ModifiedColumns:     []*ColumnDiff{},
+		RenamedColumns:      []*ColumnRename{},
 		AddedConstraints:    []*ir.Constraint{},
 		DroppedConstraints:  []*ir.Constraint{},
 		ModifiedConstraints: []*ConstraintDiff{},
@@ -335,7 +336,8 @@ func diffTables(oldTable, newTable *ir.Table, targetSchema string) *tableDiff {
 
 	// Return nil if no changes
 	if len(diff.AddedColumns) == 0 && len(diff.DroppedColumns) == 0 &&
-		len(diff.ModifiedColumns) == 0 && len(diff.AddedConstraints) == 0 &&
+		len(diff.ModifiedColumns) == 0 && len(diff.RenamedColumns) == 0 &&
+		len(diff.AddedConstraints) == 0 &&
 		len(diff.DroppedConstraints) == 0 && len(diff.ModifiedConstraints) == 0 &&
 		len(diff.AddedIndexes) == 0 && len(diff.DroppedIndexes) == 0 &&
 		len(diff.ModifiedIndexes) == 0 && len(diff.AddedTriggers) == 0 &&
@@ -357,6 +359,7 @@ func diffExternalTable(oldTable, newTable *ir.Table) *tableDiff {
 		AddedColumns:        []*ir.Column{},
 		DroppedColumns:      []*ir.Column{},
 		ModifiedColumns:     []*ColumnDiff{},
+		RenamedColumns:      []*ColumnRename{},
 		AddedConstraints:    []*ir.Constraint{},
 		DroppedConstraints:  []*ir.Constraint{},
 		ModifiedConstraints: []*ConstraintDiff{},

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -225,6 +225,12 @@ func diffTables(oldTable, newTable *ir.Table, targetSchema string) *tableDiff {
 		}
 	}
 
+	// Build rename map (old name -> new name) for constraint comparison
+	renameMap := make(map[string]string, len(diff.RenamedColumns))
+	for _, rename := range diff.RenamedColumns {
+		renameMap[rename.Old.Name] = rename.New.Name
+	}
+
 	// Compare constraints
 	oldConstraints := make(map[string]*ir.Constraint)
 	newConstraints := make(map[string]*ir.Constraint)
@@ -258,7 +264,14 @@ func diffTables(oldTable, newTable *ir.Table, targetSchema string) *tableDiff {
 	// Find modified constraints
 	for name, newConstraint := range newConstraints {
 		if oldConstraint, exists := oldConstraints[name]; exists {
-			if !constraintsEqual(oldConstraint, newConstraint) {
+			// When columns are renamed, apply the rename map to the old constraint's
+			// column names before comparing, since PostgreSQL automatically updates
+			// constraint column references when a column is renamed.
+			oldForComparison := oldConstraint
+			if len(renameMap) > 0 {
+				oldForComparison = applyRenameMapToConstraint(oldConstraint, renameMap)
+			}
+			if !constraintsEqual(oldForComparison, newConstraint) {
 				diff.ModifiedConstraints = append(diff.ModifiedConstraints, &ConstraintDiff{
 					Old: oldConstraint,
 					New: newConstraint,
@@ -768,6 +781,22 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			Operation:           DiffOperationAlter,
 			Path:                fmt.Sprintf("%s.%s", td.Table.Schema, td.Table.Name),
 			Source:              td.Table,
+			CanRunInTransaction: true,
+		}
+		collector.collect(context, sql)
+	}
+
+	// Rename columns before any drops/adds to preserve data
+	for _, rename := range td.RenamedColumns {
+		tableName := getTableNameWithSchema(td.Table.Schema, td.Table.Name, targetSchema)
+		sql := fmt.Sprintf("ALTER TABLE %s RENAME COLUMN %s TO %s;",
+			tableName, ir.QuoteIdentifier(rename.Old.Name), ir.QuoteIdentifier(rename.New.Name))
+
+		context := &diffContext{
+			Type:                DiffTypeTableColumnRename,
+			Operation:           DiffOperationAlter,
+			Path:                fmt.Sprintf("%s.%s.%s", td.Table.Schema, td.Table.Name, rename.New.Name),
+			Source:              rename,
 			CanRunInTransaction: true,
 		}
 		collector.collect(context, sql)
@@ -1372,6 +1401,28 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 				Operation:           DiffOperationAlter,
 				Path:                fmt.Sprintf("%s.%s.%s", td.Table.Schema, td.Table.Name, colDiff.New.Name),
 				Source:              colDiff,
+				CanRunInTransaction: true,
+			}
+			collector.collect(context, sql)
+		}
+	}
+
+	// Handle comment changes on renamed columns
+	for _, rename := range td.RenamedColumns {
+		if rename.Old.Comment != rename.New.Comment {
+			tableName := getTableNameWithSchema(td.Table.Schema, td.Table.Name, targetSchema)
+			var sql string
+			if rename.New.Comment == "" {
+				sql = fmt.Sprintf("COMMENT ON COLUMN %s.%s IS NULL;", tableName, ir.QuoteIdentifier(rename.New.Name))
+			} else {
+				sql = fmt.Sprintf("COMMENT ON COLUMN %s.%s IS %s;", tableName, ir.QuoteIdentifier(rename.New.Name), quoteString(rename.New.Comment))
+			}
+
+			context := &diffContext{
+				Type:                DiffTypeTableColumnComment,
+				Operation:           DiffOperationAlter,
+				Path:                fmt.Sprintf("%s.%s.%s", td.Table.Schema, td.Table.Name, rename.New.Name),
+				Source:              rename,
 				CanRunInTransaction: true,
 			}
 			collector.collect(context, sql)

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -111,6 +111,50 @@ func diffTriggers(oldTable, newTable *ir.Table, diff *tableDiff) {
 	}
 }
 
+// detectColumnRenames finds column pairs that were renamed (same position + properties, different name).
+// Returns the detected renames and the remaining added/dropped columns that are not renames.
+func detectColumnRenames(added, dropped []*ir.Column, targetSchema string) (
+	renames []*ColumnRename,
+	remainingAdded []*ir.Column,
+	remainingDropped []*ir.Column,
+) {
+	// Build a map of dropped columns keyed by position
+	droppedByPosition := make(map[int]*ir.Column)
+	for _, col := range dropped {
+		droppedByPosition[col.Position] = col
+	}
+
+	matchedDropped := make(map[string]bool)
+	matchedAdded := make(map[string]bool)
+
+	for _, addedCol := range added {
+		if droppedCol, exists := droppedByPosition[addedCol.Position]; exists {
+			if !matchedDropped[droppedCol.Name] && columnsMatchForRename(droppedCol, addedCol, targetSchema) {
+				renames = append(renames, &ColumnRename{
+					Old: droppedCol,
+					New: addedCol,
+				})
+				matchedDropped[droppedCol.Name] = true
+				matchedAdded[addedCol.Name] = true
+			}
+		}
+	}
+
+	// Build remaining lists
+	for _, col := range added {
+		if !matchedAdded[col.Name] {
+			remainingAdded = append(remainingAdded, col)
+		}
+	}
+	for _, col := range dropped {
+		if !matchedDropped[col.Name] {
+			remainingDropped = append(remainingDropped, col)
+		}
+	}
+
+	return renames, remainingAdded, remainingDropped
+}
+
 // diffTables compares two tables and returns the differences
 // targetSchema is used to normalize type names before comparison
 func diffTables(oldTable, newTable *ir.Table, targetSchema string) *tableDiff {
@@ -159,6 +203,14 @@ func diffTables(oldTable, newTable *ir.Table, targetSchema string) *tableDiff {
 		if _, exists := newColumns[name]; !exists {
 			diff.DroppedColumns = append(diff.DroppedColumns, column)
 		}
+	}
+
+	// Detect column renames from added/dropped pairs
+	renames, remainingAdded, remainingDropped := detectColumnRenames(diff.AddedColumns, diff.DroppedColumns, targetSchema)
+	if len(renames) > 0 {
+		diff.RenamedColumns = renames
+		diff.AddedColumns = remainingAdded
+		diff.DroppedColumns = remainingDropped
 	}
 
 	// Find modified columns

--- a/testdata/diff/create_table/issue_384_rename_column_constraint/diff.sql
+++ b/testdata/diff/create_table/issue_384_rename_column_constraint/diff.sql
@@ -1,6 +1,1 @@
-ALTER TABLE a DROP COLUMN revision;
-
-ALTER TABLE a ADD COLUMN current_revision bigint;
-
-ALTER TABLE a
-ADD CONSTRAINT a_revision_fkey FOREIGN KEY (current_revision) REFERENCES b (id);
+ALTER TABLE a RENAME COLUMN revision TO current_revision;

--- a/testdata/diff/create_table/issue_384_rename_column_constraint/plan.sql
+++ b/testdata/diff/create_table/issue_384_rename_column_constraint/plan.sql
@@ -1,8 +1,1 @@
-ALTER TABLE a DROP COLUMN revision;
-
-ALTER TABLE a ADD COLUMN current_revision bigint;
-
-ALTER TABLE a
-ADD CONSTRAINT a_revision_fkey FOREIGN KEY (current_revision) REFERENCES b (id) NOT VALID;
-
-ALTER TABLE a VALIDATE CONSTRAINT a_revision_fkey;
+ALTER TABLE a RENAME COLUMN revision TO current_revision;

--- a/testdata/diff/create_table/rename_column/diff.sql
+++ b/testdata/diff/create_table/rename_column/diff.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users RENAME COLUMN active TO is_active;

--- a/testdata/diff/create_table/rename_column/new.sql
+++ b/testdata/diff/create_table/rename_column/new.sql
@@ -1,0 +1,4 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    is_active boolean NOT NULL
+);

--- a/testdata/diff/create_table/rename_column/old.sql
+++ b/testdata/diff/create_table/rename_column/old.sql
@@ -1,0 +1,4 @@
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    active boolean NOT NULL
+);

--- a/testdata/diff/create_table/rename_column/plan.json
+++ b/testdata/diff/create_table/rename_column/plan.json
@@ -3,16 +3,16 @@
   "pgschema_version": "1.9.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "7fcec59d1a0d260fce77ca55af1cad30ebc8768996825647c4002962d1a8f8ee"
+    "hash": "2269947753a914ccaf56d792f2240cbe65cb6aea022eab92bb484aff584e22f4"
   },
   "groups": [
     {
       "steps": [
         {
-          "sql": "ALTER TABLE a RENAME COLUMN revision TO current_revision;",
+          "sql": "ALTER TABLE users RENAME COLUMN active TO is_active;",
           "type": "table.column_rename",
           "operation": "alter",
-          "path": "public.a.current_revision"
+          "path": "public.users.is_active"
         }
       ]
     }

--- a/testdata/diff/create_table/rename_column/plan.sql
+++ b/testdata/diff/create_table/rename_column/plan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users RENAME COLUMN active TO is_active;

--- a/testdata/diff/create_table/rename_column/plan.txt
+++ b/testdata/diff/create_table/rename_column/plan.txt
@@ -4,10 +4,10 @@ Summary by type:
   tables: 1 to modify
 
 Tables:
-  ~ a
-    ~ current_revision (column_rename)
+  ~ users
+    ~ is_active (column_rename)
 
 DDL to be executed:
 --------------------------------------------------
 
-ALTER TABLE a RENAME COLUMN revision TO current_revision;
+ALTER TABLE users RENAME COLUMN active TO is_active;

--- a/testdata/diff/create_table/rename_column_type_change/diff.sql
+++ b/testdata/diff/create_table/rename_column_type_change/diff.sql
@@ -1,0 +1,3 @@
+ALTER TABLE orders DROP COLUMN status;
+
+ALTER TABLE orders ADD COLUMN order_status integer NOT NULL;

--- a/testdata/diff/create_table/rename_column_type_change/new.sql
+++ b/testdata/diff/create_table/rename_column_type_change/new.sql
@@ -1,0 +1,4 @@
+CREATE TABLE public.orders (
+    id integer NOT NULL,
+    order_status integer NOT NULL
+);

--- a/testdata/diff/create_table/rename_column_type_change/old.sql
+++ b/testdata/diff/create_table/rename_column_type_change/old.sql
@@ -1,0 +1,4 @@
+CREATE TABLE public.orders (
+    id integer NOT NULL,
+    status text NOT NULL
+);

--- a/testdata/diff/create_table/rename_column_type_change/plan.json
+++ b/testdata/diff/create_table/rename_column_type_change/plan.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.9.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "257331bc006ad99a91cdba3a4c7fe7a0cedd09b17fb127ed74d1b4892f93463b"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "ALTER TABLE orders DROP COLUMN status;",
+          "type": "table.column",
+          "operation": "drop",
+          "path": "public.orders.status"
+        },
+        {
+          "sql": "ALTER TABLE orders ADD COLUMN order_status integer NOT NULL;",
+          "type": "table.column",
+          "operation": "create",
+          "path": "public.orders.order_status"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_table/rename_column_type_change/plan.sql
+++ b/testdata/diff/create_table/rename_column_type_change/plan.sql
@@ -1,0 +1,3 @@
+ALTER TABLE orders DROP COLUMN status;
+
+ALTER TABLE orders ADD COLUMN order_status integer NOT NULL;

--- a/testdata/diff/create_table/rename_column_type_change/plan.txt
+++ b/testdata/diff/create_table/rename_column_type_change/plan.txt
@@ -1,0 +1,16 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ orders
+    + order_status (column)
+    - status (column)
+
+DDL to be executed:
+--------------------------------------------------
+
+ALTER TABLE orders DROP COLUMN status;
+
+ALTER TABLE orders ADD COLUMN order_status integer NOT NULL;


### PR DESCRIPTION
## Summary

Adds automatic detection of column renames, generating `ALTER TABLE ... RENAME COLUMN` instead of `DROP COLUMN` + `ADD COLUMN`. This preserves data during migrations when a column is simply renamed.

## Problem

Previously, renaming a column in a schema file (e.g. `active` -> `is_active`) produced a destructive plan:

```sql
ALTER TABLE users DROP COLUMN active;
ALTER TABLE users ADD COLUMN is_active boolean NOT NULL;
```

This loses all data in the column. The correct migration is:

```sql
ALTER TABLE users RENAME COLUMN active TO is_active;
```

Additionally, when a renamed column participates in constraints (foreign keys, primary keys, unique), PostgreSQL automatically updates constraint definitions to reference the new column name. The old behavior would emit spurious constraint drop/recreate statements.

## Approach

Rename detection uses a **position + properties** heuristic: if a dropped column and an added column share the same ordinal position and all properties match (type, nullability, default, identity, generated expression) but differ only in name, it is treated as a rename.

### Key design decisions

- **Position-based matching**: Columns must be at the same ordinal position. This avoids false positives when unrelated columns happen to share the same type.
- **Type change = not a rename**: If both name and type change, it is treated as a drop + add (no safe automatic migration exists). See the `rename_column_type_change` test case.
- **Constraint-aware**: After detecting renames, the diff engine applies a rename map to old constraint column references before comparing. This prevents false constraint diffs when PostgreSQL would auto-update the references.
- **Comment changes allowed**: A rename with a simultaneous comment change is still detected as a rename; the comment change is emitted separately.

## Changes

### Core logic (`internal/diff/`)

- **`column.go`** - `columnsMatchForRename()`: compares two columns for rename eligibility (same position, type, nullability, default, identity, generated expr; different name)
- **`column_test.go`** - Unit tests for `columnsMatchForRename` covering type mismatch, position mismatch, nullability mismatch, identity, schema-qualified types, etc.
- **`table.go`** - `detectColumnRenames()`: pairs added/dropped columns by position, returns renames and remaining unpaired columns. Integrates into `diffTables()` and `generateAlterTableStatements()` to emit `RENAME COLUMN` SQL before any drops/adds. Handles comment changes on renamed columns.
- **`constraint.go`** - `applyRenameMapToConstraint()`: shallow-copies a constraint with column names updated per the rename map, so constraint comparison ignores already-handled renames.
- **`diff.go`** - Adds `DiffTypeTableColumnRename` diff type, `ColumnRename` struct, and sorting/serialization support.

### Test cases (`testdata/diff/create_table/`)

| Test case | Scenario |
|-----------|----------|
| `rename_column/` | Simple rename: `active` -> `is_active` (same type, same position) |
| `rename_column_type_change/` | Name + type change: treated as drop + add (not a rename) |
| `issue_384_rename_column_constraint/` | Updated: rename with FK constraint now emits `RENAME COLUMN` instead of drop/recreate constraint |

## Test plan

- [ ] `PGSCHEMA_TEST_FILTER="rename_column/" go test -v ./internal/diff -run TestDiffFromFiles` - rename detection diff tests
- [ ] `PGSCHEMA_TEST_FILTER="rename_column_type_change/" go test -v ./internal/diff -run TestDiffFromFiles` - type change falls back to drop/add
- [ ] `PGSCHEMA_TEST_FILTER="issue_384" go test -v ./internal/diff -run TestDiffFromFiles` - constraint handling with renames
- [ ] `go test -v ./internal/diff -run TestColumnsMatchForRename` - unit tests for match logic
- [ ] `go test -v ./internal/diff -run TestDiffFromFiles` - all diff tests pass
- [ ] `PGSCHEMA_TEST_FILTER="rename_column/" go test -v ./cmd -run TestPlanAndApply` - integration test
- [ ] `go test ./...` - full test suite
