### PR TITLE
fix nix packaging

### DIFF
--- a/internal/postgres/embedded.go
+++ b/internal/postgres/embedded.go
@@ -17,6 +17,11 @@ import (
 	"github.com/pgplex/pgschema/cmd/util"
 )
 
+// binariesPath is the path that contains the Postgres binaries.
+// This is meant to be injected via ldflags (for example, to use the nix
+// postgres versions when building with nix).
+var binariesPath string
+
 // PostgresVersion is an alias for the embedded-postgres version type.
 type PostgresVersion = embeddedpostgres.PostgresVersion
 
@@ -91,14 +96,16 @@ func StartEmbeddedPostgres(config *EmbeddedPostgresConfig) (*EmbeddedPostgres, e
 		Password(config.Password).
 		Port(uint32(port)).
 		RuntimePath(runtimePath).
+		BinariesPath(binariesPath).
 		DataPath(filepath.Join(runtimePath, "data")).
 		Logger(io.Discard). // Suppress embedded-postgres startup logs
 		StartParameters(map[string]string{
-			"logging_collector":          "off",    // Disable log collector
-			"log_destination":            "stderr", // Send logs to stderr (which we discard)
-			"log_min_messages":           "PANIC",  // Only log PANIC level messages
-			"log_statement":              "none",   // Don't log SQL statements
-			"log_min_duration_statement": "-1",     // Don't log slow queries
+			"logging_collector":          "off",       // Disable log collector
+			"log_destination":            "stderr",    // Send logs to stderr (which we discard)
+			"log_min_messages":           "PANIC",     // Only log PANIC level messages
+			"log_statement":              "none",      // Don't log SQL statements
+			"log_min_duration_statement": "-1",        // Don't log slow queries
+			"unix_socket_directories":    runtimePath, // Use a directory that is guaranteed to exist
 		})
 
 	// Create and start PostgreSQL instance

--- a/nix/pgschema.nix
+++ b/nix/pgschema.nix
@@ -1,8 +1,9 @@
-{ pkgs ? import <nixpkgs> {}, rev ? "unknown", buildDate ? "unknown" }:
+{ pkgs ? import <nixpkgs> {}, rev ? "unknown", buildDate ? "unknown", postgresql ? null }:
 
 let
   lib = pkgs.lib;
   version = lib.strings.removeSuffix "\n" (builtins.readFile ../internal/version/VERSION);
+  postgres = if postgresql == null then pkgs.postgresql else postgresql;
 in
 pkgs.buildGoModule {
   pname = "pgschema";
@@ -31,6 +32,8 @@ pkgs.buildGoModule {
     "github.com/pgplex/pgschema/cmd.GitCommit=${rev}"
     "-X"
     "github.com/pgplex/pgschema/cmd.BuildDate=${buildDate}"
+    "-X"
+    "github.com/pgplex/pgschema/internal/postgres.binariesPath=${postgres}"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Running `pgschema` that is built by nix on NixOS is not possible since NixOS cannot run dynamically linked executables for general Linux environments. This works around that by providing the path to the Postgres binaries built using nix via ldflags.

This has an added benefit that users can override the postgresql package being used by `embeddedpostgres`.