### PR TITLE
fix: quote mixed-case trigger names and FK referenced column names in…

### DIFF
--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -1590,13 +1590,13 @@ func generateForeignKeyClause(constraint *ir.Constraint, targetSchema string, in
 	if len(constraint.ReferencedColumns) > 0 {
 		if len(constraint.ReferencedColumns) == 1 {
 			// Single column
-			clause += fmt.Sprintf(" (%s)", constraint.ReferencedColumns[0].Name)
+			clause += fmt.Sprintf(" (%s)", ir.QuoteIdentifier(constraint.ReferencedColumns[0].Name))
 		} else {
 			// Multiple columns - sort by position
 			refColumns := sortConstraintColumnsByPosition(constraint.ReferencedColumns)
 			var refColumnNames []string
 			for _, col := range refColumns {
-				refColumnNames = append(refColumnNames, col.Name)
+				refColumnNames = append(refColumnNames, ir.QuoteIdentifier(col.Name))
 			}
 			if constraint.IsTemporal && len(refColumnNames) > 0 {
 				refColumnNames[len(refColumnNames)-1] = "PERIOD " + refColumnNames[len(refColumnNames)-1]

--- a/internal/diff/trigger.go
+++ b/internal/diff/trigger.go
@@ -171,7 +171,7 @@ func generateDropTriggersFromModifiedTables(tables []*tableDiff, targetSchema st
 	// Generate DROP TRIGGER statements for all collected triggers
 	for _, trigger := range allTriggers {
 		tableName := getTableNameWithSchema(trigger.Schema, trigger.Table, targetSchema)
-		sql := fmt.Sprintf("DROP TRIGGER IF EXISTS %s ON %s;", trigger.Name, tableName)
+		sql := fmt.Sprintf("DROP TRIGGER IF EXISTS %s ON %s;", ir.QuoteIdentifier(trigger.Name), tableName)
 
 		context := &diffContext{
 			Type:                DiffTypeTableTrigger,
@@ -204,7 +204,7 @@ func generateDropTriggersFromModifiedViews(views []*viewDiff, targetSchema strin
 	// Generate DROP TRIGGER statements for all collected triggers
 	for _, trigger := range allTriggers {
 		tableName := getTableNameWithSchema(trigger.Schema, trigger.Table, targetSchema)
-		sql := fmt.Sprintf("DROP TRIGGER IF EXISTS %s ON %s;", trigger.Name, tableName)
+		sql := fmt.Sprintf("DROP TRIGGER IF EXISTS %s ON %s;", ir.QuoteIdentifier(trigger.Name), tableName)
 
 		context := &diffContext{
 			Type:                DiffTypeViewTrigger,
@@ -273,7 +273,7 @@ func generateTriggerSQLWithMode(trigger *ir.Trigger, targetSchema string) string
 		stmt += fmt.Sprintf("\n    FOR EACH %s", trigger.Level)
 	} else {
 		stmt = fmt.Sprintf("CREATE OR REPLACE TRIGGER %s\n    %s %s ON %s",
-			trigger.Name, trigger.Timing, eventList, tableName)
+			ir.QuoteIdentifier(trigger.Name), trigger.Timing, eventList, tableName)
 		// Add REFERENCING clause before FOR EACH
 		stmt += referencingClause
 		stmt += fmt.Sprintf("\n    FOR EACH %s", trigger.Level)


### PR DESCRIPTION
… DDL output

PostgreSQL folds unquoted identifiers to lowercase at parse time. When a trigger name or FK referenced column name contains uppercase letters, omitting quotes in the generated DDL causes PostgreSQL to store the identifier in lowercase — creating a persistent drift where the desired state (model file) and live state (database) never converge.

This fix applies ir.QuoteIdentifier to the three affected DDL generation sites:

internal/diff/trigger.go
- CREATE OR REPLACE TRIGGER: use QuoteIdentifier(trigger.Name) so regular triggers receive the same quoting as constraint triggers (which already called QuoteIdentifier correctly).
- DROP TRIGGER IF EXISTS (×2, tables and views): quote trigger name so the DROP targets the exact identifier that was created.

internal/diff/table.go
- generateForeignKeyClause: quote each referenced column name in the REFERENCES (...) clause, both for single-column and multi-column FKs.

ir.QuoteIdentifier was already correctly implemented — it only wraps in double quotes when the identifier contains uppercase letters, reserved words, or special characters — so purely lowercase identifiers are unaffected.

Fixes: triggers with mixed-case names being stored lowercase on fresh databases, causing perpetual DROP + CREATE churn on subsequent plans. Fixes: FK constraints referencing mixed-case columns failing with
  "column does not exist" on fresh databases.