### PR TITLE
feat: add constraints section to .pgschemaignore (#429, #447)

### DIFF
--- a/cmd/ignore_integration_test.go
+++ b/cmd/ignore_integration_test.go
@@ -1445,6 +1445,125 @@ CREATE INDEX products_name_idx ON products(name);
 	})
 }
 
+// TestIgnoreConstraints tests that constraints matching .pgschemaignore [constraints]
+// patterns are excluded from dump and plan output.
+// Addresses https://github.com/pgplex/pgschema/issues/447 and https://github.com/pgplex/pgschema/issues/429
+func TestIgnoreConstraints(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	embeddedPG := testutil.SetupPostgres(t)
+	defer embeddedPG.Stop()
+	conn, host, port, dbname, user, password := testutil.ConnectToPostgres(t, embeddedPG)
+	defer conn.Close()
+
+	containerInfo := &struct {
+		Conn     *sql.DB
+		Host     string
+		Port     int
+		DBName   string
+		User     string
+		Password string
+	}{
+		Conn:     conn,
+		Host:     host,
+		Port:     port,
+		DBName:   dbname,
+		User:     user,
+		Password: password,
+	}
+
+	// Create tables with a managed primary key plus a manually-added foreign key
+	// that is not part of the declared schema (simulates a constraint re-added
+	// out-of-band, e.g. after a DMS migration that disabled constraints).
+	setupSQL := `
+CREATE TABLE categories (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE products (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    category_id INTEGER
+);
+
+ALTER TABLE products
+    ADD CONSTRAINT fk_products_category FOREIGN KEY (category_id) REFERENCES categories(id);
+`
+	_, err := conn.Exec(setupSQL)
+	if err != nil {
+		t.Fatalf("Failed to create test schema: %v", err)
+	}
+
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalWd); err != nil {
+			t.Fatalf("Failed to restore working directory: %v", err)
+		}
+	}()
+
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
+
+	// Ignore any constraint whose name starts with "fk_"
+	ignoreContent := `[constraints]
+patterns = ["fk_*"]
+`
+	err = os.WriteFile(".pgschemaignore", []byte(ignoreContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create .pgschemaignore: %v", err)
+	}
+
+	t.Run("dump", func(t *testing.T) {
+		output := executeIgnoreDumpCommand(t, containerInfo)
+
+		if !strings.Contains(output, "products_pkey") {
+			t.Error("Dump should include products_pkey (not ignored)")
+		}
+
+		if strings.Contains(output, "fk_products_category") {
+			t.Error("Dump should not include fk_products_category (ignored by [constraints] patterns)")
+		}
+	})
+
+	t.Run("plan", func(t *testing.T) {
+		// Desired schema declares the tables but not the foreign key.
+		// Without the ignore the plan would emit ALTER TABLE ... DROP CONSTRAINT
+		// fk_products_category; with the ignore the plan should not reference it.
+		schemaSQL := `
+CREATE TABLE categories (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE products (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    category_id INTEGER
+);
+`
+		schemaFile := "schema.sql"
+		err := os.WriteFile(schemaFile, []byte(schemaSQL), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create schema file: %v", err)
+		}
+		defer os.Remove(schemaFile)
+
+		output := executeIgnorePlanCommand(t, containerInfo, schemaFile)
+
+		if strings.Contains(output, "fk_products_category") {
+			t.Errorf("Plan should not reference fk_products_category (ignored); got: %s", output)
+		}
+	})
+}
+
 // verifyPlanOutput checks that plan output excludes ignored objects
 func verifyPlanOutput(t *testing.T, output string) {
 	// Changes that should appear in plan (regular objects)

--- a/cmd/util/ignoreloader.go
+++ b/cmd/util/ignoreloader.go
@@ -35,6 +35,7 @@ type TomlConfig struct {
 	Types             TypeIgnoreConfig             `toml:"types,omitempty"`
 	Sequences         SequenceIgnoreConfig         `toml:"sequences,omitempty"`
 	Indexes           IndexIgnoreConfig            `toml:"indexes,omitempty"`
+	Constraints       ConstraintIgnoreConfig       `toml:"constraints,omitempty"`
 	Privileges        PrivilegeIgnoreConfig        `toml:"privileges,omitempty"`
 	DefaultPrivileges DefaultPrivilegeIgnoreConfig `toml:"default_privileges,omitempty"`
 }
@@ -71,6 +72,12 @@ type SequenceIgnoreConfig struct {
 
 // IndexIgnoreConfig represents index-specific ignore configuration
 type IndexIgnoreConfig struct {
+	Patterns []string `toml:"patterns,omitempty"`
+}
+
+// ConstraintIgnoreConfig represents constraint-specific ignore configuration
+// Patterns match on constraint names
+type ConstraintIgnoreConfig struct {
 	Patterns []string `toml:"patterns,omitempty"`
 }
 
@@ -118,6 +125,7 @@ func LoadIgnoreFileWithStructureFromPath(filePath string) (*ir.IgnoreConfig, err
 		Types:             tomlConfig.Types.Patterns,
 		Sequences:         tomlConfig.Sequences.Patterns,
 		Indexes:           tomlConfig.Indexes.Patterns,
+		Constraints:       tomlConfig.Constraints.Patterns,
 		Privileges:        tomlConfig.Privileges.Patterns,
 		DefaultPrivileges: tomlConfig.DefaultPrivileges.Patterns,
 	}

--- a/cmd/util/ignoreloader_test.go
+++ b/cmd/util/ignoreloader_test.go
@@ -44,6 +44,9 @@ patterns = ["seq_temp_*"]
 
 [indexes]
 patterns = ["idx_temp_*"]
+
+[constraints]
+patterns = ["fk_temp_*"]
 `
 
 	err := os.WriteFile(testFile, []byte(tomlContent), 0644)
@@ -85,6 +88,10 @@ patterns = ["idx_temp_*"]
 
 	if len(config.Indexes) != 1 || config.Indexes[0] != "idx_temp_*" {
 		t.Errorf("Expected indexes patterns [\"idx_temp_*\"], got %v", config.Indexes)
+	}
+
+	if len(config.Constraints) != 1 || config.Constraints[0] != "fk_temp_*" {
+		t.Errorf("Expected constraints patterns [\"fk_temp_*\"], got %v", config.Constraints)
 	}
 }
 

--- a/docs/cli/ignore.mdx
+++ b/docs/cli/ignore.mdx
@@ -41,6 +41,12 @@ patterns = ["type_test_*"]
 [sequences]
 patterns = ["seq_temp_*", "seq_debug_*"]
 
+[indexes]
+patterns = ["idx_temp_*", "manual_*"]
+
+[constraints]
+patterns = ["fk_legacy_*"]
+
 [privileges]
 patterns = ["deploy_bot", "admin_*"]
 
@@ -103,6 +109,24 @@ patterns = ["deploy_bot"]  # Ignore ALTER DEFAULT PRIVILEGES for deploy_bot
 ```
 
 The `[privileges]` section filters explicit grants (`GRANT ... TO role`), including column-level privileges. The `[default_privileges]` section filters `ALTER DEFAULT PRIVILEGES` statements.
+
+## Constraints
+
+The `[constraints]` section matches table constraints by **constraint name** (primary keys, unique, foreign keys, check, and exclusion constraints). When a constraint is ignored, pgschema neither creates, drops, nor reports drift on it — it is left entirely to be managed out-of-band.
+
+```toml
+[constraints]
+patterns = ["fk_*", "!fk_core_*"]
+```
+
+This is useful when:
+
+1. **Out-of-band constraints** - A constraint is added and managed manually (e.g. disabled during an AWS DMS migration and re-added afterward), and you don't want `pgschema plan` to flag it for drop.
+2. **Cross-schema foreign keys** - When modules live in separate schemas with foreign keys between them, ignore the cross-schema foreign keys so each schema can be bootstrapped independently, then drop the ignore to let pgschema manage them once all tables exist.
+
+<Warning>
+Patterns match the constraint name only, which is not necessarily unique across tables. Be careful with broad patterns like `*`, as ignoring a primary key or unique constraint can leave a table without the keys it needs.
+</Warning>
 
 ## Triggers on Ignored Tables
 

--- a/ir/ignore.go
+++ b/ir/ignore.go
@@ -23,6 +23,7 @@ type IgnoreConfig struct {
 	Types             []string `toml:"types,omitempty"`
 	Sequences         []string `toml:"sequences,omitempty"`
 	Indexes           []string `toml:"indexes,omitempty"`
+	Constraints       []string `toml:"constraints,omitempty"`
 	Privileges        []string `toml:"privileges,omitempty"`
 	DefaultPrivileges []string `toml:"default_privileges,omitempty"`
 }
@@ -81,6 +82,16 @@ func (c *IgnoreConfig) ShouldIgnoreIndex(indexName string) bool {
 		return false
 	}
 	return c.shouldIgnore(indexName, c.Indexes)
+}
+
+// ShouldIgnoreConstraint checks if a constraint should be ignored based on the patterns.
+// Patterns match on the constraint name, letting users preserve constraints that exist
+// in the database but are managed out-of-band (e.g. manually re-added after a DMS migration).
+func (c *IgnoreConfig) ShouldIgnoreConstraint(constraintName string) bool {
+	if c == nil {
+		return false
+	}
+	return c.shouldIgnore(constraintName, c.Constraints)
 }
 
 // ShouldIgnorePrivilegeByObjectType checks if a privilege should be ignored based on the object name

--- a/ir/ignore_test.go
+++ b/ir/ignore_test.go
@@ -101,13 +101,14 @@ func TestIgnoreConfig_ShouldIgnoreTable(t *testing.T) {
 
 func TestIgnoreConfig_AllObjectTypes(t *testing.T) {
 	config := &IgnoreConfig{
-		Tables:     []string{"table_*"},
-		Views:      []string{"view_*"},
-		Functions:  []string{"fn_*"},
-		Procedures: []string{"sp_*"},
-		Types:      []string{"type_*"},
-		Sequences:  []string{"seq_*"},
-		Indexes:    []string{"idx_*"},
+		Tables:      []string{"table_*"},
+		Views:       []string{"view_*"},
+		Functions:   []string{"fn_*"},
+		Procedures:  []string{"sp_*"},
+		Types:       []string{"type_*"},
+		Sequences:   []string{"seq_*"},
+		Indexes:     []string{"idx_*"},
+		Constraints: []string{"fk_*"},
 	}
 
 	// Test each object type
@@ -130,6 +131,8 @@ func TestIgnoreConfig_AllObjectTypes(t *testing.T) {
 		{config.ShouldIgnoreSequence, "user_id_seq", false},
 		{config.ShouldIgnoreIndex, "idx_temp", true},
 		{config.ShouldIgnoreIndex, "users_pkey", false},
+		{config.ShouldIgnoreConstraint, "fk_orders_product", true},
+		{config.ShouldIgnoreConstraint, "users_pkey", false},
 	}
 
 	for _, tt := range tests {
@@ -164,6 +167,9 @@ func TestIgnoreConfig_NilConfig(t *testing.T) {
 	}
 	if config.ShouldIgnoreIndex("any_index") {
 		t.Error("nil config should not ignore any index")
+	}
+	if config.ShouldIgnoreConstraint("any_constraint") {
+		t.Error("nil config should not ignore any constraint")
 	}
 }
 

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -442,6 +442,13 @@ func (i *Inspector) buildConstraints(ctx context.Context, schema *IR, targetSche
 		schemaName := constraint.TableSchema
 		tableName := constraint.TableName
 		constraintName := constraint.ConstraintName
+
+		// Skip ignored constraints early to avoid the per-column position
+		// queries below for constraints that would be discarded anyway.
+		if i.ignoreConfig != nil && i.ignoreConfig.ShouldIgnoreConstraint(constraintName) {
+			continue
+		}
+
 		constraintType := ""
 		if constraint.ConstraintType.Valid {
 			constraintType = constraint.ConstraintType.String
@@ -612,11 +619,6 @@ func (i *Inspector) buildConstraints(ctx context.Context, schema *IR, targetSche
 
 	// Add constraints to tables
 	for key, constraint := range constraintGroups {
-		// Check if constraint should be ignored
-		if i.ignoreConfig != nil && i.ignoreConfig.ShouldIgnoreConstraint(key.name) {
-			continue
-		}
-
 		dbSchema := schema.getOrCreateSchema(key.schema)
 		table, exists := dbSchema.Tables[key.table]
 		if exists {

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -612,6 +612,11 @@ func (i *Inspector) buildConstraints(ctx context.Context, schema *IR, targetSche
 
 	// Add constraints to tables
 	for key, constraint := range constraintGroups {
+		// Check if constraint should be ignored
+		if i.ignoreConfig != nil && i.ignoreConfig.ShouldIgnoreConstraint(key.name) {
+			continue
+		}
+
 		dbSchema := schema.getOrCreateSchema(key.schema)
 		table, exists := dbSchema.Tables[key.table]
 		if exists {


### PR DESCRIPTION
## Summary

Adds a `[constraints]` section to `.pgschemaignore` that matches table constraints by **name** (glob). Ignored constraints are filtered at the inspector, so they are excluded from dump, plan generation, **and** drift detection alike — pgschema neither creates, drops, nor reports them.

```toml
[constraints]
patterns = ["fk_*", "!fk_core_*"]
```

This is one feature that addresses two related requests:

- **#447** — ignore constraints that are managed out-of-band by name (e.g. disabled during an AWS DMS migration and re-added manually afterward), so `pgschema plan` does not flag them for drop. *(closes)*
- **#429** — cross-schema foreign keys: ignore them to bootstrap each schema independently, then drop the ignore once all tables exist. *(workaround)*

## Implementation

Mirrors the existing per-object ignore pattern (the `[indexes]` section from #441) end to end:

- `ir/ignore.go` — `Constraints []string` field + `ShouldIgnoreConstraint(name)`
- `ir/inspector.go` — skip ignored constraints at the single attach site in the constraint loop
- `cmd/util/ignoreloader.go` — `ConstraintIgnoreConfig` TOML struct + wiring
- `docs/cli/ignore.mdx` — new `## Constraints` section with use cases + a footgun warning (also backfilled the previously-missing `[indexes]` example)

## Testing

- `ir` unit tests — `ShouldIgnoreConstraint` + nil-config coverage
- `cmd/util` loader test — parses `[constraints]` patterns
- `cmd/TestIgnoreConstraints` integration test (embedded PG): a manually-added `fk_products_category` is excluded from both dump output and the plan (no spurious `DROP CONSTRAINT`), while the managed `products_pkey` is retained

## Design note

Matching is by **bare constraint name** (consistent with how `[indexes]`/`[sequences]` match), which is not globally unique across tables. Documented with a warning about broad patterns. Happy to switch to `table.constraint` qualified matching if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)