### PR TITLE
feat: add triggers section to .pgschemaignore (#407)

### DIFF
--- a/cmd/ignore_integration_test.go
+++ b/cmd/ignore_integration_test.go
@@ -1564,6 +1564,145 @@ CREATE TABLE products (
 	})
 }
 
+// TestIgnoreTriggers tests that triggers matching .pgschemaignore [triggers]
+// patterns are excluded from dump and plan output.
+// Addresses https://github.com/pgplex/pgschema/issues/407
+func TestIgnoreTriggers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	embeddedPG := testutil.SetupPostgres(t)
+	defer embeddedPG.Stop()
+	conn, host, port, dbname, user, password := testutil.ConnectToPostgres(t, embeddedPG)
+	defer conn.Close()
+
+	containerInfo := &struct {
+		Conn     *sql.DB
+		Host     string
+		Port     int
+		DBName   string
+		User     string
+		Password string
+	}{
+		Conn:     conn,
+		Host:     host,
+		Port:     port,
+		DBName:   dbname,
+		User:     user,
+		Password: password,
+	}
+
+	// Create a table with a managed trigger plus an extension-style trigger that
+	// is not part of the declared schema (simulates a trigger an extension adds
+	// automatically, e.g. the pgai vectorizer's _vectorizer_src_trg_* triggers).
+	setupSQL := `
+CREATE TABLE products (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    updated_at TIMESTAMPTZ
+);
+
+CREATE FUNCTION set_updated_at() RETURNS trigger AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION vectorizer_noop() RETURNS trigger AS $$
+BEGIN
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER products_set_updated_at
+    BEFORE UPDATE ON products
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER _vectorizer_src_trg_products
+    AFTER INSERT OR UPDATE ON products
+    FOR EACH ROW EXECUTE FUNCTION vectorizer_noop();
+`
+	_, err := conn.Exec(setupSQL)
+	if err != nil {
+		t.Fatalf("Failed to create test schema: %v", err)
+	}
+
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalWd); err != nil {
+			t.Fatalf("Failed to restore working directory: %v", err)
+		}
+	}()
+
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
+
+	// Ignore any trigger whose name starts with "_vectorizer_src_trg_"
+	ignoreContent := `[triggers]
+patterns = ["_vectorizer_src_trg_*"]
+`
+	err = os.WriteFile(".pgschemaignore", []byte(ignoreContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create .pgschemaignore: %v", err)
+	}
+
+	t.Run("dump", func(t *testing.T) {
+		output := executeIgnoreDumpCommand(t, containerInfo)
+
+		if !strings.Contains(output, "products_set_updated_at") {
+			t.Error("Dump should include products_set_updated_at (not ignored)")
+		}
+
+		if strings.Contains(output, "_vectorizer_src_trg_products") {
+			t.Error("Dump should not include _vectorizer_src_trg_products (ignored by [triggers] patterns)")
+		}
+	})
+
+	t.Run("plan", func(t *testing.T) {
+		// Desired schema declares the table, the function, and the managed trigger
+		// but not the extension trigger. Without the ignore the plan would emit
+		// DROP TRIGGER _vectorizer_src_trg_products; with the ignore it should not
+		// reference it.
+		schemaSQL := `
+CREATE TABLE products (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    updated_at TIMESTAMPTZ
+);
+
+CREATE FUNCTION set_updated_at() RETURNS trigger AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER products_set_updated_at
+    BEFORE UPDATE ON products
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+`
+		schemaFile := "schema.sql"
+		err := os.WriteFile(schemaFile, []byte(schemaSQL), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create schema file: %v", err)
+		}
+		defer os.Remove(schemaFile)
+
+		output := executeIgnorePlanCommand(t, containerInfo, schemaFile)
+
+		if strings.Contains(output, "_vectorizer_src_trg_products") {
+			t.Errorf("Plan should not reference _vectorizer_src_trg_products (ignored); got: %s", output)
+		}
+	})
+}
+
 // verifyPlanOutput checks that plan output excludes ignored objects
 func verifyPlanOutput(t *testing.T, output string) {
 	// Changes that should appear in plan (regular objects)

--- a/cmd/ignore_integration_test.go
+++ b/cmd/ignore_integration_test.go
@@ -1594,8 +1594,10 @@ func TestIgnoreTriggers(t *testing.T) {
 	}
 
 	// Create a table with a managed trigger plus an extension-style trigger that
-	// is not part of the declared schema (simulates a trigger an extension adds
-	// automatically, e.g. the pgai vectorizer's _vectorizer_src_trg_* triggers).
+	// is not part of the declared schema (simulates a trigger that an extension
+	// adds automatically, e.g. the pgai vectorizer's _vectorizer_src_trg_*
+	// triggers). Both triggers reuse the same function so the only unmanaged
+	// object is the ignored trigger itself — no stray DROP FUNCTION noise.
 	setupSQL := `
 CREATE TABLE products (
     id SERIAL PRIMARY KEY,
@@ -1610,19 +1612,13 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE FUNCTION vectorizer_noop() RETURNS trigger AS $$
-BEGIN
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
 CREATE TRIGGER products_set_updated_at
     BEFORE UPDATE ON products
     FOR EACH ROW EXECUTE FUNCTION set_updated_at();
 
 CREATE TRIGGER _vectorizer_src_trg_products
-    AFTER INSERT OR UPDATE ON products
-    FOR EACH ROW EXECUTE FUNCTION vectorizer_noop();
+    BEFORE INSERT ON products
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
 `
 	_, err := conn.Exec(setupSQL)
 	if err != nil {

--- a/cmd/util/ignoreloader.go
+++ b/cmd/util/ignoreloader.go
@@ -36,6 +36,7 @@ type TomlConfig struct {
 	Sequences         SequenceIgnoreConfig         `toml:"sequences,omitempty"`
 	Indexes           IndexIgnoreConfig            `toml:"indexes,omitempty"`
 	Constraints       ConstraintIgnoreConfig       `toml:"constraints,omitempty"`
+	Triggers          TriggerIgnoreConfig          `toml:"triggers,omitempty"`
 	Privileges        PrivilegeIgnoreConfig        `toml:"privileges,omitempty"`
 	DefaultPrivileges DefaultPrivilegeIgnoreConfig `toml:"default_privileges,omitempty"`
 }
@@ -78,6 +79,12 @@ type IndexIgnoreConfig struct {
 // ConstraintIgnoreConfig represents constraint-specific ignore configuration
 // Patterns match on constraint names
 type ConstraintIgnoreConfig struct {
+	Patterns []string `toml:"patterns,omitempty"`
+}
+
+// TriggerIgnoreConfig represents trigger-specific ignore configuration
+// Patterns match on trigger names
+type TriggerIgnoreConfig struct {
 	Patterns []string `toml:"patterns,omitempty"`
 }
 
@@ -126,6 +133,7 @@ func LoadIgnoreFileWithStructureFromPath(filePath string) (*ir.IgnoreConfig, err
 		Sequences:         tomlConfig.Sequences.Patterns,
 		Indexes:           tomlConfig.Indexes.Patterns,
 		Constraints:       tomlConfig.Constraints.Patterns,
+		Triggers:          tomlConfig.Triggers.Patterns,
 		Privileges:        tomlConfig.Privileges.Patterns,
 		DefaultPrivileges: tomlConfig.DefaultPrivileges.Patterns,
 	}

--- a/cmd/util/ignoreloader_test.go
+++ b/cmd/util/ignoreloader_test.go
@@ -47,6 +47,9 @@ patterns = ["idx_temp_*"]
 
 [constraints]
 patterns = ["fk_temp_*"]
+
+[triggers]
+patterns = ["trg_temp_*"]
 `
 
 	err := os.WriteFile(testFile, []byte(tomlContent), 0644)
@@ -92,6 +95,10 @@ patterns = ["fk_temp_*"]
 
 	if len(config.Constraints) != 1 || config.Constraints[0] != "fk_temp_*" {
 		t.Errorf("Expected constraints patterns [\"fk_temp_*\"], got %v", config.Constraints)
+	}
+
+	if len(config.Triggers) != 1 || config.Triggers[0] != "trg_temp_*" {
+		t.Errorf("Expected triggers patterns [\"trg_temp_*\"], got %v", config.Triggers)
 	}
 }
 

--- a/docs/cli/ignore.mdx
+++ b/docs/cli/ignore.mdx
@@ -47,6 +47,9 @@ patterns = ["idx_temp_*", "manual_*"]
 [constraints]
 patterns = ["fk_legacy_*"]
 
+[triggers]
+patterns = ["_vectorizer_src_trg_*"]
+
 [privileges]
 patterns = ["deploy_bot", "admin_*"]
 
@@ -126,6 +129,21 @@ This is useful when:
 
 <Warning>
 Patterns match the constraint name only, which is not necessarily unique across tables. Be careful with broad patterns like `*`, as ignoring a primary key or unique constraint can leave a table without the keys it needs.
+</Warning>
+
+## Triggers
+
+The `[triggers]` section matches triggers by **trigger name**. When a trigger is ignored, pgschema neither creates, drops, nor reports drift on it — it is left entirely to be managed out-of-band.
+
+```toml
+[triggers]
+patterns = ["_vectorizer_src_trg_*"]
+```
+
+This is useful when an extension automatically creates triggers on tables you manage. For example, the [pgai](https://github.com/timescale/pgai) vectorizer adds `_vectorizer_src_trg_*` triggers to source tables; ignoring them keeps `pgschema plan` from flagging them for drop while you continue to manage the rest of the table.
+
+<Warning>
+Patterns match the trigger name only, which is not necessarily unique across tables. Be careful with broad patterns like `*`.
 </Warning>
 
 ## Triggers on Ignored Tables

--- a/ir/ignore.go
+++ b/ir/ignore.go
@@ -24,6 +24,7 @@ type IgnoreConfig struct {
 	Sequences         []string `toml:"sequences,omitempty"`
 	Indexes           []string `toml:"indexes,omitempty"`
 	Constraints       []string `toml:"constraints,omitempty"`
+	Triggers          []string `toml:"triggers,omitempty"`
 	Privileges        []string `toml:"privileges,omitempty"`
 	DefaultPrivileges []string `toml:"default_privileges,omitempty"`
 }
@@ -92,6 +93,16 @@ func (c *IgnoreConfig) ShouldIgnoreConstraint(constraintName string) bool {
 		return false
 	}
 	return c.shouldIgnore(constraintName, c.Constraints)
+}
+
+// ShouldIgnoreTrigger checks if a trigger should be ignored based on the patterns.
+// Patterns match on the trigger name, letting users exclude triggers created
+// out-of-band (e.g. triggers an extension automatically adds to tracked tables).
+func (c *IgnoreConfig) ShouldIgnoreTrigger(triggerName string) bool {
+	if c == nil {
+		return false
+	}
+	return c.shouldIgnore(triggerName, c.Triggers)
 }
 
 // ShouldIgnorePrivilegeByObjectType checks if a privilege should be ignored based on the object name

--- a/ir/ignore.go
+++ b/ir/ignore.go
@@ -97,7 +97,7 @@ func (c *IgnoreConfig) ShouldIgnoreConstraint(constraintName string) bool {
 
 // ShouldIgnoreTrigger checks if a trigger should be ignored based on the patterns.
 // Patterns match on the trigger name, letting users exclude triggers created
-// out-of-band (e.g. triggers an extension automatically adds to tracked tables).
+// out-of-band (e.g. triggers that an extension automatically adds to tracked tables).
 func (c *IgnoreConfig) ShouldIgnoreTrigger(triggerName string) bool {
 	if c == nil {
 		return false

--- a/ir/ignore_test.go
+++ b/ir/ignore_test.go
@@ -109,6 +109,7 @@ func TestIgnoreConfig_AllObjectTypes(t *testing.T) {
 		Sequences:   []string{"seq_*"},
 		Indexes:     []string{"idx_*"},
 		Constraints: []string{"fk_*"},
+		Triggers:    []string{"trg_*"},
 	}
 
 	// Test each object type
@@ -133,6 +134,8 @@ func TestIgnoreConfig_AllObjectTypes(t *testing.T) {
 		{config.ShouldIgnoreIndex, "users_pkey", false},
 		{config.ShouldIgnoreConstraint, "fk_orders_product", true},
 		{config.ShouldIgnoreConstraint, "users_pkey", false},
+		{config.ShouldIgnoreTrigger, "trg_audit", true},
+		{config.ShouldIgnoreTrigger, "set_updated_at", false},
 	}
 
 	for _, tt := range tests {
@@ -170,6 +173,9 @@ func TestIgnoreConfig_NilConfig(t *testing.T) {
 	}
 	if config.ShouldIgnoreConstraint("any_constraint") {
 		t.Error("nil config should not ignore any constraint")
+	}
+	if config.ShouldIgnoreTrigger("any_trigger") {
+		t.Error("nil config should not ignore any trigger")
 	}
 }
 

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -1592,6 +1592,13 @@ func (i *Inspector) buildTriggers(ctx context.Context, schema *IR, targetSchema 
 		schemaName := triggerRow.TriggerSchema
 		triggerName := triggerRow.TriggerName
 
+		// Check if the trigger should be ignored (e.g. triggers an extension
+		// automatically creates on tracked tables). Ignored triggers are excluded
+		// from dump, plan generation, and drift detection alike.
+		if i.ignoreConfig != nil && i.ignoreConfig.ShouldIgnoreTrigger(triggerName) {
+			continue
+		}
+
 		// Find where to store this trigger: table, view, or ignored external table
 		targetDBSchema := schema.getOrCreateSchema(schemaName)
 		var triggerMap map[string]*Trigger

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -1592,7 +1592,7 @@ func (i *Inspector) buildTriggers(ctx context.Context, schema *IR, targetSchema 
 		schemaName := triggerRow.TriggerSchema
 		triggerName := triggerRow.TriggerName
 
-		// Check if the trigger should be ignored (e.g. triggers an extension
+		// Check if the trigger should be ignored (e.g. triggers that an extension
 		// automatically creates on tracked tables). Ignored triggers are excluded
 		// from dump, plan generation, and drift detection alike.
 		if i.ignoreConfig != nil && i.ignoreConfig.ShouldIgnoreTrigger(triggerName) {


### PR DESCRIPTION
## Summary

Adds a `[triggers]` section to `.pgschemaignore` that matches triggers by **name** (glob, with negation). Ignored triggers are filtered at the inspector, so they are excluded from **dump**, **plan generation**, and **drift detection** alike — pgschema neither creates, drops, nor reports them.

```toml
[triggers]
patterns = ["_vectorizer_src_trg_*"]
```

## Motivation (#407)

Extensions sometimes create triggers automatically on tables you manage — e.g. the [pgai](https://github.com/timescale/pgai) vectorizer adds `_vectorizer_src_trg_*` triggers to source tables. Without a way to ignore them, `pgschema plan` flags them for drop on every run. Ignoring by name keeps the rest of the table managed while leaving those triggers out-of-band.

## Implementation

Mirrors the existing per-object pattern just merged for constraints (#452):

- `ir/ignore.go` — `Triggers []string` field + `ShouldIgnoreTrigger(name)`
- `ir/inspector.go` — filter in `buildTriggers` (skips ignored triggers before they attach to any table/view)
- `cmd/util/ignoreloader.go` — `TriggerIgnoreConfig` struct + `TomlConfig` field + mapping
- `docs/cli/ignore.mdx` — new `## Triggers` section using the pgai example

## Tests

- Unit: trigger cases in `ir/ignore_test.go` and `cmd/util/ignoreloader_test.go`
- Integration: `TestIgnoreTriggers` (dump + plan) — a managed `products_set_updated_at` trigger stays, while `_vectorizer_src_trg_products` is excluded from dump and never flagged for drop

All unit tests, the new integration test, and `go vet` pass.

Fixes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)