### PR TITLE
fix: detect numeric precision/scale changes in column diff (#362)

### DIFF
--- a/internal/diff/column.go
+++ b/internal/diff/column.go
@@ -12,9 +12,15 @@ func (cd *ColumnDiff) generateColumnSQL(tableSchema, tableName string, targetSch
 	var statements []string
 	qualifiedTableName := getTableNameWithSchema(tableSchema, tableName, targetSchema)
 
-	// Handle data type changes - normalize types by stripping target schema prefix
-	oldType := stripSchemaPrefix(cd.Old.DataType, targetSchema)
-	newType := stripSchemaPrefix(cd.New.DataType, targetSchema)
+	// Handle data type changes - normalize types by stripping target schema prefix.
+	// Base type names (without modifiers) drive cast-compatibility decisions,
+	// while the full type strings (with numeric precision/scale, varchar length)
+	// drive change detection and the emitted TYPE clause - otherwise a
+	// numeric(18,6) -> numeric(20,6) change would be invisible here.
+	oldBaseType := stripSchemaPrefix(cd.Old.DataType, targetSchema)
+	newBaseType := stripSchemaPrefix(cd.New.DataType, targetSchema)
+	oldType := stripSchemaPrefix(comparableColumnType(cd.Old), targetSchema)
+	newType := stripSchemaPrefix(comparableColumnType(cd.New), targetSchema)
 
 	// Check if there's a type change AND the column has a default value
 	// When a USING clause is needed, we must: DROP DEFAULT -> ALTER TYPE -> SET DEFAULT
@@ -23,7 +29,7 @@ func (cd *ColumnDiff) generateColumnSQL(tableSchema, tableName string, targetSch
 	oldDefault := cd.Old.DefaultValue
 	newDefault := cd.New.DefaultValue
 	hasOldDefault := oldDefault != nil && *oldDefault != ""
-	needsUsing := hasTypeChange && needsUsingClause(oldType, newType)
+	needsUsing := hasTypeChange && needsUsingClause(oldBaseType, newBaseType)
 
 	// If type is changing with USING clause and there's an existing default, drop the default first
 	if needsUsing && hasOldDefault {
@@ -138,15 +144,31 @@ func needsUsingClause(oldType, newType string) bool {
 	return false
 }
 
+// comparableColumnType returns the column's data type including any
+// precision/scale/length modifiers, for use in type-change detection and
+// the emitted ALTER ... TYPE clause. Unlike formatColumnDataType it does
+// not expand SERIAL: serial is integer + sequence-default sugar, and
+// serial<->integer/identity transitions are handled by the sequence and
+// identity machinery rather than a TYPE change.
+func comparableColumnType(column *ir.Column) string {
+	if isSerialColumn(column) {
+		return column.DataType
+	}
+	return formatColumnDataType(column)
+}
+
 // columnsEqual compares two columns for equality
 // targetSchema is used to normalize type names before comparison
 func columnsEqual(old, new *ir.Column, targetSchema string) bool {
 	if old.Name != new.Name {
 		return false
 	}
-	// Normalize types by stripping target schema prefix before comparison
-	oldType := stripSchemaPrefix(old.DataType, targetSchema)
-	newType := stripSchemaPrefix(new.DataType, targetSchema)
+	// Normalize types by stripping target schema prefix before comparison.
+	// Use comparableColumnType so type modifiers (numeric precision/scale,
+	// varchar length) are included - DataType alone is just "numeric" for
+	// both numeric(18,6) and numeric(20,6).
+	oldType := stripSchemaPrefix(comparableColumnType(old), targetSchema)
+	newType := stripSchemaPrefix(comparableColumnType(new), targetSchema)
 	if oldType != newType {
 		return false
 	}

--- a/testdata/diff/create_table/alter_column_types/diff.sql
+++ b/testdata/diff/create_table/alter_column_types/diff.sql
@@ -19,3 +19,5 @@ ALTER TABLE user_pending_permissions ALTER COLUMN status TYPE action_type USING 
 ALTER TABLE user_pending_permissions ALTER COLUMN status SET DEFAULT 'pending'::action_type;
 
 ALTER TABLE user_pending_permissions ALTER COLUMN tags TYPE action_type[] USING tags::action_type[];
+
+ALTER TABLE user_pending_permissions ALTER COLUMN amount TYPE numeric(20,6);

--- a/testdata/diff/create_table/alter_column_types/new.sql
+++ b/testdata/diff/create_table/alter_column_types/new.sql
@@ -7,5 +7,6 @@ CREATE TABLE public.user_pending_permissions (
     object_ids_ints bigint[],
     action public.action_type,
     status public.action_type DEFAULT 'pending',
-    tags public.action_type[]
+    tags public.action_type[],
+    amount numeric(20,6) NOT NULL DEFAULT 0
 );

--- a/testdata/diff/create_table/alter_column_types/old.sql
+++ b/testdata/diff/create_table/alter_column_types/old.sql
@@ -5,5 +5,6 @@ CREATE TABLE public.user_pending_permissions (
     object_ids_ints integer[],
     action text,
     status text DEFAULT 'pending',
-    tags text[]
+    tags text[],
+    amount numeric(18,6) NOT NULL DEFAULT 0
 );

--- a/testdata/diff/create_table/alter_column_types/plan.json
+++ b/testdata/diff/create_table/alter_column_types/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.10.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "3af9d137d24bdf3ddf4b191cf2393ada9a71adb61e7fa88d779e2e751933a409"
+    "hash": "614655f95d349ec321da570d4e232db71f8bfb57404998153f9fd53720cd2acb"
   },
   "groups": [
     {
@@ -61,6 +61,12 @@
           "type": "table.column",
           "operation": "alter",
           "path": "public.user_pending_permissions.tags"
+        },
+        {
+          "sql": "ALTER TABLE user_pending_permissions ALTER COLUMN amount TYPE numeric(20,6);",
+          "type": "table.column",
+          "operation": "alter",
+          "path": "public.user_pending_permissions.amount"
         }
       ]
     }

--- a/testdata/diff/create_table/alter_column_types/plan.sql
+++ b/testdata/diff/create_table/alter_column_types/plan.sql
@@ -19,3 +19,5 @@ ALTER TABLE user_pending_permissions ALTER COLUMN status TYPE action_type USING 
 ALTER TABLE user_pending_permissions ALTER COLUMN status SET DEFAULT 'pending'::action_type;
 
 ALTER TABLE user_pending_permissions ALTER COLUMN tags TYPE action_type[] USING tags::action_type[];
+
+ALTER TABLE user_pending_permissions ALTER COLUMN amount TYPE numeric(20,6);

--- a/testdata/diff/create_table/alter_column_types/plan.txt
+++ b/testdata/diff/create_table/alter_column_types/plan.txt
@@ -10,6 +10,7 @@ Types:
 Tables:
   ~ user_pending_permissions
     ~ action (column)
+    ~ amount (column)
     ~ id (column)
     ~ object_ids_ints (column)
     ~ status (column)
@@ -40,3 +41,5 @@ ALTER TABLE user_pending_permissions ALTER COLUMN status TYPE action_type USING 
 ALTER TABLE user_pending_permissions ALTER COLUMN status SET DEFAULT 'pending'::action_type;
 
 ALTER TABLE user_pending_permissions ALTER COLUMN tags TYPE action_type[] USING tags::action_type[];
+
+ALTER TABLE user_pending_permissions ALTER COLUMN amount TYPE numeric(20,6);


### PR DESCRIPTION
Fixes #362.

## Problem

pgschema did not detect changes to a column's numeric precision or scale. Changing `NUMERIC(18,6)` → `NUMERIC(20,6)` produced an empty plan — the change was silently dropped.

## Root cause

For built-in `pg_catalog` types like `numeric`, the inspector stores `Column.DataType` as the bare type name (`"numeric"`), with precision/scale in separate `Precision`/`Scale` fields. `columnsEqual` only compared `DataType`, so `numeric(18,6)` and `numeric(20,6)` compared equal → no diff. A second latent bug: `generateColumnSQL` built the `ALTER ... TYPE` clause from the bare `DataType`, which would have emitted `TYPE numeric` and dropped the precision.

(Note: `varchar` length was already handled because `columnsEqual` compares `MaxLength` separately — this gap was specific to numeric precision/scale.)

## Fix

- Add `comparableColumnType()`, which returns the type **with** precision/scale/length modifiers but does **not** expand `SERIAL` (serial↔integer/identity transitions are handled by the sequence/identity machinery, not a TYPE change).
- `columnsEqual` and `generateColumnSQL` use it for change detection and the emitted `TYPE` clause; cast-compatibility (`needsUsingClause`) still keys off the bare base type names.

## Test

Extended the existing `testdata/diff/create_table/alter_column_types` case with an `amount numeric(18,6)` → `numeric(20,6)` column, which now correctly produces:

```sql
ALTER TABLE user_pending_permissions ALTER COLUMN amount TYPE numeric(20,6);
```

## Verification

- `TestDiffFromFiles` (full diff suite): ok
- `TestPlanAndApply` (full integration suite): ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)