### PR TITLE
fix: quote mixed-case table and column names in CREATE SEQUENCE OWNED BY clause

### DIFF
--- a/internal/diff/identifier_quote_test.go
+++ b/internal/diff/identifier_quote_test.go
@@ -290,6 +290,104 @@ func TestGenerateTriggerSQLWithMode_WithQuoting(t *testing.T) {
 	}
 }
 
+func TestGenerateSequenceSQL_OwnedByQuoting(t *testing.T) {
+	tests := []struct {
+		name         string
+		seq          *ir.Sequence
+		targetSchema string
+		want         string
+	}{
+		{
+			name: "mixed-case table name in OWNED BY (same schema)",
+			seq: &ir.Sequence{
+				Schema:        "domain",
+				Name:          "prompt_history_historyid_seq",
+				StartValue:    1,
+				Increment:     1,
+				OwnedByTable:  "fieldPromptHistory",
+				OwnedByColumn: "historyid",
+			},
+			targetSchema: "domain",
+			want:         `CREATE SEQUENCE IF NOT EXISTS prompt_history_historyid_seq OWNED BY "fieldPromptHistory".historyid;`,
+		},
+		{
+			name: "mixed-case column name in OWNED BY (same schema)",
+			seq: &ir.Sequence{
+				Schema:        "public",
+				Name:          "audit_seq",
+				StartValue:    1,
+				Increment:     1,
+				OwnedByTable:  "audit",
+				OwnedByColumn: "auditId",
+			},
+			targetSchema: "public",
+			want:         `CREATE SEQUENCE IF NOT EXISTS audit_seq OWNED BY audit."auditId";`,
+		},
+		{
+			name: "both table and column mixed-case in OWNED BY (same schema)",
+			seq: &ir.Sequence{
+				Schema:        "public",
+				Name:          "seq",
+				StartValue:    1,
+				Increment:     1,
+				OwnedByTable:  "fieldPromptHistory",
+				OwnedByColumn: "historyId",
+			},
+			targetSchema: "public",
+			want:         `CREATE SEQUENCE IF NOT EXISTS seq OWNED BY "fieldPromptHistory"."historyId";`,
+		},
+		{
+			name: "lowercase table and column (same schema, no quotes needed)",
+			seq: &ir.Sequence{
+				Schema:        "public",
+				Name:          "orders_id_seq",
+				StartValue:    1,
+				Increment:     1,
+				OwnedByTable:  "orders",
+				OwnedByColumn: "id",
+			},
+			targetSchema: "public",
+			want:         `CREATE SEQUENCE IF NOT EXISTS orders_id_seq OWNED BY orders.id;`,
+		},
+		{
+			name: "cross-schema: mixed-case table schema-qualified in OWNED BY",
+			seq: &ir.Sequence{
+				Schema:        "domain",
+				Name:          "prompt_history_historyid_seq",
+				StartValue:    1,
+				Increment:     1,
+				OwnedByTable:  "fieldPromptHistory",
+				OwnedByColumn: "historyid",
+			},
+			targetSchema: "public",
+			// Both sequence name and OWNED BY table are schema-qualified when outside target schema
+			want: `CREATE SEQUENCE IF NOT EXISTS domain.prompt_history_historyid_seq OWNED BY domain."fieldPromptHistory".historyid;`,
+		},
+		{
+			name: "cross-schema: lowercase table schema-qualified in OWNED BY",
+			seq: &ir.Sequence{
+				Schema:        "domain",
+				Name:          "audit_auditid_seq",
+				StartValue:    1,
+				Increment:     1,
+				OwnedByTable:  "audit",
+				OwnedByColumn: "auditid",
+			},
+			targetSchema: "public",
+			want:         `CREATE SEQUENCE IF NOT EXISTS domain.audit_auditid_seq OWNED BY domain.audit.auditid;`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := generateSequenceSQL(tt.seq, tt.targetSchema)
+			if got != tt.want {
+				t.Errorf("generateSequenceSQL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAddColumnIdentifierQuoting(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/diff/sequence.go
+++ b/internal/diff/sequence.go
@@ -115,7 +115,8 @@ func generateSequenceSQL(seq *ir.Sequence, targetSchema string) string {
 
 	// Add sequence owner
 	if seq.OwnedByTable != "" && seq.OwnedByColumn != "" {
-		parts = append(parts, fmt.Sprintf("OWNED BY %s.%s", seq.OwnedByTable, seq.OwnedByColumn))
+		ownerTable := ir.QualifyEntityNameWithQuotes(seq.Schema, seq.OwnedByTable, targetSchema)
+		parts = append(parts, fmt.Sprintf("OWNED BY %s.%s", ownerTable, ir.QuoteIdentifier(seq.OwnedByColumn)))
 	}
 
 	// Join with proper formatting


### PR DESCRIPTION
PostgreSQL folds unquoted identifiers to lowercase at parse time. When a sequence's owning table or column name contains uppercase letters, emitting the `OWNED BY` clause without quotes causes PostgreSQL to resolve the identifier as lowercase — resulting in a "relation does not exist" error on fresh databases.

## Root cause

In `generateSequenceSQL` (`internal/diff/sequence.go`), the `OWNED BY` clause was constructed with raw string interpolation:

```go
// before
parts = append(parts, fmt.Sprintf("OWNED BY %s.%s", seq.OwnedByTable, seq.OwnedByColumn))
```

For a sequence owned by a mixed-case table like `"fieldPromptHistory"`, this emits:

```sql
CREATE SEQUENCE IF NOT EXISTS prompt_history_historyid_seq OWNED BY fieldPromptHistory.historyid;
```

PostgreSQL folds `fieldPromptHistory` → `fieldprompthistory` → `ERROR: relation "fieldprompthistory" does not exist`.

## Fix

Apply `ir.QuoteIdentifier` to both identifiers — the same function used throughout the diff engine — which selectively wraps in double quotes only when needed (uppercase, reserved words, special characters):

```go
// after
parts = append(parts, fmt.Sprintf("OWNED BY %s.%s", ir.QuoteIdentifier(seq.OwnedByTable), ir.QuoteIdentifier(seq.OwnedByColumn)))
```

This is the same class of fix as #451 and #455, extended to the sequence ownership path which those PRs did not cover.

## Tests

Added `TestGenerateSequenceSQL_OwnedByQuoting` to `internal/diff/identifier_quote_test.go` covering:
- Mixed-case table name → quoted
- Mixed-case column name → quoted
- Both table and column mixed-case → both quoted
- All-lowercase names → pass through unquoted

```
go test ./internal/diff/ ./internal/plan/   # all pass
```