### PR TITLE
fix: preserve DEFERRABLE on UNIQUE/PRIMARY KEY constraints (#404)

### DIFF
--- a/internal/diff/constraint.go
+++ b/internal/diff/constraint.go
@@ -25,7 +25,7 @@ func generateConstraintSQL(constraint *ir.Constraint, targetSchema string) strin
 		if constraint.IsTemporal && len(cols) > 0 {
 			cols[len(cols)-1] = cols[len(cols)-1] + " WITHOUT OVERLAPS"
 		}
-		return fmt.Sprintf("CONSTRAINT %s PRIMARY KEY (%s)", ir.QuoteIdentifier(constraint.Name), strings.Join(cols, ", "))
+		return fmt.Sprintf("CONSTRAINT %s PRIMARY KEY (%s)%s", ir.QuoteIdentifier(constraint.Name), strings.Join(cols, ", "), deferrableClause(constraint))
 	case ir.ConstraintTypeUnique:
 		// Always include CONSTRAINT name to be explicit and consistent
 		cols := getColumnNames(constraint.Columns)
@@ -36,7 +36,7 @@ func generateConstraintSQL(constraint *ir.Constraint, targetSchema string) strin
 		if constraint.NullsNotDistinct {
 			modifier = " NULLS NOT DISTINCT"
 		}
-		return fmt.Sprintf("CONSTRAINT %s UNIQUE%s (%s)", ir.QuoteIdentifier(constraint.Name), modifier, strings.Join(cols, ", "))
+		return fmt.Sprintf("CONSTRAINT %s UNIQUE%s (%s)%s", ir.QuoteIdentifier(constraint.Name), modifier, strings.Join(cols, ", "), deferrableClause(constraint))
 	case ir.ConstraintTypeForeignKey:
 		// Always include CONSTRAINT name to preserve explicit FK names
 		// Use QualifyEntityNameWithQuotes to add schema qualifier when referencing tables in other schemas
@@ -63,13 +63,7 @@ func generateConstraintSQL(constraint *ir.Constraint, targetSchema string) strin
 			stmt += fmt.Sprintf(" ON DELETE %s", constraint.DeleteRule)
 		}
 		// Add deferrable clause
-		if constraint.Deferrable {
-			if constraint.InitiallyDeferred {
-				stmt += " DEFERRABLE INITIALLY DEFERRED"
-			} else {
-				stmt += " DEFERRABLE"
-			}
-		}
+		stmt += deferrableClause(constraint)
 		// Add NOT VALID if needed
 		if !constraint.IsValid {
 			stmt += " NOT VALID"
@@ -93,6 +87,21 @@ func generateConstraintSQL(constraint *ir.Constraint, targetSchema string) strin
 	default:
 		return ""
 	}
+}
+
+// deferrableClause returns the " DEFERRABLE [INITIALLY DEFERRED]" suffix for a
+// constraint, or "" when it is not deferrable. PRIMARY KEY, UNIQUE, and FOREIGN
+// KEY constraints all support this; EXCLUDE constraints carry the clause inside
+// their full pg_get_constraintdef() text, so callers using ExclusionDefinition
+// must not append this on top of it.
+func deferrableClause(constraint *ir.Constraint) string {
+	if !constraint.Deferrable {
+		return ""
+	}
+	if constraint.InitiallyDeferred {
+		return " DEFERRABLE INITIALLY DEFERRED"
+	}
+	return " DEFERRABLE"
 }
 
 // getInlineConstraintsForTable returns constraints in the correct order: PRIMARY KEY, UNIQUE, FOREIGN KEY

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -802,13 +802,13 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			if len(constraint.Columns) == 1 && constraint.Columns[0].Name == column.Name {
 				switch constraint.Type {
 				case ir.ConstraintTypePrimaryKey:
-					inlineConstraint = fmt.Sprintf(" CONSTRAINT %s PRIMARY KEY", ir.QuoteIdentifier(constraint.Name))
+					inlineConstraint = fmt.Sprintf(" CONSTRAINT %s PRIMARY KEY%s", ir.QuoteIdentifier(constraint.Name), deferrableClause(constraint))
 				case ir.ConstraintTypeUnique:
 					modifier := ""
 					if constraint.NullsNotDistinct {
 						modifier = " NULLS NOT DISTINCT"
 					}
-					inlineConstraint = fmt.Sprintf(" CONSTRAINT %s UNIQUE%s", ir.QuoteIdentifier(constraint.Name), modifier)
+					inlineConstraint = fmt.Sprintf(" CONSTRAINT %s UNIQUE%s%s", ir.QuoteIdentifier(constraint.Name), modifier, deferrableClause(constraint))
 				case ir.ConstraintTypeForeignKey:
 					// For FK, use the generateForeignKeyClause with inline=true
 					fkClause := generateForeignKeyClause(constraint, targetSchema, true)

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -914,8 +914,8 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			if constraint.NullsNotDistinct {
 				modifier = " NULLS NOT DISTINCT"
 			}
-			sql := fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s UNIQUE%s (%s);",
-				tableName, ir.QuoteIdentifier(constraint.Name), modifier, strings.Join(columnNames, ", "))
+			sql := fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s UNIQUE%s (%s)%s;",
+				tableName, ir.QuoteIdentifier(constraint.Name), modifier, strings.Join(columnNames, ", "), deferrableClause(constraint))
 
 			context := &diffContext{
 				Type:                DiffTypeTableConstraint,
@@ -983,8 +983,8 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 				columnNames[len(columnNames)-1] = columnNames[len(columnNames)-1] + " WITHOUT OVERLAPS"
 			}
 			tableName := getTableNameWithSchema(td.Table.Schema, td.Table.Name, targetSchema)
-			sql := fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s PRIMARY KEY (%s);",
-				tableName, ir.QuoteIdentifier(constraint.Name), strings.Join(columnNames, ", "))
+			sql := fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s PRIMARY KEY (%s)%s;",
+				tableName, ir.QuoteIdentifier(constraint.Name), strings.Join(columnNames, ", "), deferrableClause(constraint))
 
 			context := &diffContext{
 				Type:                DiffTypeTableConstraint,
@@ -1046,8 +1046,8 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			if constraint.NullsNotDistinct {
 				modifier = " NULLS NOT DISTINCT"
 			}
-			addSQL = fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s UNIQUE%s (%s);",
-				tableName, ir.QuoteIdentifier(constraint.Name), modifier, strings.Join(columnNames, ", "))
+			addSQL = fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s UNIQUE%s (%s)%s;",
+				tableName, ir.QuoteIdentifier(constraint.Name), modifier, strings.Join(columnNames, ", "), deferrableClause(constraint))
 
 		case ir.ConstraintTypeCheck:
 			// Add CHECK constraint with ensured outer parentheses
@@ -1084,8 +1084,8 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			if constraint.IsTemporal && len(columnNames) > 0 {
 				columnNames[len(columnNames)-1] = columnNames[len(columnNames)-1] + " WITHOUT OVERLAPS"
 			}
-			addSQL = fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s PRIMARY KEY (%s);",
-				tableName, ir.QuoteIdentifier(constraint.Name), strings.Join(columnNames, ", "))
+			addSQL = fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s PRIMARY KEY (%s)%s;",
+				tableName, ir.QuoteIdentifier(constraint.Name), strings.Join(columnNames, ", "), deferrableClause(constraint))
 
 		case ir.ConstraintTypeExclusion:
 			addSQL = fmt.Sprintf("ALTER TABLE %s\nADD CONSTRAINT %s %s;",

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -504,6 +504,14 @@ func (i *Inspector) buildConstraints(ctx context.Context, schema *IR, targetSche
 				NullsNotDistinct: constraint.NullsNotDistinct.Bool, // PG15+ UNIQUE NULLS NOT DISTINCT
 			}
 
+			// Handle deferrable attributes. PRIMARY KEY, UNIQUE, FOREIGN KEY, and
+			// EXCLUDE constraints can all be DEFERRABLE; CHECK constraints cannot
+			// (condeferrable is always false for them). EXCLUDE carries the clause
+			// in its full pg_get_constraintdef() text, but we still record the
+			// fields so constraint comparison stays uniform across types.
+			c.Deferrable = constraint.Deferrable
+			c.InitiallyDeferred = constraint.InitiallyDeferred
+
 			// Handle foreign key references
 			if cType == ConstraintTypeForeignKey {
 				if refSchema := i.safeInterfaceToString(constraint.ForeignTableSchema); refSchema != "" && refSchema != "<nil>" {
@@ -518,9 +526,6 @@ func (i *Inspector) buildConstraints(ctx context.Context, schema *IR, targetSche
 				if updateRule := i.safeInterfaceToString(constraint.UpdateRule); updateRule != "" && updateRule != "<nil>" {
 					c.UpdateRule = updateRule
 				}
-				// Handle deferrable attributes for foreign key constraints
-				c.Deferrable = constraint.Deferrable
-				c.InitiallyDeferred = constraint.InitiallyDeferred
 			}
 
 			// Handle check constraints

--- a/testdata/diff/create_table/add_unique_constraint/diff.sql
+++ b/testdata/diff/create_table/add_unique_constraint/diff.sql
@@ -1,5 +1,7 @@
 ALTER TABLE user_sessions
-ADD CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint);
+ADD CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint) DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE user_sessions DROP CONSTRAINT user_sessions_user_device_key;
 
 ALTER TABLE user_sessions
-ADD CONSTRAINT user_sessions_user_device_key UNIQUE (user_id, device_fingerprint);
+ADD CONSTRAINT user_sessions_user_device_key UNIQUE (user_id, device_fingerprint) DEFERRABLE INITIALLY DEFERRED;

--- a/testdata/diff/create_table/add_unique_constraint/diff.sql
+++ b/testdata/diff/create_table/add_unique_constraint/diff.sql
@@ -1,4 +1,7 @@
 ALTER TABLE user_sessions
+ADD COLUMN api_key text NOT NULL CONSTRAINT user_sessions_api_key_key UNIQUE DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE user_sessions
 ADD CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint) DEFERRABLE INITIALLY DEFERRED;
 
 ALTER TABLE user_sessions DROP CONSTRAINT user_sessions_user_device_key;

--- a/testdata/diff/create_table/add_unique_constraint/new.sql
+++ b/testdata/diff/create_table/add_unique_constraint/new.sql
@@ -3,6 +3,8 @@ CREATE TABLE public.user_sessions (
     session_token text NOT NULL,
     device_fingerprint text NOT NULL,
     created_at timestamp NOT NULL,
+    api_key text NOT NULL,
     CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint) DEFERRABLE INITIALLY DEFERRED,
-    CONSTRAINT user_sessions_user_device_key UNIQUE (user_id, device_fingerprint) DEFERRABLE INITIALLY DEFERRED
+    CONSTRAINT user_sessions_user_device_key UNIQUE (user_id, device_fingerprint) DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT user_sessions_api_key_key UNIQUE (api_key) DEFERRABLE INITIALLY DEFERRED
 );

--- a/testdata/diff/create_table/add_unique_constraint/new.sql
+++ b/testdata/diff/create_table/add_unique_constraint/new.sql
@@ -3,6 +3,6 @@ CREATE TABLE public.user_sessions (
     session_token text NOT NULL,
     device_fingerprint text NOT NULL,
     created_at timestamp NOT NULL,
-    CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint),
-    CONSTRAINT user_sessions_user_device_key UNIQUE (user_id, device_fingerprint)
+    CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint) DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT user_sessions_user_device_key UNIQUE (user_id, device_fingerprint) DEFERRABLE INITIALLY DEFERRED
 );

--- a/testdata/diff/create_table/add_unique_constraint/old.sql
+++ b/testdata/diff/create_table/add_unique_constraint/old.sql
@@ -2,5 +2,6 @@ CREATE TABLE public.user_sessions (
     user_id integer NOT NULL,
     session_token text NOT NULL,
     device_fingerprint text NOT NULL,
-    created_at timestamp NOT NULL
+    created_at timestamp NOT NULL,
+    CONSTRAINT user_sessions_user_device_key UNIQUE (user_id, device_fingerprint)
 );

--- a/testdata/diff/create_table/add_unique_constraint/plan.json
+++ b/testdata/diff/create_table/add_unique_constraint/plan.json
@@ -3,19 +3,25 @@
   "pgschema_version": "1.10.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "5b049e926c4be3b7398c0f37d3f1c3b84c6721f3e07be244cfc34b568000e803"
+    "hash": "070c561462cc0a3c6adeaab240ac374d64b6c984fe35cfc7499a677fabc16478"
   },
   "groups": [
     {
       "steps": [
         {
-          "sql": "ALTER TABLE user_sessions\nADD CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint);",
+          "sql": "ALTER TABLE user_sessions\nADD CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint) DEFERRABLE INITIALLY DEFERRED;",
           "type": "table.constraint",
           "operation": "create",
           "path": "public.user_sessions.user_sessions_token_device_key"
         },
         {
-          "sql": "ALTER TABLE user_sessions\nADD CONSTRAINT user_sessions_user_device_key UNIQUE (user_id, device_fingerprint);",
+          "sql": "ALTER TABLE user_sessions DROP CONSTRAINT user_sessions_user_device_key;",
+          "type": "table.constraint",
+          "operation": "drop",
+          "path": "public.user_sessions.user_sessions_user_device_key"
+        },
+        {
+          "sql": "ALTER TABLE user_sessions\nADD CONSTRAINT user_sessions_user_device_key UNIQUE (user_id, device_fingerprint) DEFERRABLE INITIALLY DEFERRED;",
           "type": "table.constraint",
           "operation": "create",
           "path": "public.user_sessions.user_sessions_user_device_key"

--- a/testdata/diff/create_table/add_unique_constraint/plan.json
+++ b/testdata/diff/create_table/add_unique_constraint/plan.json
@@ -9,6 +9,12 @@
     {
       "steps": [
         {
+          "sql": "ALTER TABLE user_sessions\nADD COLUMN api_key text NOT NULL CONSTRAINT user_sessions_api_key_key UNIQUE DEFERRABLE INITIALLY DEFERRED;",
+          "type": "table.column",
+          "operation": "create",
+          "path": "public.user_sessions.api_key"
+        },
+        {
           "sql": "ALTER TABLE user_sessions\nADD CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint) DEFERRABLE INITIALLY DEFERRED;",
           "type": "table.constraint",
           "operation": "create",

--- a/testdata/diff/create_table/add_unique_constraint/plan.sql
+++ b/testdata/diff/create_table/add_unique_constraint/plan.sql
@@ -1,5 +1,7 @@
 ALTER TABLE user_sessions
-ADD CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint);
+ADD CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint) DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE user_sessions DROP CONSTRAINT user_sessions_user_device_key;
 
 ALTER TABLE user_sessions
-ADD CONSTRAINT user_sessions_user_device_key UNIQUE (user_id, device_fingerprint);
+ADD CONSTRAINT user_sessions_user_device_key UNIQUE (user_id, device_fingerprint) DEFERRABLE INITIALLY DEFERRED;

--- a/testdata/diff/create_table/add_unique_constraint/plan.sql
+++ b/testdata/diff/create_table/add_unique_constraint/plan.sql
@@ -1,4 +1,7 @@
 ALTER TABLE user_sessions
+ADD COLUMN api_key text NOT NULL CONSTRAINT user_sessions_api_key_key UNIQUE DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE user_sessions
 ADD CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint) DEFERRABLE INITIALLY DEFERRED;
 
 ALTER TABLE user_sessions DROP CONSTRAINT user_sessions_user_device_key;

--- a/testdata/diff/create_table/add_unique_constraint/plan.txt
+++ b/testdata/diff/create_table/add_unique_constraint/plan.txt
@@ -5,12 +5,16 @@ Summary by type:
 
 Tables:
   ~ user_sessions
+    + api_key (column)
     + user_sessions_token_device_key (constraint)
     - user_sessions_user_device_key (constraint)
     + user_sessions_user_device_key (constraint)
 
 DDL to be executed:
 --------------------------------------------------
+
+ALTER TABLE user_sessions
+ADD COLUMN api_key text NOT NULL CONSTRAINT user_sessions_api_key_key UNIQUE DEFERRABLE INITIALLY DEFERRED;
 
 ALTER TABLE user_sessions
 ADD CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint) DEFERRABLE INITIALLY DEFERRED;

--- a/testdata/diff/create_table/add_unique_constraint/plan.txt
+++ b/testdata/diff/create_table/add_unique_constraint/plan.txt
@@ -6,13 +6,16 @@ Summary by type:
 Tables:
   ~ user_sessions
     + user_sessions_token_device_key (constraint)
+    - user_sessions_user_device_key (constraint)
     + user_sessions_user_device_key (constraint)
 
 DDL to be executed:
 --------------------------------------------------
 
 ALTER TABLE user_sessions
-ADD CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint);
+ADD CONSTRAINT user_sessions_token_device_key UNIQUE (session_token, device_fingerprint) DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE user_sessions DROP CONSTRAINT user_sessions_user_device_key;
 
 ALTER TABLE user_sessions
-ADD CONSTRAINT user_sessions_user_device_key UNIQUE (user_id, device_fingerprint);
+ADD CONSTRAINT user_sessions_user_device_key UNIQUE (user_id, device_fingerprint) DEFERRABLE INITIALLY DEFERRED;

--- a/testdata/dump/issue_83_explicit_constraint_name/pgdump.sql
+++ b/testdata/dump/issue_83_explicit_constraint_name/pgdump.sql
@@ -306,6 +306,14 @@ ALTER TABLE ONLY public.authors
 
 
 --
+-- Name: authors authors_name_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.authors
+    ADD CONSTRAINT authors_name_key UNIQUE (name) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
 -- Name: books books_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 

--- a/testdata/dump/issue_83_explicit_constraint_name/pgschema.sql
+++ b/testdata/dump/issue_83_explicit_constraint_name/pgschema.sql
@@ -13,7 +13,8 @@
 CREATE TABLE IF NOT EXISTS authors (
     id SERIAL,
     name varchar(255) NOT NULL,
-    CONSTRAINT authors_pkey PRIMARY KEY (id)
+    CONSTRAINT authors_pkey PRIMARY KEY (id),
+    CONSTRAINT authors_name_key UNIQUE (name) DEFERRABLE INITIALLY DEFERRED
 );
 
 --

--- a/testdata/dump/issue_83_explicit_constraint_name/raw.sql
+++ b/testdata/dump/issue_83_explicit_constraint_name/raw.sql
@@ -104,3 +104,12 @@ CREATE TABLE books (
 ALTER TABLE ONLY books
     ADD CONSTRAINT fk_book_author_deferred
     FOREIGN KEY (author_id) REFERENCES authors(id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
+-- Case 5: Named UNIQUE constraint with DEFERRABLE option (issue #404)
+-- Tests that DEFERRABLE INITIALLY DEFERRED is preserved on non-FK constraints,
+-- not just foreign keys
+--
+ALTER TABLE ONLY authors
+    ADD CONSTRAINT authors_name_key UNIQUE (name) DEFERRABLE INITIALLY DEFERRED;


### PR DESCRIPTION
## Summary

`DEFERRABLE [INITIALLY DEFERRED]` was tracked and emitted **only for FOREIGN KEY** constraints. For `UNIQUE` and `PRIMARY KEY` constraints it was silently dropped at every stage (reported in #404):

1. **dump** — stripped the clause from output
2. **plan** — reported "No changes detected" when only deferrability differed
3. **apply** — created non-deferrable constraints

### Root cause (two gaps)

- **`ir/inspector.go`** — `condeferrable`/`condeferred` were copied into the IR only inside the `if cType == ConstraintTypeForeignKey` branch, so every non-FK constraint looked non-deferrable.
- **`internal/diff`** — the inline (`CREATE TABLE`), `ADD CONSTRAINT`, and modified (drop+recreate) emission paths appended the clause only for FK. The modify path was additionally **non-convergent**: even after the inspector fix, recreating a unique constraint would drop `DEFERRABLE`, so the next plan would report the same diff forever.

`EXCLUDE` constraints were already correct because they emit the full `pg_get_constraintdef()` text, which embeds the clause.

## Fix

- `inspector.go`: populate `Deferrable`/`InitiallyDeferred` for all constraint types (CHECK is never deferrable; EXCLUDE keeps using its full def).
- `constraint.go`: add a shared `deferrableClause()` helper, apply it to the inline `PRIMARY KEY`/`UNIQUE` branches, and reuse it for FK.
- `table.go`: append the clause in the `ADD` and modify `UNIQUE`/`PRIMARY KEY` branches.

## Test plan

Amended existing fixtures (no brand-new test dirs):

- **`testdata/dump/issue_83_explicit_constraint_name`** — added a deferrable `UNIQUE` constraint to the dump fixture; verifies the clause survives a dump.
- **`testdata/diff/create_table/add_unique_constraint`** — now covers both **adding** a new deferrable `UNIQUE` and **modifying** an existing `UNIQUE` to deferrable (drop+recreate). `TestPlanAndApply` exercises the round-trip apply, confirming the plan converges.

```bash
go test ./cmd/dump -run TestDumpCommand_Issue83
PGSCHEMA_TEST_FILTER="create_table/add_unique_constraint" go test ./internal/diff -run TestDiffFromFiles
PGSCHEMA_TEST_FILTER="create_table/add_unique_constraint" go test ./cmd -run TestPlanAndApply
```

All green; `create_table/` and `online/` diff suites pass with no regressions.

Fixes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)