### PR TITLE
fix: emit non-concurrent CREATE INDEX on partitioned parents (#418)

### DIFF
--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -321,3 +321,41 @@ func TestPlanDebugJSONRoundTrip(t *testing.T) {
 		t.Errorf("Group count mismatch: got %d, want %d", len(loaded2.Groups), len(loaded.Groups))
 	}
 }
+
+// TestPartitionedParentIndexRewrite verifies that index rewrites on partitioned
+// parents fall back to the canonical synchronous DDL instead of emitting
+// CREATE INDEX CONCURRENTLY, which PostgreSQL rejects with SQLSTATE 0A000 (#418).
+func TestPartitionedParentIndexRewrite(t *testing.T) {
+	regular := &ir.Index{Schema: "public", Table: "events", Name: "events_idx",
+		Type: ir.IndexTypeRegular, Columns: []*ir.IndexColumn{{Name: "occurred"}}}
+	partitioned := *regular
+	partitioned.IsPartitioned = true
+
+	// CREATE path
+	if steps := generateIndexRewrite(&partitioned); steps != nil {
+		t.Errorf("generateIndexRewrite on partitioned parent: got %d steps, want nil (synchronous fallback)", len(steps))
+	}
+	if steps := generateIndexRewrite(regular); len(steps) == 0 {
+		t.Error("generateIndexRewrite on regular table: want concurrent rewrite steps, got nil")
+	} else if !strings.Contains(steps[0].SQL, "CONCURRENTLY") {
+		t.Errorf("generateIndexRewrite on regular table: expected CONCURRENTLY, got %q", steps[0].SQL)
+	}
+
+	// ALTER/replacement path (source is new index)
+	if steps := generateIndexChangeRewriteFromIndex(&partitioned); steps != nil {
+		t.Errorf("generateIndexChangeRewriteFromIndex on partitioned parent: got %d steps, want nil", len(steps))
+	}
+	if steps := generateIndexChangeRewriteFromIndex(regular); len(steps) == 0 {
+		t.Error("generateIndexChangeRewriteFromIndex on regular table: want rewrite steps, got nil")
+	}
+
+	// ALTER/replacement path (source is IndexDiff)
+	partDiff := &diff.IndexDiff{Old: &partitioned, New: &partitioned}
+	if steps := generateIndexChangeRewrite(partDiff); steps != nil {
+		t.Errorf("generateIndexChangeRewrite on partitioned parent: got %d steps, want nil", len(steps))
+	}
+	regDiff := &diff.IndexDiff{Old: regular, New: regular}
+	if steps := generateIndexChangeRewrite(regDiff); len(steps) == 0 {
+		t.Error("generateIndexChangeRewrite on regular table: want rewrite steps, got nil")
+	}
+}

--- a/internal/plan/rewrite.go
+++ b/internal/plan/rewrite.go
@@ -137,6 +137,13 @@ func generateIndexRewrite(index *ir.Index) []RewriteStep {
 
 // generateIndexChangeRewriteFromIndex generates rewrite steps for index replacement when source is new index
 func generateIndexChangeRewriteFromIndex(index *ir.Index) []RewriteStep {
+	// PostgreSQL rejects CREATE INDEX CONCURRENTLY on partitioned parents
+	// (SQLSTATE 0A000). Fall back to the canonical synchronous DROP/CREATE
+	// (returning nil here makes the plan emit the non-concurrent statements).
+	if index.IsPartitioned {
+		return nil
+	}
+
 	// For index replacements, we need to create new index, wait, drop old, rename
 	tempIndexName := index.Name + "_pgschema_new"
 
@@ -176,6 +183,13 @@ func generateIndexChangeRewriteFromIndex(index *ir.Index) []RewriteStep {
 
 // generateIndexChangeRewrite generates rewrite steps for index modifications
 func generateIndexChangeRewrite(indexDiff *diff.IndexDiff) []RewriteStep {
+	// PostgreSQL rejects CREATE INDEX CONCURRENTLY on partitioned parents
+	// (SQLSTATE 0A000). Fall back to the canonical synchronous DROP/CREATE
+	// (returning nil here makes the plan emit the non-concurrent statements).
+	if indexDiff.New.IsPartitioned {
+		return nil
+	}
+
 	// For index changes, we need to create new index, wait, drop old, rename
 	tempIndexName := indexDiff.New.Name + "_pgschema_new"
 

--- a/internal/plan/rewrite.go
+++ b/internal/plan/rewrite.go
@@ -108,6 +108,13 @@ func generateRewrite(d diff.Diff, newlyCreatedTables map[string]bool, newlyCreat
 
 // generateIndexRewrite generates rewrite steps for CREATE INDEX operations
 func generateIndexRewrite(index *ir.Index) []RewriteStep {
+	// PostgreSQL rejects CREATE INDEX CONCURRENTLY on partitioned parents
+	// (SQLSTATE 0A000). Fall back to the canonical synchronous CREATE INDEX
+	// (returning nil here makes the plan emit the non-concurrent statement).
+	if index.IsPartitioned {
+		return nil
+	}
+
 	// Generate concurrent SQL
 	concurrentSQL := generateIndexSQL(index, true) // With CONCURRENTLY
 	waitSQL := generateIndexWaitQueryWithName(index.Name)

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -835,6 +835,10 @@ func (i *Inspector) buildIndexes(ctx context.Context, schema *IR, targetSchema s
 
 		// Add index to table or materialized view
 		if table, exists := dbSchema.Tables[tableName]; exists {
+			// Track whether the index targets a partitioned parent. PostgreSQL does
+			// not allow CREATE INDEX CONCURRENTLY on partitioned parents, so the
+			// online rewrite must emit a synchronous CREATE INDEX for these.
+			index.IsPartitioned = table.IsPartitioned
 			table.Indexes[indexName] = index
 		} else if view, exists := dbSchema.Views[tableName]; exists && view.Materialized {
 			// Initialize Indexes map if nil

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -259,6 +259,7 @@ type Index struct {
 	IsExpression     bool     `json:"is_expression"`                // functional/expression index
 	Where            string   `json:"where,omitempty"`              // partial index condition
 	NullsNotDistinct bool     `json:"nulls_not_distinct,omitempty"` // NULLS NOT DISTINCT (PG15+)
+	IsPartitioned    bool     `json:"is_partitioned,omitempty"`     // index target is a partitioned parent (relkind 'p')
 	Comment          string   `json:"comment,omitempty"`
 }
 

--- a/testdata/diff/online/issue_418_partitioned_parent_index/diff.sql
+++ b/testdata/diff/online/issue_418_partitioned_parent_index/diff.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS events_payload_idx ON events USING gin (payload);
+CREATE INDEX IF NOT EXISTS events_2026_04_payload_idx ON events_2026_04 USING gin (payload);

--- a/testdata/diff/online/issue_418_partitioned_parent_index/new.sql
+++ b/testdata/diff/online/issue_418_partitioned_parent_index/new.sql
@@ -1,0 +1,10 @@
+CREATE TABLE public.events (
+    id bigint NOT NULL,
+    occurred timestamp with time zone NOT NULL,
+    payload jsonb
+) PARTITION BY RANGE (occurred);
+
+CREATE TABLE public.events_2026_04 PARTITION OF public.events
+    FOR VALUES FROM ('2026-04-01') TO ('2026-05-01');
+
+CREATE INDEX events_payload_idx ON public.events USING gin (payload);

--- a/testdata/diff/online/issue_418_partitioned_parent_index/old.sql
+++ b/testdata/diff/online/issue_418_partitioned_parent_index/old.sql
@@ -1,0 +1,8 @@
+CREATE TABLE public.events (
+    id bigint NOT NULL,
+    occurred timestamp with time zone NOT NULL,
+    payload jsonb
+) PARTITION BY RANGE (occurred);
+
+CREATE TABLE public.events_2026_04 PARTITION OF public.events
+    FOR VALUES FROM ('2026-04-01') TO ('2026-05-01');

--- a/testdata/diff/online/issue_418_partitioned_parent_index/plan.json
+++ b/testdata/diff/online/issue_418_partitioned_parent_index/plan.json
@@ -1,0 +1,44 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.10.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "78af5157bfb48369c44c1028df6929fa7b3966b23a288d78ab8cd45a3953dd7d"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE INDEX IF NOT EXISTS events_payload_idx ON events USING gin (payload);",
+          "type": "table.index",
+          "operation": "create",
+          "path": "public.events.events_payload_idx"
+        }
+      ]
+    },
+    {
+      "steps": [
+        {
+          "sql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS events_2026_04_payload_idx ON events_2026_04 USING gin (payload);",
+          "type": "table.index",
+          "operation": "create",
+          "path": "public.events_2026_04.events_2026_04_payload_idx"
+        }
+      ]
+    },
+    {
+      "steps": [
+        {
+          "sql": "SELECT \n    COALESCE(i.indisvalid, false) as done,\n    CASE \n        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total\n        ELSE 0\n    END as progress\nFROM pg_class c\nLEFT JOIN pg_index i ON c.oid = i.indexrelid\nLEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid\nWHERE c.relname = 'events_2026_04_payload_idx';",
+          "directive": {
+            "type": "wait",
+            "message": "Creating index events_2026_04_payload_idx"
+          },
+          "type": "table.index",
+          "operation": "create",
+          "path": "public.events_2026_04.events_2026_04_payload_idx"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/online/issue_418_partitioned_parent_index/plan.sql
+++ b/testdata/diff/online/issue_418_partitioned_parent_index/plan.sql
@@ -1,0 +1,15 @@
+CREATE INDEX IF NOT EXISTS events_payload_idx ON events USING gin (payload);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS events_2026_04_payload_idx ON events_2026_04 USING gin (payload);
+
+-- pgschema:wait
+SELECT 
+    COALESCE(i.indisvalid, false) as done,
+    CASE 
+        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total
+        ELSE 0
+    END as progress
+FROM pg_class c
+LEFT JOIN pg_index i ON c.oid = i.indexrelid
+LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
+WHERE c.relname = 'events_2026_04_payload_idx';

--- a/testdata/diff/online/issue_418_partitioned_parent_index/plan.txt
+++ b/testdata/diff/online/issue_418_partitioned_parent_index/plan.txt
@@ -1,0 +1,32 @@
+Plan: 2 to modify.
+
+Summary by type:
+  tables: 2 to modify
+
+Tables:
+  ~ events
+    + events_payload_idx (index)
+  ~ events_2026_04
+    + events_2026_04_payload_idx (index)
+
+DDL to be executed:
+--------------------------------------------------
+
+-- Transaction Group #1
+CREATE INDEX IF NOT EXISTS events_payload_idx ON events USING gin (payload);
+
+-- Transaction Group #2
+CREATE INDEX CONCURRENTLY IF NOT EXISTS events_2026_04_payload_idx ON events_2026_04 USING gin (payload);
+
+-- Transaction Group #3
+-- pgschema:wait
+SELECT 
+    COALESCE(i.indisvalid, false) as done,
+    CASE 
+        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total
+        ELSE 0
+    END as progress
+FROM pg_class c
+LEFT JOIN pg_index i ON c.oid = i.indexrelid
+LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
+WHERE c.relname = 'events_2026_04_payload_idx';


### PR DESCRIPTION
## Summary

`pgschema apply` failed with `SQLSTATE 0A000` when adding an index to a partitioned parent table. The online-DDL rewrite unconditionally emitted `CREATE INDEX CONCURRENTLY` for any new index on an existing table, but PostgreSQL does not allow concurrent index builds on partitioned parents (`pg_class.relkind = 'p'`).

### Fix

- Added `Index.IsPartitioned`, populated by the inspector from the parent table's `IsPartitioned` flag (`ir/inspector.go`).
- `generateIndexRewrite` now falls back to the canonical synchronous `CREATE INDEX` (no `CONCURRENTLY`, no wait directive) when the index targets a partitioned parent (`internal/plan/rewrite.go`).
- Indexes on regular/leaf tables keep the concurrent online build, unchanged.

The brief `AccessExclusiveLock` during a synchronous build on the parent is the expected behavior for declarative SQL, as called out in the issue.

Fixes #418

## Test plan

New diff/plan test `testdata/diff/online/issue_418_partitioned_parent_index/`:

```bash
PGSCHEMA_TEST_FILTER="online/issue_418_partitioned_parent_index" go test ./internal/diff -run TestDiffFromFiles
PGSCHEMA_TEST_FILTER="online/issue_418_partitioned_parent_index" go test ./cmd -run TestPlanAndApply
```

The plan now emits `CREATE INDEX IF NOT EXISTS events_payload_idx ON events ...` (synchronous) for the partitioned parent, and `apply` against embedded PostgreSQL succeeds. The full `online/` suite passes across both diff and plan/apply paths (verified deterministic over repeated runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)