### PR TITLE
fix: skip internal per-partition FK constraints in dump (#409)

### DIFF
--- a/cmd/dump/dump_integration_test.go
+++ b/cmd/dump/dump_integration_test.go
@@ -158,6 +158,13 @@ func TestDumpCommand_Issue420VarcharArrayLengthModifier(t *testing.T) {
 	runExactMatchTest(t, "issue_420_varchar_array_length_modifier")
 }
 
+func TestDumpCommand_Issue409PartitionedFK(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	runExactMatchTest(t, "issue_409_partitioned_fk")
+}
+
 // Reproduces a bug where a column declared as `name` is dumped as `char[]`.
 // The inspector classifies any base type with pg_type.typelem <> 0 as an array,
 // but the `name` type has typelem = 18 (the OID of "char") despite not being an array.

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -358,6 +358,10 @@ LEFT JOIN pg_attribute fa ON fa.attrelid = c.confrelid AND fa.attnum = c.confkey
 WHERE n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
     AND n.nspname NOT LIKE 'pg_temp_%'
     AND n.nspname NOT LIKE 'pg_toast_temp_%'
+    -- Skip internal per-partition FK rows (conparentid != 0) that PostgreSQL
+    -- creates when a FK references a partitioned table. pg_dump omits these;
+    -- only the top-level FK (conparentid = 0) is a real, dumpable constraint.
+    AND (c.contype <> 'f' OR c.conparentid = 0)
 ORDER BY n.nspname, cl.relname, c.contype, c.conname, a.attnum;
 
 -- GetIndexes retrieves all indexes including regular and unique indexes created with CREATE INDEX
@@ -947,6 +951,10 @@ LEFT JOIN pg_namespace fn ON fcl.relnamespace = fn.oid
 LEFT JOIN pg_attribute fa ON fa.attrelid = c.confrelid AND fa.attnum = c.confkey[array_position(c.conkey, a.attnum)]
 LEFT JOIN pg_index i ON i.indexrelid = c.conindid
 WHERE n.nspname = $1
+    -- Skip internal per-partition FK rows (conparentid != 0) that PostgreSQL
+    -- creates when a FK references a partitioned table. pg_dump omits these;
+    -- only the top-level FK (conparentid = 0) is a real, dumpable constraint.
+    AND (c.contype <> 'f' OR c.conparentid = 0)
 ORDER BY n.nspname, cl.relname, c.contype, c.conname, a.attnum;
 
 -- GetSequencesForSchema retrieves all sequences for a specific schema

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -815,6 +815,10 @@ LEFT JOIN pg_attribute fa ON fa.attrelid = c.confrelid AND fa.attnum = c.confkey
 WHERE n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
     AND n.nspname NOT LIKE 'pg_temp_%'
     AND n.nspname NOT LIKE 'pg_toast_temp_%'
+    -- Skip internal per-partition FK rows (conparentid != 0) that PostgreSQL
+    -- creates when a FK references a partitioned table. pg_dump omits these;
+    -- only the top-level FK (conparentid = 0) is a real, dumpable constraint.
+    AND (c.contype <> 'f' OR c.conparentid = 0)
 ORDER BY n.nspname, cl.relname, c.contype, c.conname, a.attnum
 `
 
@@ -938,6 +942,10 @@ LEFT JOIN pg_namespace fn ON fcl.relnamespace = fn.oid
 LEFT JOIN pg_attribute fa ON fa.attrelid = c.confrelid AND fa.attnum = c.confkey[array_position(c.conkey, a.attnum)]
 LEFT JOIN pg_index i ON i.indexrelid = c.conindid
 WHERE n.nspname = $1
+    -- Skip internal per-partition FK rows (conparentid != 0) that PostgreSQL
+    -- creates when a FK references a partitioned table. pg_dump omits these;
+    -- only the top-level FK (conparentid = 0) is a real, dumpable constraint.
+    AND (c.contype <> 'f' OR c.conparentid = 0)
 ORDER BY n.nspname, cl.relname, c.contype, c.conname, a.attnum
 `
 

--- a/testdata/dump/issue_409_partitioned_fk/manifest.json
+++ b/testdata/dump/issue_409_partitioned_fk/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "issue_409_partitioned_fk",
+  "description": "pgschema dump emits internal per-partition FK constraints when a foreign key references a partitioned table",
+  "source": "https://github.com/pgplex/pgschema/issues/409",
+  "notes": [
+    "A FK referencing a partitioned table causes PostgreSQL to create one extra pg_constraint row per partition with conparentid != 0; pg_dump omits these and only emits the top-level FK (conparentid = 0).",
+    "The constraint queries in ir/queries now filter FK rows with (c.contype <> 'f' OR c.conparentid = 0) to match pg_dump.",
+    "Without the fix, dump produced bogus event_..._fkey1 / event_..._fkey2 constraints referencing individual partitions, which also left dangling REFERENCES when those partitions were excluded via .pgschemaignore."
+  ]
+}

--- a/testdata/dump/issue_409_partitioned_fk/pgdump.sql
+++ b/testdata/dump/issue_409_partitioned_fk/pgdump.sql
@@ -1,0 +1,55 @@
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+-- SET transaction_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: session; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.session (
+    id bigint NOT NULL,
+    started_at timestamp with time zone NOT NULL
+)
+PARTITION BY RANGE (started_at);
+
+ALTER TABLE ONLY public.session
+    ADD CONSTRAINT session_pkey PRIMARY KEY (id, started_at);
+
+--
+-- Name: event; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.event (
+    session_id bigint NOT NULL,
+    session_started_at timestamp with time zone NOT NULL
+);
+
+ALTER TABLE ONLY public.event
+    ADD CONSTRAINT event_session_id_session_started_at_fkey FOREIGN KEY (session_id, session_started_at) REFERENCES public.session(id, started_at);
+
+--
+-- Name: session_2026_01; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.session_2026_01 PARTITION OF public.session
+FOR VALUES FROM ('2026-01-01') TO ('2026-02-01');
+
+--
+-- Name: session_2026_02; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.session_2026_02 PARTITION OF public.session
+FOR VALUES FROM ('2026-02-01') TO ('2026-03-01');
+
+--
+-- PostgreSQL database dump complete
+--

--- a/testdata/dump/issue_409_partitioned_fk/pgschema.sql
+++ b/testdata/dump/issue_409_partitioned_fk/pgschema.sql
@@ -1,0 +1,48 @@
+--
+-- pgschema database dump
+--
+
+-- Dumped from database version PostgreSQL 17.6
+-- Dumped by pgschema version 1.10.0
+
+
+--
+-- Name: session; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS session (
+    id bigint,
+    started_at timestamptz,
+    CONSTRAINT session_pkey PRIMARY KEY (started_at, id)
+) PARTITION BY RANGE (started_at);
+
+--
+-- Name: event; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS event (
+    session_id bigint NOT NULL,
+    session_started_at timestamptz NOT NULL,
+    CONSTRAINT event_session_id_session_started_at_fkey FOREIGN KEY (session_id, session_started_at) REFERENCES session (id, started_at)
+);
+
+--
+-- Name: session_2026_01; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS session_2026_01 (
+    id bigint,
+    started_at timestamptz,
+    CONSTRAINT session_2026_01_pkey PRIMARY KEY (started_at, id)
+);
+
+--
+-- Name: session_2026_02; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS session_2026_02 (
+    id bigint,
+    started_at timestamptz,
+    CONSTRAINT session_2026_02_pkey PRIMARY KEY (started_at, id)
+);
+

--- a/testdata/dump/issue_409_partitioned_fk/raw.sql
+++ b/testdata/dump/issue_409_partitioned_fk/raw.sql
@@ -1,0 +1,33 @@
+--
+-- Test case for GitHub issue #409: internal per-partition FK constraints dumped
+--
+-- When a foreign key references a partitioned table, PostgreSQL automatically
+-- creates one extra pg_constraint row per partition (conparentid != 0) to track
+-- the FK on each partition. These are internal artifacts: pg_dump never emits
+-- them, only the top-level FK (conparentid = 0) that references the partitioned
+-- parent.
+--
+-- pgschema dump used to emit all of them, producing bogus extra constraints like
+-- event_..._fkey1 / event_..._fkey2 that reference individual partitions. This
+-- also broke .pgschemaignore'd partitions, leaving dangling REFERENCES.
+--
+
+CREATE TABLE session (
+    id bigint NOT NULL,
+    started_at timestamptz NOT NULL,
+    PRIMARY KEY (id, started_at)
+) PARTITION BY RANGE (started_at);
+
+CREATE TABLE event (
+    session_id bigint NOT NULL,
+    session_started_at timestamptz NOT NULL,
+    FOREIGN KEY (session_id, session_started_at) REFERENCES session (id, started_at)
+);
+
+CREATE TABLE session_2026_01
+    PARTITION OF session
+    FOR VALUES FROM ('2026-01-01') TO ('2026-02-01');
+
+CREATE TABLE session_2026_02
+    PARTITION OF session
+    FOR VALUES FROM ('2026-02-01') TO ('2026-03-01');


### PR DESCRIPTION
## Summary

When a foreign key references a **partitioned table**, PostgreSQL automatically creates one extra `pg_constraint` row **per partition** (`conparentid != 0`) to track the FK on each partition. These are internal artifacts — `pg_dump` never emits them, only the top-level FK (`conparentid = 0`) that references the partitioned parent.

pgschema's constraint queries had no `conparentid` filter, so dump emitted **all** of them, producing bogus extra constraints referencing individual partitions:

```sql
CONSTRAINT event_..._fkey  FOREIGN KEY (...) REFERENCES session (...),          -- real
CONSTRAINT event_..._fkey1 FOREIGN KEY (...) REFERENCES session_2026_01 (...),  -- bogus
CONSTRAINT event_..._fkey2 FOREIGN KEY (...) REFERENCES session_2026_02 (...)   -- bogus
```

As the issue reporter noted, this also breaks `.pgschemaignore`: ignoring the partition tables left **dangling `REFERENCES`** to skipped tables. The root cause is broader than the ignore feature — these constraints should never be dumped.

## Fix

Add `AND (c.contype <> 'f' OR c.conparentid = 0)` to both `GetConstraints` and `GetConstraintsForSchema` in `ir/queries`, matching pg_dump. The filter is scoped to `FOREIGN KEY` so partition **primary keys** (which pg_dump *does* emit) are unaffected.

Verified against live PostgreSQL 17:
- `event_..._fkey` → `conparentid = 0` (emitted by pg_dump)
- `event_..._fkey1/2` → `conparentid != 0` (omitted by pg_dump)

Fixes #409

## Test plan

Added dump regression `testdata/dump/issue_409_partitioned_fk/` (partitioned table + FK + partitions). Before the fix, dump emitted the two bogus per-partition FKs; after, only the top-level FK remains.

```bash
go test -v ./cmd/dump -run TestDumpCommand_Issue409PartitionedFK   # green
PGSCHEMA_TEST_FILTER="create_table/" go test ./internal/diff -run TestDiffFromFiles  # no regressions
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)