### PR TITLE
feat: log when no .pgschemaignore file is found (#419)

### DIFF
--- a/cmd/util/ignoreloader.go
+++ b/cmd/util/ignoreloader.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pgplex/pgschema/internal/logger"
@@ -109,27 +110,31 @@ func LoadIgnoreFileWithStructure() (*ir.IgnoreConfig, error) {
 
 // LoadIgnoreFileWithStructureFromPath loads an ignore file using structured format from the specified path
 func LoadIgnoreFileWithStructureFromPath(filePath string) (*ir.IgnoreConfig, error) {
+	// Resolve to an absolute path so the diagnostic logs below unambiguously
+	// show where pgschema looked (e.g. when running from the wrong directory).
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		absPath = filePath
+	}
+
 	// Check if file exists
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		// File doesn't exist, return nil config (no filtering).
-		// Log the resolved path and working directory so a missing ignore
-		// file (e.g. running from the wrong directory) is diagnosable.
-		cwd, _ := os.Getwd()
 		logger.Get().Info("no ignore file found, no filtering applied",
-			"file", filePath, "cwd", cwd)
+			"file", absPath)
 		return nil, nil
 	} else if err != nil {
 		// Other error accessing file
 		return nil, err
 	}
 
-	logger.Get().Debug("loaded ignore file", "file", filePath)
-
 	// File exists, parse it
 	var tomlConfig TomlConfig
 	if _, err := toml.DecodeFile(filePath, &tomlConfig); err != nil {
 		return nil, err
 	}
+
+	logger.Get().Debug("loaded ignore file", "file", absPath)
 
 	// Convert to simple IgnoreConfig structure
 	config := &ir.IgnoreConfig{

--- a/cmd/util/ignoreloader.go
+++ b/cmd/util/ignoreloader.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
+	"github.com/pgplex/pgschema/internal/logger"
 	"github.com/pgplex/pgschema/ir"
 )
 
@@ -110,12 +111,19 @@ func LoadIgnoreFileWithStructure() (*ir.IgnoreConfig, error) {
 func LoadIgnoreFileWithStructureFromPath(filePath string) (*ir.IgnoreConfig, error) {
 	// Check if file exists
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		// File doesn't exist, return nil config (no filtering)
+		// File doesn't exist, return nil config (no filtering).
+		// Log the resolved path and working directory so a missing ignore
+		// file (e.g. running from the wrong directory) is diagnosable.
+		cwd, _ := os.Getwd()
+		logger.Get().Info("no ignore file found, no filtering applied",
+			"file", filePath, "cwd", cwd)
 		return nil, nil
 	} else if err != nil {
 		// Other error accessing file
 		return nil, err
 	}
+
+	logger.Get().Debug("loaded ignore file", "file", filePath)
 
 	// File exists, parse it
 	var tomlConfig TomlConfig


### PR DESCRIPTION
## Summary

Closes the diagnostic gap behind #419.

When no `.pgschemaignore` file exists in the current working directory, `LoadIgnoreFileWithStructureFromPath` silently returned a `nil` config and applied no filtering — no log, no warning. In CI (e.g. running `pgschema` from a directory where the ignore file isn't present), this looks like a mysterious "ignore patterns are being ignored" bug with zero signal, which is exactly what was reported in #419.

This PR makes the not-found case visible, logging the **absolute resolved path** pgschema looked for:

```
level=INFO msg="no ignore file found, no filtering applied" file=/path/where/it/ran/.pgschemaignore
```

The absolute path already encodes the working directory, so a wrong-directory situation is obvious at a glance. It also adds a debug-level log (with the same resolved path) after the file is successfully parsed.

## Why this is the right fix for #419

`.pgschemaignore` is loaded from the **current working directory** via a relative path, and pgschema never `chdir`s. The loader is also identical between `v1.9.0` and `v1.10.0` (only an additive `[indexes]` section changed). So the reported "`go install` vs `.deb`" difference cannot come from the install method — it's a workflow/working-directory difference. Surfacing the not-found case makes that class of problem immediately diagnosable.

## Notes

- Logs to **stderr** (default info level), so it does not pollute `--output-json` plan output on stdout.
- Shows by default (no `--debug` needed), since the whole point is default-on visibility.
- The "loaded ignore file" debug log fires only after a successful TOML parse, so it never reports success when parsing fails.

## Testing

- `go build ./...` passes
- `go test ./cmd/util/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)