### PR TITLE
fix: quote mixed-case user-defined type names in column type references (#422)

### DIFF
--- a/cmd/dump/dump_integration_test.go
+++ b/cmd/dump/dump_integration_test.go
@@ -165,6 +165,20 @@ func TestDumpCommand_Issue409PartitionedFK(t *testing.T) {
 	runExactMatchTest(t, "issue_409_partitioned_fk")
 }
 
+func TestDumpCommand_Issue421QuotedFKColumns(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	runExactMatchTest(t, "issue_421_quoted_fk_columns")
+}
+
+func TestDumpCommand_Issue422QuotedCustomType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	runExactMatchTest(t, "issue_422_quoted_custom_type")
+}
+
 // Reproduces a bug where a column declared as `name` is dumped as `char[]`.
 // The inspector classifies any base type with pg_type.typelem <> 0 as an array,
 // but the `name` type has typelem = 18 (the OID of "char") despite not being an array.

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -74,12 +74,12 @@ WITH column_base AS (
         COALESCE(d.description, '') AS column_comment,
         CASE
             WHEN dt.typtype = 'd' THEN
-                CASE WHEN dn.nspname = c.table_schema THEN dt.typname
-                     ELSE dn.nspname || '.' || dt.typname
+                CASE WHEN dn.nspname = c.table_schema THEN quote_ident(dt.typname)
+                     ELSE quote_ident(dn.nspname) || '.' || quote_ident(dt.typname)
                 END
             WHEN dt.typtype = 'e' OR dt.typtype = 'c' THEN
-                CASE WHEN dn.nspname = c.table_schema THEN dt.typname
-                     ELSE dn.nspname || '.' || dt.typname
+                CASE WHEN dn.nspname = c.table_schema THEN quote_ident(dt.typname)
+                     ELSE quote_ident(dn.nspname) || '.' || quote_ident(dt.typname)
                 END
             WHEN dt.typtype = 'b' AND dt.typcategory = 'A' THEN
                 -- Array types: apply same schema qualification logic to element type
@@ -88,8 +88,8 @@ WITH column_base AS (
                 -- Use format_type to preserve typmod for element types (e.g., varchar(128)[] for character varying(128)[])
                 CASE
                     WHEN en.nspname = 'pg_catalog' THEN et.typname
-                    WHEN en.nspname = c.table_schema THEN et.typname
-                    ELSE en.nspname || '.' || et.typname
+                    WHEN en.nspname = c.table_schema THEN quote_ident(et.typname)
+                    ELSE quote_ident(en.nspname) || '.' || quote_ident(et.typname)
                 END || COALESCE(substring(format_type(a.atttypid, a.atttypmod) FROM '\([^)]*\)'), '') || '[]'
             WHEN dt.typtype = 'b' THEN
                 -- Non-array base types: qualify if not in pg_catalog or table's schema
@@ -193,12 +193,12 @@ WITH column_base AS (
         COALESCE(d.description, '') AS column_comment,
         CASE
             WHEN dt.typtype = 'd' THEN
-                CASE WHEN dn.nspname = c.table_schema THEN dt.typname
-                     ELSE dn.nspname || '.' || dt.typname
+                CASE WHEN dn.nspname = c.table_schema THEN quote_ident(dt.typname)
+                     ELSE quote_ident(dn.nspname) || '.' || quote_ident(dt.typname)
                 END
             WHEN dt.typtype = 'e' OR dt.typtype = 'c' THEN
-                CASE WHEN dn.nspname = c.table_schema THEN dt.typname
-                     ELSE dn.nspname || '.' || dt.typname
+                CASE WHEN dn.nspname = c.table_schema THEN quote_ident(dt.typname)
+                     ELSE quote_ident(dn.nspname) || '.' || quote_ident(dt.typname)
                 END
             WHEN dt.typtype = 'b' AND dt.typcategory = 'A' THEN
                 -- Array types: apply same schema qualification logic to element type
@@ -207,8 +207,8 @@ WITH column_base AS (
                 -- Use format_type to preserve typmod for element types (e.g., varchar(128)[] for character varying(128)[])
                 CASE
                     WHEN en.nspname = 'pg_catalog' THEN et.typname
-                    WHEN en.nspname = c.table_schema THEN et.typname
-                    ELSE en.nspname || '.' || et.typname
+                    WHEN en.nspname = c.table_schema THEN quote_ident(et.typname)
+                    ELSE quote_ident(en.nspname) || '.' || quote_ident(et.typname)
                 END || COALESCE(substring(format_type(a.atttypid, a.atttypmod) FROM '\([^)]*\)'), '') || '[]'
             WHEN dt.typtype = 'b' THEN
                 -- Non-array base types: qualify if not in pg_catalog or table's schema

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -271,12 +271,12 @@ WITH column_base AS (
         COALESCE(d.description, '') AS column_comment,
         CASE
             WHEN dt.typtype = 'd' THEN
-                CASE WHEN dn.nspname = c.table_schema THEN dt.typname
-                     ELSE dn.nspname || '.' || dt.typname
+                CASE WHEN dn.nspname = c.table_schema THEN quote_ident(dt.typname)
+                     ELSE quote_ident(dn.nspname) || '.' || quote_ident(dt.typname)
                 END
             WHEN dt.typtype = 'e' OR dt.typtype = 'c' THEN
-                CASE WHEN dn.nspname = c.table_schema THEN dt.typname
-                     ELSE dn.nspname || '.' || dt.typname
+                CASE WHEN dn.nspname = c.table_schema THEN quote_ident(dt.typname)
+                     ELSE quote_ident(dn.nspname) || '.' || quote_ident(dt.typname)
                 END
             WHEN dt.typtype = 'b' AND dt.typcategory = 'A' THEN
                 -- Array types: apply same schema qualification logic to element type
@@ -285,8 +285,8 @@ WITH column_base AS (
                 -- Use format_type to preserve typmod for element types (e.g., varchar(128)[] for character varying(128)[])
                 CASE
                     WHEN en.nspname = 'pg_catalog' THEN et.typname
-                    WHEN en.nspname = c.table_schema THEN et.typname
-                    ELSE en.nspname || '.' || et.typname
+                    WHEN en.nspname = c.table_schema THEN quote_ident(et.typname)
+                    ELSE quote_ident(en.nspname) || '.' || quote_ident(et.typname)
                 END || COALESCE(substring(format_type(a.atttypid, a.atttypmod) FROM '\([^)]*\)'), '') || '[]'
             WHEN dt.typtype = 'b' THEN
                 -- Non-array base types: qualify if not in pg_catalog or table's schema
@@ -462,12 +462,12 @@ WITH column_base AS (
         COALESCE(d.description, '') AS column_comment,
         CASE
             WHEN dt.typtype = 'd' THEN
-                CASE WHEN dn.nspname = c.table_schema THEN dt.typname
-                     ELSE dn.nspname || '.' || dt.typname
+                CASE WHEN dn.nspname = c.table_schema THEN quote_ident(dt.typname)
+                     ELSE quote_ident(dn.nspname) || '.' || quote_ident(dt.typname)
                 END
             WHEN dt.typtype = 'e' OR dt.typtype = 'c' THEN
-                CASE WHEN dn.nspname = c.table_schema THEN dt.typname
-                     ELSE dn.nspname || '.' || dt.typname
+                CASE WHEN dn.nspname = c.table_schema THEN quote_ident(dt.typname)
+                     ELSE quote_ident(dn.nspname) || '.' || quote_ident(dt.typname)
                 END
             WHEN dt.typtype = 'b' AND dt.typcategory = 'A' THEN
                 -- Array types: apply same schema qualification logic to element type
@@ -476,8 +476,8 @@ WITH column_base AS (
                 -- Use format_type to preserve typmod for element types (e.g., varchar(128)[] for character varying(128)[])
                 CASE
                     WHEN en.nspname = 'pg_catalog' THEN et.typname
-                    WHEN en.nspname = c.table_schema THEN et.typname
-                    ELSE en.nspname || '.' || et.typname
+                    WHEN en.nspname = c.table_schema THEN quote_ident(et.typname)
+                    ELSE quote_ident(en.nspname) || '.' || quote_ident(et.typname)
                 END || COALESCE(substring(format_type(a.atttypid, a.atttypmod) FROM '\([^)]*\)'), '') || '[]'
             WHEN dt.typtype = 'b' THEN
                 -- Non-array base types: qualify if not in pg_catalog or table's schema

--- a/testdata/dump/issue_421_quoted_fk_columns/manifest.json
+++ b/testdata/dump/issue_421_quoted_fk_columns/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "issue_421_quoted_fk_columns",
+  "description": "Regression test for round-tripping a schema with quoted mixed-case foreign key columns and circular FK dependencies (GitHub issue #421)",
+  "source": "https://github.com/pgplex/pgschema/issues/421",
+  "notes": [
+    "Reproduces a schema with quoted mixed-case columns (\"aId\", \"bId\") and circular foreign keys",
+    "Both the referencing and referenced FK columns must stay double-quoted in the dump output",
+    "Circular FKs force one constraint inline in CREATE TABLE and the other as a deferred ALTER TABLE; both must quote columns",
+    "Reported against 1.9.0; already fixed on current main. This fixture guards against regression."
+  ]
+}

--- a/testdata/dump/issue_421_quoted_fk_columns/pgdump.sql
+++ b/testdata/dump/issue_421_quoted_fk_columns/pgdump.sql
@@ -1,0 +1,23 @@
+--
+-- Test case for GitHub issue #421: Quoted mixed-case FK columns cannot be round-tripped
+--
+-- A schema with quoted mixed-case column names and circular foreign key
+-- dependencies must round-trip through dump + plan. Both the referencing and
+-- referenced columns of every foreign key must remain double-quoted, otherwise
+-- the dumped SQL folds them to lower case and the referenced column "does not exist".
+--
+
+CREATE TABLE aaa (
+    "aId" bigint NOT NULL,
+    "bId" bigint,
+    CONSTRAINT aaa_pkey PRIMARY KEY ("aId")
+);
+
+CREATE TABLE bbb (
+    "bId" bigint NOT NULL,
+    "aId" bigint,
+    CONSTRAINT bbb_pkey PRIMARY KEY ("bId")
+);
+
+ALTER TABLE aaa ADD CONSTRAINT aaa_fk FOREIGN KEY ("bId") REFERENCES bbb ("bId") DEFERRABLE;
+ALTER TABLE bbb ADD CONSTRAINT bbb_fk FOREIGN KEY ("aId") REFERENCES aaa ("aId") DEFERRABLE;

--- a/testdata/dump/issue_421_quoted_fk_columns/pgschema.sql
+++ b/testdata/dump/issue_421_quoted_fk_columns/pgschema.sql
@@ -1,0 +1,36 @@
+--
+-- pgschema database dump
+--
+
+-- Dumped from database version PostgreSQL 17.5
+-- Dumped by pgschema version 1.10.0
+
+
+--
+-- Name: aaa; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS aaa (
+    "aId" bigint,
+    "bId" bigint,
+    CONSTRAINT aaa_pkey PRIMARY KEY ("aId")
+);
+
+--
+-- Name: bbb; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS bbb (
+    "bId" bigint,
+    "aId" bigint,
+    CONSTRAINT bbb_pkey PRIMARY KEY ("bId"),
+    CONSTRAINT bbb_fk FOREIGN KEY ("aId") REFERENCES aaa ("aId") DEFERRABLE
+);
+
+--
+-- Name: aaa_fk; Type: CONSTRAINT; Schema: -; Owner: -
+--
+
+ALTER TABLE aaa
+ADD CONSTRAINT aaa_fk FOREIGN KEY ("bId") REFERENCES bbb ("bId") DEFERRABLE;
+

--- a/testdata/dump/issue_421_quoted_fk_columns/raw.sql
+++ b/testdata/dump/issue_421_quoted_fk_columns/raw.sql
@@ -1,0 +1,23 @@
+--
+-- Test case for GitHub issue #421: Quoted mixed-case FK columns cannot be round-tripped
+--
+-- A schema with quoted mixed-case column names and circular foreign key
+-- dependencies must round-trip through dump + plan. Both the referencing and
+-- referenced columns of every foreign key must remain double-quoted, otherwise
+-- the dumped SQL folds them to lower case and the referenced column "does not exist".
+--
+
+CREATE TABLE aaa (
+    "aId" bigint NOT NULL,
+    "bId" bigint,
+    CONSTRAINT aaa_pkey PRIMARY KEY ("aId")
+);
+
+CREATE TABLE bbb (
+    "bId" bigint NOT NULL,
+    "aId" bigint,
+    CONSTRAINT bbb_pkey PRIMARY KEY ("bId")
+);
+
+ALTER TABLE aaa ADD CONSTRAINT aaa_fk FOREIGN KEY ("bId") REFERENCES bbb ("bId") DEFERRABLE;
+ALTER TABLE bbb ADD CONSTRAINT bbb_fk FOREIGN KEY ("aId") REFERENCES aaa ("aId") DEFERRABLE;

--- a/testdata/dump/issue_422_quoted_custom_type/manifest.json
+++ b/testdata/dump/issue_422_quoted_custom_type/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "issue_422_quoted_custom_type",
+  "description": "Test case for quoted mixed-case custom type names being dumped unquoted in column type references (GitHub issue #422)",
+  "source": "https://github.com/pgplex/pgschema/issues/422",
+  "notes": [
+    "Reproduces the bug where a column whose type is a mixed-case user-defined type (e.g. \"MyStatus\") is dumped with the type reference unquoted (status MyStatus), folding to mystatus and breaking round-trip",
+    "Covers enum, composite, and domain user-defined types, plus an array of a mixed-case enum (\"MyStatus\"[])",
+    "The CREATE TYPE/DOMAIN definitions and the ::\"MyStatus\" default cast were already quoted; only the column type reference was missing quoting"
+  ]
+}

--- a/testdata/dump/issue_422_quoted_custom_type/pgdump.sql
+++ b/testdata/dump/issue_422_quoted_custom_type/pgdump.sql
@@ -1,0 +1,21 @@
+--
+-- Schema for GitHub issue #422: quoted mixed-case custom type names
+--
+
+CREATE TYPE "MyStatus" AS ENUM ('active', 'inactive');
+
+CREATE TYPE "MyComposite" AS (
+    a integer,
+    b text
+);
+
+CREATE DOMAIN "MyDomain" AS integer CONSTRAINT "MyDomain_check" CHECK (VALUE > 0);
+
+CREATE TABLE items (
+    id        bigint NOT NULL,
+    status    "MyStatus" DEFAULT 'active'::"MyStatus" NOT NULL,
+    tags      "MyStatus"[],
+    payload   "MyComposite",
+    quantity  "MyDomain",
+    CONSTRAINT items_pkey PRIMARY KEY (id)
+);

--- a/testdata/dump/issue_422_quoted_custom_type/pgschema.sql
+++ b/testdata/dump/issue_422_quoted_custom_type/pgschema.sql
@@ -1,0 +1,43 @@
+--
+-- pgschema database dump
+--
+
+-- Dumped from database version PostgreSQL 17.5
+-- Dumped by pgschema version 1.10.0
+
+
+--
+-- Name: MyComposite; Type: TYPE; Schema: -; Owner: -
+--
+
+CREATE TYPE "MyComposite" AS (a integer, b text);
+
+--
+-- Name: MyDomain; Type: DOMAIN; Schema: -; Owner: -
+--
+
+CREATE DOMAIN "MyDomain" AS integer
+  CONSTRAINT "MyDomain_check" CHECK (VALUE > 0);
+
+--
+-- Name: MyStatus; Type: TYPE; Schema: -; Owner: -
+--
+
+CREATE TYPE "MyStatus" AS ENUM (
+    'active',
+    'inactive'
+);
+
+--
+-- Name: items; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS items (
+    id bigint,
+    status "MyStatus" DEFAULT 'active'::"MyStatus" NOT NULL,
+    tags "MyStatus"[],
+    payload "MyComposite",
+    quantity "MyDomain",
+    CONSTRAINT items_pkey PRIMARY KEY (id)
+);
+

--- a/testdata/dump/issue_422_quoted_custom_type/raw.sql
+++ b/testdata/dump/issue_422_quoted_custom_type/raw.sql
@@ -1,0 +1,25 @@
+--
+-- Test case for GitHub issue #422: Quoted mixed-case custom types cannot be round-tripped
+--
+-- A column whose type is a mixed-case user-defined type must reference that type
+-- with double quotes (status "MyStatus"). Without quoting, the dumped SQL folds the
+-- type name to lower case (mystatus), which does not exist, breaking round-trip.
+--
+
+CREATE TYPE "MyStatus" AS ENUM ('active', 'inactive');
+
+CREATE TYPE "MyComposite" AS (
+    a integer,
+    b text
+);
+
+CREATE DOMAIN "MyDomain" AS integer CHECK (VALUE > 0);
+
+CREATE TABLE items (
+    id        bigint NOT NULL,
+    status    "MyStatus" DEFAULT 'active'::"MyStatus" NOT NULL,
+    tags      "MyStatus"[],
+    payload   "MyComposite",
+    quantity  "MyDomain",
+    CONSTRAINT items_pkey PRIMARY KEY (id)
+);


### PR DESCRIPTION
## Summary

Fixes #422 and adds a regression guard for #421 — both reported as round-trip failures with quoted mixed-case identifiers.

### #422 — real bug, fixed

A column whose type is a mixed-case user-defined type (enum/composite/domain) was dumped with the type reference **unquoted**:

```sql
status MyStatus DEFAULT 'active'::"MyStatus" NOT NULL   -- before: folds to "mystatus"
status "MyStatus" DEFAULT 'active'::"MyStatus" NOT NULL  -- after
```

PostgreSQL folds the unquoted name to lower case, so `pgschema plan --file <dump>` failed with `type "mystatus" does not exist`, breaking the dump → plan round-trip.

**Root cause:** the column-type query (`ir/queries/queries.sql`) built `resolved_type` from raw `dt.typname` / `et.typname`, dropping the quoting needed for mixed-case names. The `CREATE TYPE` definition and the `::"MyStatus"` default cast were already quoted; only the column type reference was missing it.

**Fix:** wrap the domain/enum/composite branches and the array element branch in `quote_ident()`, so both scalar (`"MyStatus"`) and array (`"MyStatus"[]`) forms, plus cross-schema references, stay quoted. Regenerated the sqlc `.go`. `quote_ident()` is a no-op for already-lowercase names, so built-in and lowercased types are unaffected.

### #421 — already fixed, now guarded

Could not reproduce on current `main` (was filed against 1.9.0): the FK paths already quote both sides of `REFERENCES ... (...)`. Added a dump fixture (circular FKs with quoted `"aId"`/`"bId"`) so it stays fixed.

## Testing

- New `TestDumpCommand_Issue422QuotedCustomType` (enum + composite + domain + array of enum) and `TestDumpCommand_Issue421QuotedFKColumns` pass.
- Verified the real CLI round-trip end-to-end against PostgreSQL 17 (dump → plan against a fresh DB) → `No changes detected` for both issues.
- Existing type/domain/dependency diff suites and the dump suite remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)