### PR TITLE
fix: use DROP MATERIALIZED VIEW for materialized dependents during recreate (#415)

### DIFF
--- a/internal/diff/view.go
+++ b/internal/diff/view.go
@@ -480,6 +480,16 @@ func generateModifyViewsSQL(diffs []*viewDiff, targetSchema string, collector *d
 			}
 			collector.collect(commentContext, commentSQL)
 		}
+
+		// Dropping a materialized view also drops its indexes, so recreate them
+		// for materialized dependents (issue #415).
+		if depView.Materialized && depView.Indexes != nil {
+			indexList := make([]*ir.Index, 0, len(depView.Indexes))
+			for _, index := range depView.Indexes {
+				indexList = append(indexList, index)
+			}
+			generateCreateIndexesSQLWithType(indexList, targetSchema, collector, DiffTypeMaterializedViewIndex, DiffTypeMaterializedViewIndexComment)
+		}
 	}
 }
 

--- a/internal/diff/view.go
+++ b/internal/diff/view.go
@@ -143,10 +143,19 @@ func generateModifyViewsSQL(diffs []*viewDiff, targetSchema string, collector *d
 				droppedDependentViews[depViewKey] = true
 
 				depViewName := qualifyEntityName(depView.Schema, depView.Name, targetSchema)
+
+				// Use the correct DROP variant based on relkind. IF EXISTS does NOT
+				// suppress the error when the object exists with a different relkind,
+				// so dropping a materialized view with DROP VIEW fails (issue #415).
+				depDiffType := DiffTypeView
 				dropDepSQL := fmt.Sprintf("DROP VIEW IF EXISTS %s RESTRICT;", depViewName)
+				if depView.Materialized {
+					depDiffType = DiffTypeMaterializedView
+					dropDepSQL = fmt.Sprintf("DROP MATERIALIZED VIEW IF EXISTS %s RESTRICT;", depViewName)
+				}
 
 				depContext := &diffContext{
-					Type:                DiffTypeView,
+					Type:                depDiffType,
 					Operation:           DiffOperationRecreate,
 					Path:                fmt.Sprintf("%s.%s", depView.Schema, depView.Name),
 					Source:              depView,
@@ -433,8 +442,19 @@ func generateModifyViewsSQL(diffs []*viewDiff, targetSchema string, collector *d
 
 		createDepSQL := generateViewSQL(depView, targetSchema)
 
+		// Categorize using the correct relkind so materialized dependents are
+		// reported (and commented) as materialized views (issue #415).
+		depDiffType := DiffTypeView
+		depCommentType := DiffTypeViewComment
+		commentKeyword := "VIEW"
+		if depView.Materialized {
+			depDiffType = DiffTypeMaterializedView
+			depCommentType = DiffTypeMaterializedViewComment
+			commentKeyword = "MATERIALIZED VIEW"
+		}
+
 		depContext := &diffContext{
-			Type:                DiffTypeView,
+			Type:                depDiffType,
 			Operation:           DiffOperationRecreate,
 			Path:                fmt.Sprintf("%s.%s", depView.Schema, depView.Name),
 			Source:              depView,
@@ -450,9 +470,9 @@ func generateModifyViewsSQL(diffs []*viewDiff, targetSchema string, collector *d
 		// Recreate view comment if present
 		if depView.Comment != "" {
 			depViewName := qualifyEntityName(depView.Schema, depView.Name, targetSchema)
-			commentSQL := fmt.Sprintf("COMMENT ON VIEW %s IS %s;", depViewName, quoteString(depView.Comment))
+			commentSQL := fmt.Sprintf("COMMENT ON %s %s IS %s;", commentKeyword, depViewName, quoteString(depView.Comment))
 			commentContext := &diffContext{
-				Type:                DiffTypeViewComment,
+				Type:                depCommentType,
 				Operation:           DiffOperationCreate,
 				Path:                fmt.Sprintf("%s.%s", depView.Schema, depView.Name),
 				Source:              depView,

--- a/testdata/diff/dependency/issue_308_view_select_star_column_reorder/diff.sql
+++ b/testdata/diff/dependency/issue_308_view_select_star_column_reorder/diff.sql
@@ -1,5 +1,7 @@
 ALTER TABLE item ADD COLUMN new_col text;
 
+DROP MATERIALIZED VIEW IF EXISTS item_summary RESTRICT;
+
 DROP VIEW IF EXISTS item_extended RESTRICT;
 
 CREATE OR REPLACE VIEW item_extended AS
@@ -10,3 +12,8 @@ CREATE OR REPLACE VIEW item_extended AS
     c.name AS category_name
    FROM item i
      JOIN category c ON c.id = i.id;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS item_summary AS
+ SELECT id,
+    title
+   FROM item_extended;

--- a/testdata/diff/dependency/issue_308_view_select_star_column_reorder/diff.sql
+++ b/testdata/diff/dependency/issue_308_view_select_star_column_reorder/diff.sql
@@ -17,3 +17,5 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS item_summary AS
  SELECT id,
     title
    FROM item_extended;
+
+CREATE INDEX IF NOT EXISTS item_summary_id_idx ON item_summary (id);

--- a/testdata/diff/dependency/issue_308_view_select_star_column_reorder/new.sql
+++ b/testdata/diff/dependency/issue_308_view_select_star_column_reorder/new.sql
@@ -20,3 +20,5 @@ JOIN category c ON c.id = i.id;
 -- DROP MATERIALIZED VIEW, not DROP VIEW.
 CREATE MATERIALIZED VIEW item_summary AS
 SELECT id, title FROM item_extended;
+
+CREATE INDEX item_summary_id_idx ON item_summary (id);

--- a/testdata/diff/dependency/issue_308_view_select_star_column_reorder/new.sql
+++ b/testdata/diff/dependency/issue_308_view_select_star_column_reorder/new.sql
@@ -14,3 +14,9 @@ CREATE VIEW item_extended AS
 SELECT i.*, c.name AS category_name
 FROM item i
 JOIN category c ON c.id = i.id;
+
+-- Materialized view depending on the recreated view (issue #415):
+-- when item_extended is recreated, this MV must be dropped with
+-- DROP MATERIALIZED VIEW, not DROP VIEW.
+CREATE MATERIALIZED VIEW item_summary AS
+SELECT id, title FROM item_extended;

--- a/testdata/diff/dependency/issue_308_view_select_star_column_reorder/old.sql
+++ b/testdata/diff/dependency/issue_308_view_select_star_column_reorder/old.sql
@@ -13,3 +13,9 @@ CREATE VIEW item_extended AS
 SELECT i.*, c.name AS category_name
 FROM item i
 JOIN category c ON c.id = i.id;
+
+-- Materialized view depending on the recreated view (issue #415):
+-- when item_extended is recreated, this MV must be dropped with
+-- DROP MATERIALIZED VIEW, not DROP VIEW.
+CREATE MATERIALIZED VIEW item_summary AS
+SELECT id, title FROM item_extended;

--- a/testdata/diff/dependency/issue_308_view_select_star_column_reorder/old.sql
+++ b/testdata/diff/dependency/issue_308_view_select_star_column_reorder/old.sql
@@ -19,3 +19,5 @@ JOIN category c ON c.id = i.id;
 -- DROP MATERIALIZED VIEW, not DROP VIEW.
 CREATE MATERIALIZED VIEW item_summary AS
 SELECT id, title FROM item_extended;
+
+CREATE INDEX item_summary_id_idx ON item_summary (id);

--- a/testdata/diff/dependency/issue_308_view_select_star_column_reorder/plan.json
+++ b/testdata/diff/dependency/issue_308_view_select_star_column_reorder/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.11.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "584e78ed59cc9fc48eae0b3f7fb8951623a81775c011bafcb4c27e781ed5f170"
+    "hash": "050bd87923cac97403770169d6e1b9fc6dd6d70d5293fa64e6ba6cf1466db1b7"
   },
   "groups": [
     {
@@ -13,6 +13,12 @@
           "type": "table.column",
           "operation": "create",
           "path": "public.item.new_col"
+        },
+        {
+          "sql": "DROP MATERIALIZED VIEW IF EXISTS item_summary RESTRICT;",
+          "type": "materialized_view",
+          "operation": "recreate",
+          "path": "public.item_summary"
         },
         {
           "sql": "DROP VIEW IF EXISTS item_extended RESTRICT;",
@@ -25,6 +31,12 @@
           "type": "view",
           "operation": "alter",
           "path": "public.item_extended"
+        },
+        {
+          "sql": "CREATE MATERIALIZED VIEW IF NOT EXISTS item_summary AS\n SELECT id,\n    title\n   FROM item_extended;",
+          "type": "materialized_view",
+          "operation": "recreate",
+          "path": "public.item_summary"
         }
       ]
     }

--- a/testdata/diff/dependency/issue_308_view_select_star_column_reorder/plan.json
+++ b/testdata/diff/dependency/issue_308_view_select_star_column_reorder/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.11.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "050bd87923cac97403770169d6e1b9fc6dd6d70d5293fa64e6ba6cf1466db1b7"
+    "hash": "49447108ebe654f664db169922b4da0da2bad955df8a351b78df704f3d7cea65"
   },
   "groups": [
     {
@@ -37,6 +37,30 @@
           "type": "materialized_view",
           "operation": "recreate",
           "path": "public.item_summary"
+        }
+      ]
+    },
+    {
+      "steps": [
+        {
+          "sql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS item_summary_id_idx ON item_summary (id);",
+          "type": "materialized_view.index",
+          "operation": "create",
+          "path": "public.item_summary.item_summary_id_idx"
+        }
+      ]
+    },
+    {
+      "steps": [
+        {
+          "sql": "SELECT \n    COALESCE(i.indisvalid, false) as done,\n    CASE \n        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total\n        ELSE 0\n    END as progress\nFROM pg_class c\nLEFT JOIN pg_index i ON c.oid = i.indexrelid\nLEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid\nWHERE c.relname = 'item_summary_id_idx';",
+          "directive": {
+            "type": "wait",
+            "message": "Creating index item_summary_id_idx"
+          },
+          "type": "materialized_view.index",
+          "operation": "create",
+          "path": "public.item_summary.item_summary_id_idx"
         }
       ]
     }

--- a/testdata/diff/dependency/issue_308_view_select_star_column_reorder/plan.sql
+++ b/testdata/diff/dependency/issue_308_view_select_star_column_reorder/plan.sql
@@ -1,5 +1,7 @@
 ALTER TABLE item ADD COLUMN new_col text;
 
+DROP MATERIALIZED VIEW IF EXISTS item_summary RESTRICT;
+
 DROP VIEW IF EXISTS item_extended RESTRICT;
 
 CREATE OR REPLACE VIEW item_extended AS
@@ -10,3 +12,8 @@ CREATE OR REPLACE VIEW item_extended AS
     c.name AS category_name
    FROM item i
      JOIN category c ON c.id = i.id;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS item_summary AS
+ SELECT id,
+    title
+   FROM item_extended;

--- a/testdata/diff/dependency/issue_308_view_select_star_column_reorder/plan.sql
+++ b/testdata/diff/dependency/issue_308_view_select_star_column_reorder/plan.sql
@@ -17,3 +17,17 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS item_summary AS
  SELECT id,
     title
    FROM item_extended;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS item_summary_id_idx ON item_summary (id);
+
+-- pgschema:wait
+SELECT 
+    COALESCE(i.indisvalid, false) as done,
+    CASE 
+        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total
+        ELSE 0
+    END as progress
+FROM pg_class c
+LEFT JOIN pg_index i ON c.oid = i.indexrelid
+LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
+WHERE c.relname = 'item_summary_id_idx';

--- a/testdata/diff/dependency/issue_308_view_select_star_column_reorder/plan.txt
+++ b/testdata/diff/dependency/issue_308_view_select_star_column_reorder/plan.txt
@@ -1,8 +1,9 @@
-Plan: 2 to modify.
+Plan: 3 to modify.
 
 Summary by type:
   tables: 1 to modify
   views: 1 to modify
+  materialized views: 1 to modify
 
 Tables:
   ~ item
@@ -11,10 +12,15 @@ Tables:
 Views:
   ~ item_extended
 
+Materialized views:
+  ~ item_summary
+
 DDL to be executed:
 --------------------------------------------------
 
 ALTER TABLE item ADD COLUMN new_col text;
+
+DROP MATERIALIZED VIEW IF EXISTS item_summary RESTRICT;
 
 DROP VIEW IF EXISTS item_extended RESTRICT;
 
@@ -26,3 +32,8 @@ CREATE OR REPLACE VIEW item_extended AS
     c.name AS category_name
    FROM item i
      JOIN category c ON c.id = i.id;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS item_summary AS
+ SELECT id,
+    title
+   FROM item_extended;

--- a/testdata/diff/dependency/issue_308_view_select_star_column_reorder/plan.txt
+++ b/testdata/diff/dependency/issue_308_view_select_star_column_reorder/plan.txt
@@ -14,10 +14,12 @@ Views:
 
 Materialized views:
   ~ item_summary
+    + item_summary_id_idx (index)
 
 DDL to be executed:
 --------------------------------------------------
 
+-- Transaction Group #1
 ALTER TABLE item ADD COLUMN new_col text;
 
 DROP MATERIALIZED VIEW IF EXISTS item_summary RESTRICT;
@@ -37,3 +39,19 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS item_summary AS
  SELECT id,
     title
    FROM item_extended;
+
+-- Transaction Group #2
+CREATE INDEX CONCURRENTLY IF NOT EXISTS item_summary_id_idx ON item_summary (id);
+
+-- Transaction Group #3
+-- pgschema:wait
+SELECT 
+    COALESCE(i.indisvalid, false) as done,
+    CASE 
+        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total
+        ELSE 0
+    END as progress
+FROM pg_class c
+LEFT JOIN pg_index i ON c.oid = i.indexrelid
+LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
+WHERE c.relname = 'item_summary_id_idx';


### PR DESCRIPTION
## Summary

When a view requires recreation (`DROP` + `CREATE`, e.g. column reorder per #308), pgschema first drops the views that depend on it. The dependent-drop path in `internal/diff/view.go` hardcoded `DROP VIEW IF EXISTS` regardless of the dependent's relkind.

`IF EXISTS` only suppresses the error when the object is **absent** — it does **not** suppress the error when the object exists with a different `relkind`. So whenever a **materialized** view depended on a view being recreated, `pgschema apply` failed with:

```
ERROR: "<mv>" is not a view (SQLSTATE 42809)
```

The fix branches on the dependent's `Materialized` flag to emit `DROP MATERIALIZED VIEW IF EXISTS` for materialized dependents, and likewise categorizes the recreate/comment statements as materialized-view operations.

Note: the issue's headline repro (adding an index to an existing MV) was **not** reproducible — that path was already correct. The real, apply-breaking bug is the dependent-MV case fixed here.

Fixes #415

## Test plan

Enhanced the existing recreate test `testdata/diff/dependency/issue_308_view_select_star_column_reorder` by adding a materialized view that depends on the recreated view — reproducing the bug, then verifying the fix:

```bash
PGSCHEMA_TEST_FILTER="dependency/issue_308_view_select_star_column_reorder" go test ./internal/diff -run TestDiffFromFiles
PGSCHEMA_TEST_FILTER="dependency/" go test ./cmd -run TestPlanAndApply
```

Before fix: `DROP VIEW IF EXISTS item_summary RESTRICT;` (apply fails, SQLSTATE 42809).
After fix: `DROP MATERIALIZED VIEW IF EXISTS item_summary RESTRICT;` (applies cleanly).

Regression checks (all green): `dependency/`, `create_view/`, `create_materialized_view/` diff suites + `dependency/` integration suite (applies against a real embedded DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)