### PR TITLE
fix: support CREATE/DROP/ALTER AGGREGATE in diff and dump (#416)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,7 +273,7 @@ The tool supports comprehensive PostgreSQL schema objects (see `ir/ir.go` for co
 
 Tests are organized by object type (150+ test cases):
 
-- `comment/` (12), `create_aggregate/` (3), `create_domain/` (5), `create_function/` (8), `create_index/` (2)
+- `comment/` (12), `create_aggregate/` (4), `create_domain/` (5), `create_function/` (8), `create_index/` (2)
 - `create_materialized_view/` (3), `create_policy/` (10), `create_procedure/` (3), `create_sequence/` (3)
 - `create_table/` (37), `create_trigger/` (7), `create_type/` (3), `create_view/` (4)
 - `default_privilege/` (9), `privilege/` (13)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,7 +273,7 @@ The tool supports comprehensive PostgreSQL schema objects (see `ir/ir.go` for co
 
 Tests are organized by object type (150+ test cases):
 
-- `comment/` (12), `create_aggregate/` (2), `create_domain/` (5), `create_function/` (8), `create_index/` (2)
+- `comment/` (12), `create_aggregate/` (3), `create_domain/` (5), `create_function/` (8), `create_index/` (2)
 - `create_materialized_view/` (3), `create_policy/` (10), `create_procedure/` (3), `create_sequence/` (3)
 - `create_table/` (37), `create_trigger/` (7), `create_type/` (3), `create_view/` (4)
 - `default_privilege/` (9), `privilege/` (13)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ The tool supports comprehensive PostgreSQL schema objects (see `ir/ir.go` for co
 - **Sequences**: Start, increment, min/max, cycle, cache, owned by tracking
 - **Types**: Enum, composite, domain types with constraints
 - **Policies**: Row-level security with commands, roles, USING/WITH CHECK expressions
-- **Aggregates**: Custom aggregates with transition and final functions
+- **Aggregates**: Custom aggregates with the full option set (transition/final/combine/serial/deserial functions, moving-aggregate support, SSPACE, SORTOP, PARALLEL, ordered-set/hypothetical-set)
 - **Privileges**: GRANT/REVOKE for tables, functions, sequences, types
 - **Default Privileges**: ALTER DEFAULT PRIVILEGES for grantor-level access control
 - **Comments**: On all supported object types

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,7 +273,7 @@ The tool supports comprehensive PostgreSQL schema objects (see `ir/ir.go` for co
 
 Tests are organized by object type (150+ test cases):
 
-- `comment/` (11), `create_domain/` (5), `create_function/` (8), `create_index/` (2)
+- `comment/` (12), `create_aggregate/` (2), `create_domain/` (5), `create_function/` (8), `create_index/` (2)
 - `create_materialized_view/` (3), `create_policy/` (10), `create_procedure/` (3), `create_sequence/` (3)
 - `create_table/` (37), `create_trigger/` (7), `create_type/` (3), `create_view/` (4)
 - `default_privilege/` (9), `privilege/` (13)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ pgschema covers all the schema objects developers use in real-world Postgres app
 | **Materialized Views** | WITH [NO] DATA, indexes on materialized views |
 | **Functions** | IN/OUT/INOUT parameters with defaults, SETOF/TABLE return types, SECURITY DEFINER, IMMUTABLE/STABLE/VOLATILE, STRICT |
 | **Procedures** | IN/OUT/INOUT parameters with defaults, all procedural languages |
+| **Aggregates** | SFUNC/STYPE/FINALFUNC/INITCOND, COMBINEFUNC and SERIALFUNC/DESERIALFUNC, moving-aggregate support, SORTOP, PARALLEL, ordered-set/hypothetical-set |
 | **Triggers** | BEFORE/AFTER/INSTEAD OF, INSERT/UPDATE/DELETE/TRUNCATE, ROW/STATEMENT level, WHEN conditions, constraint triggers, REFERENCING OLD/NEW TABLE |
 | **Sequences** | START WITH, INCREMENT BY, MINVALUE/MAXVALUE, CYCLE, CACHE, OWNED BY |
 | **Types** | ENUM (add values in-place), composite types |
@@ -90,7 +91,7 @@ pgschema covers all the schema objects developers use in real-world Postgres app
 | **Policies** | Row-level security (RLS), PERMISSIVE/RESTRICTIVE, ALL/SELECT/INSERT/UPDATE/DELETE commands, USING/WITH CHECK expressions, ENABLE/DISABLE/FORCE ROW LEVEL SECURITY |
 | **Privileges** | GRANT/REVOKE for tables (including column-level), sequences, functions, procedures, types/domains; WITH GRANT OPTION |
 | **Default Privileges** | ALTER DEFAULT PRIVILEGES for tables, sequences, functions, types |
-| **Comments** | COMMENT ON for tables, columns, views, materialized views, functions, procedures, indexes |
+| **Comments** | COMMENT ON for tables, columns, views, materialized views, functions, procedures, aggregates, indexes |
 
 See [Unsupported](https://www.pgschema.com/syntax/unsupported) for objects that are explicitly out of scope.
 

--- a/cmd/dump/multifile_test.go
+++ b/cmd/dump/multifile_test.go
@@ -63,6 +63,21 @@ func TestCreateMultiFileOutput(t *testing.T) {
 		{
 			Statements: []diff.SQLStatement{
 				{
+					SQL:                 "CREATE AGGREGATE group_concat(text) (\n    SFUNC = _group_concat,\n    STYPE = text\n);",
+					CanRunInTransaction: true,
+				},
+			},
+			Type:      diff.DiffTypeAggregate,
+			Operation: diff.DiffOperationCreate,
+			Path:      "public.group_concat",
+			Source: &ir.Aggregate{
+				Name:      "group_concat",
+				Arguments: "text",
+			},
+		},
+		{
+			Statements: []diff.SQLStatement{
+				{
 					SQL:                 "CREATE VIEW active_users AS SELECT * FROM users WHERE status = 'active';",
 					CanRunInTransaction: true,
 				},
@@ -89,7 +104,7 @@ func TestCreateMultiFileOutput(t *testing.T) {
 	}
 
 	// Check that subdirectories were created
-	expectedDirs := []string{"types", "functions", "tables", "views"}
+	expectedDirs := []string{"types", "functions", "aggregates", "tables", "views"}
 	for _, dir := range expectedDirs {
 		dirPath := filepath.Join(tmpDir, dir)
 		if _, err := os.Stat(dirPath); os.IsNotExist(err) {
@@ -101,6 +116,7 @@ func TestCreateMultiFileOutput(t *testing.T) {
 	expectedFiles := []string{
 		"types/user_status.sql",
 		"functions/get_user_count.sql",
+		"aggregates/group_concat.sql",
 		"tables/users.sql",
 		"views/active_users.sql",
 	}
@@ -121,6 +137,7 @@ func TestCreateMultiFileOutput(t *testing.T) {
 	expectedIncludes := []string{
 		"\\i types/user_status.sql",
 		"\\i functions/get_user_count.sql",
+		"\\i aggregates/group_concat.sql",
 		"\\i tables/users.sql",
 		"\\i views/active_users.sql",
 	}
@@ -149,6 +166,21 @@ func TestCreateMultiFileOutput(t *testing.T) {
 	}
 	if !strings.Contains(typeStr, "-- Name: user_status; Type: TYPE; Schema: -; Owner: -") {
 		t.Errorf("Type file should contain comment header")
+	}
+
+	// Check aggregate file content and that its header carries the argument signature
+	aggregateFile := filepath.Join(tmpDir, "aggregates", "group_concat.sql")
+	aggregateContent, err := os.ReadFile(aggregateFile)
+	if err != nil {
+		t.Fatalf("Failed to read aggregate file: %v", err)
+	}
+
+	aggregateStr := string(aggregateContent)
+	if !strings.Contains(aggregateStr, "CREATE AGGREGATE group_concat(text)") {
+		t.Errorf("Aggregate file should contain the CREATE AGGREGATE statement")
+	}
+	if !strings.Contains(aggregateStr, "-- Name: group_concat(text); Type: AGGREGATE; Schema: -; Owner: -") {
+		t.Errorf("Aggregate file should contain comment header with argument signature")
 	}
 }
 

--- a/cmd/ignore_integration_test.go
+++ b/cmd/ignore_integration_test.go
@@ -1726,3 +1726,112 @@ func verifyPlanOutput(t *testing.T, output string) {
 		}
 	}
 }
+
+func TestIgnoreAggregates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	embeddedPG := testutil.SetupPostgres(t)
+	defer embeddedPG.Stop()
+	conn, host, port, dbname, user, password := testutil.ConnectToPostgres(t, embeddedPG)
+	defer conn.Close()
+
+	containerInfo := &struct {
+		Conn     *sql.DB
+		Host     string
+		Port     int
+		DBName   string
+		User     string
+		Password string
+	}{
+		Conn:     conn,
+		Host:     host,
+		Port:     port,
+		DBName:   dbname,
+		User:     user,
+		Password: password,
+	}
+
+	// Two aggregates share one transition function: a managed aggregate plus a
+	// debug aggregate that is managed out-of-band and should be filtered.
+	setupSQL := `
+CREATE FUNCTION _concat_step(text, text) RETURNS text
+    LANGUAGE sql IMMUTABLE
+    AS $$ SELECT CASE WHEN $1 IS NULL THEN $2 WHEN $2 IS NULL THEN $1 ELSE $1 || ',' || $2 END $$;
+
+CREATE AGGREGATE group_concat(text) (
+    SFUNC = _concat_step,
+    STYPE = text
+);
+
+CREATE AGGREGATE agg_debug_concat(text) (
+    SFUNC = _concat_step,
+    STYPE = text
+);
+`
+	if _, err := conn.Exec(setupSQL); err != nil {
+		t.Fatalf("Failed to create test schema: %v", err)
+	}
+
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalWd); err != nil {
+			t.Fatalf("Failed to restore working directory: %v", err)
+		}
+	}()
+
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
+
+	// Ignore any aggregate whose name starts with "agg_debug_"
+	ignoreContent := `[aggregates]
+patterns = ["agg_debug_*"]
+`
+	if err := os.WriteFile(".pgschemaignore", []byte(ignoreContent), 0644); err != nil {
+		t.Fatalf("Failed to create .pgschemaignore: %v", err)
+	}
+
+	t.Run("dump", func(t *testing.T) {
+		output := executeIgnoreDumpCommand(t, containerInfo)
+
+		if !strings.Contains(output, "CREATE AGGREGATE group_concat") {
+			t.Error("Dump should include group_concat (not ignored)")
+		}
+		if strings.Contains(output, "agg_debug_concat") {
+			t.Error("Dump should not include agg_debug_concat (ignored by [aggregates] patterns)")
+		}
+	})
+
+	t.Run("plan", func(t *testing.T) {
+		// Desired schema declares only the managed aggregate and its function.
+		// Without the ignore, the plan would emit DROP AGGREGATE agg_debug_concat;
+		// with the ignore it should not reference it.
+		schemaSQL := `
+CREATE FUNCTION _concat_step(text, text) RETURNS text
+    LANGUAGE sql IMMUTABLE
+    AS $$ SELECT CASE WHEN $1 IS NULL THEN $2 WHEN $2 IS NULL THEN $1 ELSE $1 || ',' || $2 END $$;
+
+CREATE AGGREGATE group_concat(text) (
+    SFUNC = _concat_step,
+    STYPE = text
+);
+`
+		schemaFile := "schema.sql"
+		if err := os.WriteFile(schemaFile, []byte(schemaSQL), 0644); err != nil {
+			t.Fatalf("Failed to create schema file: %v", err)
+		}
+		defer os.Remove(schemaFile)
+
+		output := executeIgnorePlanCommand(t, containerInfo, schemaFile)
+
+		if strings.Contains(output, "agg_debug_concat") {
+			t.Errorf("Plan should not reference agg_debug_concat (ignored); got: %s", output)
+		}
+	})
+}

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -628,6 +628,19 @@ func normalizeSchemaNames(irData *ir.IR, fromSchema, toSchema string) {
 			}
 			agg.SortOperator = replaceString(agg.SortOperator)
 		}
+
+		// The Aggregates map is keyed by "name(arguments)". Because Arguments was just
+		// normalized, rebuild the map so the keys stay consistent with the fields (and
+		// therefore match the current-state IR during diffing). In practice the identity
+		// argument types are unqualified for same-schema types, so this is usually a no-op,
+		// but re-keying makes the invariant robust to cross-schema argument types.
+		if len(schema.Aggregates) > 0 {
+			rekeyed := make(map[string]*ir.Aggregate, len(schema.Aggregates))
+			for _, agg := range schema.Aggregates {
+				rekeyed[agg.Name+"("+agg.Arguments+")"] = agg
+			}
+			schema.Aggregates = rekeyed
+		}
 	}
 }
 

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -599,21 +599,28 @@ func normalizeSchemaNames(irData *ir.IR, fromSchema, toSchema string) {
 			seq.OwnedByTable = replaceString(seq.OwnedByTable)
 		}
 
-		// Aggregates
+		// Aggregates. Support-function references are stored unqualified when they share
+		// the aggregate's schema, so they carry no temporary-schema prefix; applying
+		// replaceString is still safe (the distinctive temp name simply won't match) and
+		// keeps cross-schema type/argument references correct.
 		for _, agg := range schema.Aggregates {
 			agg.Schema = toSchema
 			agg.Arguments = replaceString(agg.Arguments)
+			agg.Signature = replaceString(agg.Signature)
 			agg.ReturnType = replaceString(agg.ReturnType)
 			agg.TransitionFunction = replaceString(agg.TransitionFunction)
-			if agg.TransitionFunctionSchema == fromSchema {
-				agg.TransitionFunctionSchema = toSchema
-			}
 			agg.StateType = replaceString(agg.StateType)
 			agg.InitialCondition = replaceString(agg.InitialCondition)
 			agg.FinalFunction = replaceString(agg.FinalFunction)
-			if agg.FinalFunctionSchema == fromSchema {
-				agg.FinalFunctionSchema = toSchema
-			}
+			agg.CombineFunction = replaceString(agg.CombineFunction)
+			agg.SerialFunction = replaceString(agg.SerialFunction)
+			agg.DeserialFunction = replaceString(agg.DeserialFunction)
+			agg.MTransitionFunction = replaceString(agg.MTransitionFunction)
+			agg.MInvTransitionFunction = replaceString(agg.MInvTransitionFunction)
+			agg.MStateType = replaceString(agg.MStateType)
+			agg.MFinalFunction = replaceString(agg.MFinalFunction)
+			agg.MInitialCondition = replaceString(agg.MInitialCondition)
+			agg.SortOperator = replaceString(agg.SortOperator)
 		}
 	}
 }

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -445,9 +445,6 @@ func processOutput(migrationPlan *plan.Plan, output outputSpec, cmd *cobra.Comma
 // - Dependencies, cross-references, and LIKE clauses
 // - Aggregate function schemas (TransitionFunctionSchema, FinalFunctionSchema)
 //
-// Note: Aggregates are normalized for future-proofing even though the diff package
-// does not currently support aggregate migrations.
-//
 // Without this normalization, generated DDL would reference non-existent temporary schemas
 // and fail when applied to the target database.
 func normalizeSchemaNames(irData *ir.IR, fromSchema, toSchema string) {
@@ -605,6 +602,7 @@ func normalizeSchemaNames(irData *ir.IR, fromSchema, toSchema string) {
 		// Aggregates
 		for _, agg := range schema.Aggregates {
 			agg.Schema = toSchema
+			agg.Arguments = replaceString(agg.Arguments)
 			agg.ReturnType = replaceString(agg.ReturnType)
 			agg.TransitionFunction = replaceString(agg.TransitionFunction)
 			if agg.TransitionFunctionSchema == fromSchema {

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -443,7 +443,7 @@ func processOutput(migrationPlan *plan.Plan, output outputSpec, cmd *cobra.Comma
 // - Constraints (including foreign key referenced schemas)
 // - Indexes, triggers, policies
 // - Dependencies, cross-references, and LIKE clauses
-// - Aggregate function schemas (TransitionFunctionSchema, FinalFunctionSchema)
+// - Aggregate support-function references (SFUNC/FINALFUNC/...) and signature/type strings
 //
 // Without this normalization, generated DDL would reference non-existent temporary schemas
 // and fail when applied to the target database.

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -610,7 +610,10 @@ func normalizeSchemaNames(irData *ir.IR, fromSchema, toSchema string) {
 			agg.ReturnType = replaceString(agg.ReturnType)
 			agg.TransitionFunction = replaceString(agg.TransitionFunction)
 			agg.StateType = replaceString(agg.StateType)
-			agg.InitialCondition = replaceString(agg.InitialCondition)
+			if agg.InitialCondition != nil {
+				v := replaceString(*agg.InitialCondition)
+				agg.InitialCondition = &v
+			}
 			agg.FinalFunction = replaceString(agg.FinalFunction)
 			agg.CombineFunction = replaceString(agg.CombineFunction)
 			agg.SerialFunction = replaceString(agg.SerialFunction)
@@ -619,7 +622,10 @@ func normalizeSchemaNames(irData *ir.IR, fromSchema, toSchema string) {
 			agg.MInvTransitionFunction = replaceString(agg.MInvTransitionFunction)
 			agg.MStateType = replaceString(agg.MStateType)
 			agg.MFinalFunction = replaceString(agg.MFinalFunction)
-			agg.MInitialCondition = replaceString(agg.MInitialCondition)
+			if agg.MInitialCondition != nil {
+				v := replaceString(*agg.MInitialCondition)
+				agg.MInitialCondition = &v
+			}
 			agg.SortOperator = replaceString(agg.SortOperator)
 		}
 	}

--- a/cmd/util/ignoreloader.go
+++ b/cmd/util/ignoreloader.go
@@ -34,6 +34,7 @@ type TomlConfig struct {
 	Views             ViewIgnoreConfig             `toml:"views,omitempty"`
 	Functions         FunctionIgnoreConfig         `toml:"functions,omitempty"`
 	Procedures        ProcedureIgnoreConfig        `toml:"procedures,omitempty"`
+	Aggregates        AggregateIgnoreConfig        `toml:"aggregates,omitempty"`
 	Types             TypeIgnoreConfig             `toml:"types,omitempty"`
 	Sequences         SequenceIgnoreConfig         `toml:"sequences,omitempty"`
 	Indexes           IndexIgnoreConfig            `toml:"indexes,omitempty"`
@@ -60,6 +61,11 @@ type FunctionIgnoreConfig struct {
 
 // ProcedureIgnoreConfig represents procedure-specific ignore configuration
 type ProcedureIgnoreConfig struct {
+	Patterns []string `toml:"patterns,omitempty"`
+}
+
+// AggregateIgnoreConfig represents aggregate-specific ignore configuration
+type AggregateIgnoreConfig struct {
 	Patterns []string `toml:"patterns,omitempty"`
 }
 
@@ -142,6 +148,7 @@ func LoadIgnoreFileWithStructureFromPath(filePath string) (*ir.IgnoreConfig, err
 		Views:             tomlConfig.Views.Patterns,
 		Functions:         tomlConfig.Functions.Patterns,
 		Procedures:        tomlConfig.Procedures.Patterns,
+		Aggregates:        tomlConfig.Aggregates.Patterns,
 		Types:             tomlConfig.Types.Patterns,
 		Sequences:         tomlConfig.Sequences.Patterns,
 		Indexes:           tomlConfig.Indexes.Patterns,

--- a/docs/cli/ignore.mdx
+++ b/docs/cli/ignore.mdx
@@ -35,6 +35,9 @@ patterns = ["fn_test_*", "fn_debug_*"]
 [procedures]
 patterns = ["sp_temp_*", "sp_legacy_*"]
 
+[aggregates]
+patterns = ["agg_test_*", "agg_debug_*"]
+
 [types]
 patterns = ["type_test_*"]
 

--- a/docs/coding-agent.mdx
+++ b/docs/coding-agent.mdx
@@ -157,6 +157,7 @@ pgschema handles most common PostgreSQL schema objects:
 - **Views**: Regular and materialized views
 - **Functions**: PL/pgSQL and SQL functions with all options
 - **Procedures**: Stored procedures
+- **Aggregates**: Custom aggregates with the full option set
 - **Triggers**: Table triggers with dependency handling
 - **Types**: Custom types (enum, composite, domain)  
 - **Constraints**: Primary keys, foreign keys, unique, check constraints

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -55,6 +55,7 @@
           "syntax/unsupported",
           "syntax/alter_default_privileges",
           "syntax/comment_on",
+          "syntax/create_aggregate",
           "syntax/create_domain",
           "syntax/create_function",
           "syntax/create_index",

--- a/docs/syntax/comment_on.mdx
+++ b/docs/syntax/comment_on.mdx
@@ -8,16 +8,18 @@ title: "COMMENT ON"
 comment_on ::= COMMENT ON object_type object_name IS 'comment_text'
              | COMMENT ON object_type object_name IS NULL
 
-object_type ::= COLUMN | FUNCTION | INDEX | MATERIALIZED VIEW | PROCEDURE | TABLE | VIEW
+object_type ::= AGGREGATE | COLUMN | FUNCTION | INDEX | MATERIALIZED VIEW | PROCEDURE | TABLE | VIEW
 
 object_name ::= [schema.]name
               | [schema.]table_name.column_name                -- for columns
               | [schema.]function_name(argument_types)         -- for functions
               | [schema.]procedure_name(argument_types)        -- for procedures
+              | [schema.]aggregate_name(argument_types)        -- for aggregates
 ```
 
 `COMMENT ON` is supported for the following objects:
 
+- Aggregate
 - Column
 - Function
 - Index

--- a/docs/syntax/create_aggregate.mdx
+++ b/docs/syntax/create_aggregate.mdx
@@ -1,0 +1,71 @@
+---
+title: "CREATE AGGREGATE"
+---
+
+## Syntax
+
+```sql
+create_aggregate ::= CREATE AGGREGATE aggregate_name ( aggregate_signature ) (
+                        SFUNC = sfunc,
+                        STYPE = state_type
+                        [ , option [, ...] ]
+                     )
+
+aggregate_name ::= [schema.]name
+
+aggregate_signature ::= * | arg_type [, ...] | [ arg_type [, ...] ] ORDER BY arg_type [, ...]
+
+option ::= SSPACE = state_space
+         | FINALFUNC = ffunc
+         | FINALFUNC_EXTRA
+         | FINALFUNC_MODIFY = { READ_ONLY | SHAREABLE | READ_WRITE }
+         | COMBINEFUNC = combinefunc
+         | SERIALFUNC = serialfunc
+         | DESERIALFUNC = deserialfunc
+         | INITCOND = initial_condition
+         | MSFUNC = msfunc
+         | MINVFUNC = minvfunc
+         | MSTYPE = mstate_type
+         | MSSPACE = mstate_space
+         | MFINALFUNC = mffunc
+         | MFINALFUNC_EXTRA
+         | MFINALFUNC_MODIFY = { READ_ONLY | SHAREABLE | READ_WRITE }
+         | MINITCOND = minitial_condition
+         | SORTOP = sort_operator
+         | PARALLEL = { SAFE | RESTRICTED | UNSAFE }
+         | HYPOTHETICAL
+```
+
+pgschema understands the following `CREATE AGGREGATE` features:
+
+- **Schema-qualified names**: Aggregates can be defined in specific schemas, and overloaded aggregates (same name, different argument types) are tracked independently.
+- **Transition and final functions**: `SFUNC`/`STYPE` (required), `FINALFUNC`, `FINALFUNC_EXTRA`, and `FINALFUNC_MODIFY`.
+- **Initial condition**: `INITCOND`.
+- **Parallel aggregation**: `COMBINEFUNC`, `SERIALFUNC`, `DESERIALFUNC`, and `PARALLEL = SAFE | RESTRICTED`.
+- **Moving-aggregate support** (for window frames): `MSFUNC`, `MINVFUNC`, `MSTYPE`, `MSSPACE`, `MFINALFUNC`, `MFINALFUNC_EXTRA`, `MFINALFUNC_MODIFY`, and `MINITCOND`.
+- **State space hints**: `SSPACE` and `MSSPACE`.
+- **Sort operator**: `SORTOP` (for normal aggregates, e.g. `MIN`/`MAX`-style aggregates).
+- **Ordered-set and hypothetical-set aggregates**: the `... ORDER BY ...` signature is preserved, and `HYPOTHETICAL` is emitted for hypothetical-set aggregates.
+- **Comments**: `COMMENT ON AGGREGATE`.
+
+Support-function references (`SFUNC`, `FINALFUNC`, `COMBINEFUNC`, ...) are schema-qualified only when they live in a different schema than the aggregate itself.
+
+## Canonical Format
+
+When generating migration SQL, pgschema produces aggregates in the following canonical format:
+
+```sql
+CREATE AGGREGATE [schema.]aggregate_name(aggregate_signature) (
+    SFUNC = sfunc,
+    STYPE = state_type[,
+    ...additional options in pg_dump order...]
+);
+```
+
+**Key characteristics of the canonical format:**
+
+- `SFUNC` and `STYPE` are always emitted; every other option is emitted only when it differs from its PostgreSQL default, in the same order pg_dump uses.
+- A zero-argument aggregate renders its signature as `(*)`.
+- PostgreSQL has no `ALTER AGGREGATE` for the defining properties, so any change to an aggregate's definition is expressed as `DROP AGGREGATE` + `CREATE AGGREGATE`. A comment-only change emits just `COMMENT ON AGGREGATE`.
+- For DROP operations: `DROP AGGREGATE IF EXISTS aggregate_name(argument_types);` — the signature contains only the argument types (the identity signature).
+- Aggregates are created after their support functions and all tables, and before views that reference them; they are dropped before their support functions.

--- a/internal/diff/aggregate.go
+++ b/internal/diff/aggregate.go
@@ -8,14 +8,47 @@ import (
 	"github.com/pgplex/pgschema/ir"
 )
 
-// aggregateArgsClause returns the argument list used inside the parentheses of
-// CREATE/DROP/COMMENT AGGREGATE statements. Zero-argument aggregates (e.g. a
-// custom count(*)) use "*".
-func aggregateArgsClause(aggregate *ir.Aggregate) string {
-	if aggregate.Arguments == "" {
+// aggregateSortKey produces a fully-qualified, overload-aware key so that aggregates
+// sharing a name (overloads, or the same name across schemas) order deterministically.
+func aggregateSortKey(a *ir.Aggregate) string {
+	return a.Schema + "." + a.Name + "(" + a.Arguments + ")"
+}
+
+// aggregateArgs returns the argument list used inside the parentheses of a
+// CREATE/DROP/COMMENT AGGREGATE statement. A zero-argument aggregate (e.g. a
+// custom count(*)) has an empty list and is rendered as "*". Ordered-set and
+// hypothetical-set aggregates already carry their "... ORDER BY ..." form.
+func aggregateArgs(args string) string {
+	if args == "" {
 		return "*"
 	}
-	return aggregate.Arguments
+	return args
+}
+
+// finalFuncModifyKeyword maps the catalog code ('r'/'s'/'w') to the CREATE
+// AGGREGATE keyword. READ_ONLY ('r') is the default and is never emitted.
+func finalFuncModifyKeyword(code string) string {
+	switch code {
+	case "s":
+		return "SHAREABLE"
+	case "w":
+		return "READ_WRITE"
+	default:
+		return ""
+	}
+}
+
+// parallelKeyword maps pg_proc.proparallel ('s'/'r'/'u') to the CREATE AGGREGATE
+// keyword. UNSAFE ('u') is the default and is never emitted.
+func parallelKeyword(code string) string {
+	switch code {
+	case "s":
+		return "SAFE"
+	case "r":
+		return "RESTRICTED"
+	default:
+		return ""
+	}
 }
 
 // generateCreateAggregatesSQL generates CREATE AGGREGATE statements
@@ -24,7 +57,7 @@ func generateCreateAggregatesSQL(aggregates []*ir.Aggregate, targetSchema string
 	sortedAggregates := make([]*ir.Aggregate, len(aggregates))
 	copy(sortedAggregates, aggregates)
 	sort.Slice(sortedAggregates, func(i, j int) bool {
-		return sortedAggregates[i].Name < sortedAggregates[j].Name
+		return aggregateSortKey(sortedAggregates[i]) < aggregateSortKey(sortedAggregates[j])
 	})
 
 	for _, aggregate := range sortedAggregates {
@@ -92,7 +125,7 @@ func generateDropAggregatesSQL(aggregates []*ir.Aggregate, targetSchema string, 
 	sortedAggregates := make([]*ir.Aggregate, len(aggregates))
 	copy(sortedAggregates, aggregates)
 	sort.Slice(sortedAggregates, func(i, j int) bool {
-		return sortedAggregates[i].Name < sortedAggregates[j].Name
+		return aggregateSortKey(sortedAggregates[i]) < aggregateSortKey(sortedAggregates[j])
 	})
 
 	for _, aggregate := range sortedAggregates {
@@ -113,34 +146,95 @@ func generateDropAggregatesSQL(aggregates []*ir.Aggregate, targetSchema string, 
 // generateAggregateDropSQL builds a DROP AGGREGATE statement
 func generateAggregateDropSQL(aggregate *ir.Aggregate, targetSchema string) string {
 	aggregateName := qualifyEntityName(aggregate.Schema, aggregate.Name, targetSchema)
-	return fmt.Sprintf("DROP AGGREGATE IF EXISTS %s(%s);", aggregateName, aggregateArgsClause(aggregate))
+	return fmt.Sprintf("DROP AGGREGATE IF EXISTS %s(%s);", aggregateName, aggregateArgs(aggregate.Arguments))
 }
 
-// generateAggregateSQL generates a CREATE AGGREGATE statement
+// generateAggregateSQL generates a CREATE AGGREGATE statement, emitting options in the
+// same order as pg_dump and only when they differ from their defaults. Support-function
+// references are stored pre-qualified relative to the aggregate's schema, so they are
+// emitted verbatim.
 func generateAggregateSQL(aggregate *ir.Aggregate, targetSchema string) string {
 	var stmt strings.Builder
 
 	aggregateName := qualifyEntityName(aggregate.Schema, aggregate.Name, targetSchema)
-	stmt.WriteString(fmt.Sprintf("CREATE AGGREGATE %s(%s) (\n", aggregateName, aggregateArgsClause(aggregate)))
+	stmt.WriteString(fmt.Sprintf("CREATE AGGREGATE %s(%s) (\n", aggregateName, aggregateArgs(aggregate.Signature)))
 
 	var parts []string
-
-	// SFUNC - the state transition function (qualified relative to the target schema)
-	sfunc := qualifyEntityName(aggregate.TransitionFunctionSchema, aggregate.TransitionFunction, targetSchema)
-	parts = append(parts, fmt.Sprintf("    SFUNC = %s", sfunc))
-
-	// STYPE - the state value type
-	parts = append(parts, fmt.Sprintf("    STYPE = %s", stripSchemaPrefix(aggregate.StateType, targetSchema)))
-
-	// FINALFUNC - the optional final function
-	if aggregate.FinalFunction != "" {
-		ffunc := qualifyEntityName(aggregate.FinalFunctionSchema, aggregate.FinalFunction, targetSchema)
-		parts = append(parts, fmt.Sprintf("    FINALFUNC = %s", ffunc))
+	add := func(format string, args ...interface{}) {
+		parts = append(parts, "    "+fmt.Sprintf(format, args...))
 	}
 
-	// INITCOND - the optional initial condition
+	// SFUNC / STYPE are always present.
+	add("SFUNC = %s", aggregate.TransitionFunction)
+	add("STYPE = %s", stripSchemaPrefix(aggregate.StateType, targetSchema))
+	if aggregate.StateSpace != 0 {
+		add("SSPACE = %d", aggregate.StateSpace)
+	}
+
+	// Final function group.
+	if aggregate.FinalFunction != "" {
+		add("FINALFUNC = %s", aggregate.FinalFunction)
+	}
+	if aggregate.FinalFuncExtra {
+		add("FINALFUNC_EXTRA")
+	}
+	if kw := finalFuncModifyKeyword(aggregate.FinalFuncModify); kw != "" {
+		add("FINALFUNC_MODIFY = %s", kw)
+	}
+
+	// Parallel-aggregation support functions.
+	if aggregate.CombineFunction != "" {
+		add("COMBINEFUNC = %s", aggregate.CombineFunction)
+	}
+	if aggregate.SerialFunction != "" {
+		add("SERIALFUNC = %s", aggregate.SerialFunction)
+	}
+	if aggregate.DeserialFunction != "" {
+		add("DESERIALFUNC = %s", aggregate.DeserialFunction)
+	}
+
 	if aggregate.InitialCondition != "" {
-		parts = append(parts, fmt.Sprintf("    INITCOND = %s", quoteString(aggregate.InitialCondition)))
+		add("INITCOND = %s", quoteString(aggregate.InitialCondition))
+	}
+
+	// Moving-aggregate group (gated on a moving transition function).
+	if aggregate.MTransitionFunction != "" {
+		add("MSFUNC = %s", aggregate.MTransitionFunction)
+		if aggregate.MInvTransitionFunction != "" {
+			add("MINVFUNC = %s", aggregate.MInvTransitionFunction)
+		}
+		if aggregate.MStateType != "" {
+			add("MSTYPE = %s", stripSchemaPrefix(aggregate.MStateType, targetSchema))
+		}
+		if aggregate.MStateSpace != 0 {
+			add("MSSPACE = %d", aggregate.MStateSpace)
+		}
+	}
+	if aggregate.MFinalFunction != "" {
+		add("MFINALFUNC = %s", aggregate.MFinalFunction)
+	}
+	if aggregate.MFinalFuncExtra {
+		add("MFINALFUNC_EXTRA")
+	}
+	if kw := finalFuncModifyKeyword(aggregate.MFinalFuncModify); kw != "" {
+		add("MFINALFUNC_MODIFY = %s", kw)
+	}
+	if aggregate.MInitialCondition != "" {
+		add("MINITCOND = %s", quoteString(aggregate.MInitialCondition))
+	}
+
+	// SORTOP is only emitted for normal aggregates.
+	if aggregate.SortOperator != "" && aggregate.Kind == "n" {
+		add("SORTOP = %s", aggregate.SortOperator)
+	}
+
+	if kw := parallelKeyword(aggregate.Parallel); kw != "" {
+		add("PARALLEL = %s", kw)
+	}
+
+	// HYPOTHETICAL flag for hypothetical-set aggregates.
+	if aggregate.Kind == "h" {
+		add("HYPOTHETICAL")
 	}
 
 	stmt.WriteString(strings.Join(parts, ",\n"))
@@ -152,7 +246,7 @@ func generateAggregateSQL(aggregate *ir.Aggregate, targetSchema string) string {
 // generateAggregateComment generates a COMMENT ON AGGREGATE statement
 func generateAggregateComment(aggregate *ir.Aggregate, targetSchema string, operation DiffOperation, collector *diffCollector) {
 	aggregateName := qualifyEntityName(aggregate.Schema, aggregate.Name, targetSchema)
-	argsClause := aggregateArgsClause(aggregate)
+	argsClause := aggregateArgs(aggregate.Arguments)
 
 	var sql string
 	if aggregate.Comment == "" {
@@ -181,11 +275,27 @@ func aggregatesEqualExceptComment(old, new *ir.Aggregate) bool {
 	return old.Schema == new.Schema &&
 		old.Name == new.Name &&
 		old.Arguments == new.Arguments &&
+		old.Signature == new.Signature &&
+		old.Kind == new.Kind &&
 		old.ReturnType == new.ReturnType &&
+		old.Parallel == new.Parallel &&
 		old.TransitionFunction == new.TransitionFunction &&
-		old.TransitionFunctionSchema == new.TransitionFunctionSchema &&
 		old.StateType == new.StateType &&
+		old.StateSpace == new.StateSpace &&
 		old.InitialCondition == new.InitialCondition &&
 		old.FinalFunction == new.FinalFunction &&
-		old.FinalFunctionSchema == new.FinalFunctionSchema
+		old.FinalFuncExtra == new.FinalFuncExtra &&
+		old.FinalFuncModify == new.FinalFuncModify &&
+		old.CombineFunction == new.CombineFunction &&
+		old.SerialFunction == new.SerialFunction &&
+		old.DeserialFunction == new.DeserialFunction &&
+		old.MTransitionFunction == new.MTransitionFunction &&
+		old.MInvTransitionFunction == new.MInvTransitionFunction &&
+		old.MStateType == new.MStateType &&
+		old.MStateSpace == new.MStateSpace &&
+		old.MFinalFunction == new.MFinalFunction &&
+		old.MFinalFuncExtra == new.MFinalFuncExtra &&
+		old.MFinalFuncModify == new.MFinalFuncModify &&
+		old.MInitialCondition == new.MInitialCondition &&
+		old.SortOperator == new.SortOperator
 }

--- a/internal/diff/aggregate.go
+++ b/internal/diff/aggregate.go
@@ -193,8 +193,8 @@ func generateAggregateSQL(aggregate *ir.Aggregate, targetSchema string) string {
 		add("DESERIALFUNC = %s", aggregate.DeserialFunction)
 	}
 
-	if aggregate.InitialCondition != "" {
-		add("INITCOND = %s", quoteString(aggregate.InitialCondition))
+	if aggregate.InitialCondition != nil {
+		add("INITCOND = %s", quoteString(*aggregate.InitialCondition))
 	}
 
 	// Moving-aggregate group (gated on a moving transition function).
@@ -219,8 +219,8 @@ func generateAggregateSQL(aggregate *ir.Aggregate, targetSchema string) string {
 	if kw := finalFuncModifyKeyword(aggregate.MFinalFuncModify); kw != "" {
 		add("MFINALFUNC_MODIFY = %s", kw)
 	}
-	if aggregate.MInitialCondition != "" {
-		add("MINITCOND = %s", quoteString(aggregate.MInitialCondition))
+	if aggregate.MInitialCondition != nil {
+		add("MINITCOND = %s", quoteString(*aggregate.MInitialCondition))
 	}
 
 	// SORTOP is only emitted for normal aggregates.
@@ -282,7 +282,7 @@ func aggregatesEqualExceptComment(old, new *ir.Aggregate) bool {
 		old.TransitionFunction == new.TransitionFunction &&
 		old.StateType == new.StateType &&
 		old.StateSpace == new.StateSpace &&
-		old.InitialCondition == new.InitialCondition &&
+		stringPtrEqual(old.InitialCondition, new.InitialCondition) &&
 		old.FinalFunction == new.FinalFunction &&
 		old.FinalFuncExtra == new.FinalFuncExtra &&
 		old.FinalFuncModify == new.FinalFuncModify &&
@@ -296,6 +296,15 @@ func aggregatesEqualExceptComment(old, new *ir.Aggregate) bool {
 		old.MFinalFunction == new.MFinalFunction &&
 		old.MFinalFuncExtra == new.MFinalFuncExtra &&
 		old.MFinalFuncModify == new.MFinalFuncModify &&
-		old.MInitialCondition == new.MInitialCondition &&
+		stringPtrEqual(old.MInitialCondition, new.MInitialCondition) &&
 		old.SortOperator == new.SortOperator
+}
+
+// stringPtrEqual compares two optional strings, distinguishing nil (NULL) from a
+// pointer to the empty string.
+func stringPtrEqual(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }

--- a/internal/diff/aggregate.go
+++ b/internal/diff/aggregate.go
@@ -1,0 +1,191 @@
+package diff
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pgplex/pgschema/ir"
+)
+
+// aggregateArgsClause returns the argument list used inside the parentheses of
+// CREATE/DROP/COMMENT AGGREGATE statements. Zero-argument aggregates (e.g. a
+// custom count(*)) use "*".
+func aggregateArgsClause(aggregate *ir.Aggregate) string {
+	if aggregate.Arguments == "" {
+		return "*"
+	}
+	return aggregate.Arguments
+}
+
+// generateCreateAggregatesSQL generates CREATE AGGREGATE statements
+func generateCreateAggregatesSQL(aggregates []*ir.Aggregate, targetSchema string, collector *diffCollector) {
+	// Sort aggregates by name for consistent ordering
+	sortedAggregates := make([]*ir.Aggregate, len(aggregates))
+	copy(sortedAggregates, aggregates)
+	sort.Slice(sortedAggregates, func(i, j int) bool {
+		return sortedAggregates[i].Name < sortedAggregates[j].Name
+	})
+
+	for _, aggregate := range sortedAggregates {
+		sql := generateAggregateSQL(aggregate, targetSchema)
+
+		context := &diffContext{
+			Type:                DiffTypeAggregate,
+			Operation:           DiffOperationCreate,
+			Path:                fmt.Sprintf("%s.%s", aggregate.Schema, aggregate.Name),
+			Source:              aggregate,
+			CanRunInTransaction: true,
+		}
+
+		collector.collect(context, sql)
+
+		// Generate COMMENT ON AGGREGATE if the aggregate has a comment
+		if aggregate.Comment != "" {
+			generateAggregateComment(aggregate, targetSchema, DiffOperationCreate, collector)
+		}
+	}
+}
+
+// generateModifyAggregatesSQL generates DROP and CREATE AGGREGATE statements for modified aggregates.
+// PostgreSQL has no ALTER AGGREGATE for the defining properties (SFUNC, STYPE, etc.),
+// so any substantive change is expressed as DROP + CREATE.
+func generateModifyAggregatesSQL(diffs []*aggregateDiff, targetSchema string, collector *diffCollector) {
+	for _, diff := range diffs {
+		oldAgg := diff.Old
+		newAgg := diff.New
+
+		// Check if only the comment changed (no definitional change)
+		if aggregatesEqualExceptComment(oldAgg, newAgg) && oldAgg.Comment != newAgg.Comment {
+			generateAggregateComment(newAgg, targetSchema, DiffOperationAlter, collector)
+			continue
+		}
+
+		dropSQL := generateAggregateDropSQL(oldAgg, targetSchema)
+		createSQL := generateAggregateSQL(newAgg, targetSchema)
+
+		alterContext := &diffContext{
+			Type:                DiffTypeAggregate,
+			Operation:           DiffOperationAlter,
+			Path:                fmt.Sprintf("%s.%s", newAgg.Schema, newAgg.Name),
+			Source:              diff,
+			CanRunInTransaction: true,
+		}
+
+		statements := []SQLStatement{
+			{SQL: dropSQL, CanRunInTransaction: true},
+			{SQL: createSQL, CanRunInTransaction: true},
+		}
+
+		collector.collectStatements(alterContext, statements)
+
+		// Re-apply the comment after recreation if one is set
+		if newAgg.Comment != "" {
+			generateAggregateComment(newAgg, targetSchema, DiffOperationAlter, collector)
+		}
+	}
+}
+
+// generateDropAggregatesSQL generates DROP AGGREGATE statements
+func generateDropAggregatesSQL(aggregates []*ir.Aggregate, targetSchema string, collector *diffCollector) {
+	// Sort aggregates by name for consistent ordering
+	sortedAggregates := make([]*ir.Aggregate, len(aggregates))
+	copy(sortedAggregates, aggregates)
+	sort.Slice(sortedAggregates, func(i, j int) bool {
+		return sortedAggregates[i].Name < sortedAggregates[j].Name
+	})
+
+	for _, aggregate := range sortedAggregates {
+		sql := generateAggregateDropSQL(aggregate, targetSchema)
+
+		context := &diffContext{
+			Type:                DiffTypeAggregate,
+			Operation:           DiffOperationDrop,
+			Path:                fmt.Sprintf("%s.%s", aggregate.Schema, aggregate.Name),
+			Source:              aggregate,
+			CanRunInTransaction: true,
+		}
+
+		collector.collect(context, sql)
+	}
+}
+
+// generateAggregateDropSQL builds a DROP AGGREGATE statement
+func generateAggregateDropSQL(aggregate *ir.Aggregate, targetSchema string) string {
+	aggregateName := qualifyEntityName(aggregate.Schema, aggregate.Name, targetSchema)
+	return fmt.Sprintf("DROP AGGREGATE IF EXISTS %s(%s);", aggregateName, aggregateArgsClause(aggregate))
+}
+
+// generateAggregateSQL generates a CREATE AGGREGATE statement
+func generateAggregateSQL(aggregate *ir.Aggregate, targetSchema string) string {
+	var stmt strings.Builder
+
+	aggregateName := qualifyEntityName(aggregate.Schema, aggregate.Name, targetSchema)
+	stmt.WriteString(fmt.Sprintf("CREATE AGGREGATE %s(%s) (\n", aggregateName, aggregateArgsClause(aggregate)))
+
+	var parts []string
+
+	// SFUNC - the state transition function (qualified relative to the target schema)
+	sfunc := qualifyEntityName(aggregate.TransitionFunctionSchema, aggregate.TransitionFunction, targetSchema)
+	parts = append(parts, fmt.Sprintf("    SFUNC = %s", sfunc))
+
+	// STYPE - the state value type
+	parts = append(parts, fmt.Sprintf("    STYPE = %s", stripSchemaPrefix(aggregate.StateType, targetSchema)))
+
+	// FINALFUNC - the optional final function
+	if aggregate.FinalFunction != "" {
+		ffunc := qualifyEntityName(aggregate.FinalFunctionSchema, aggregate.FinalFunction, targetSchema)
+		parts = append(parts, fmt.Sprintf("    FINALFUNC = %s", ffunc))
+	}
+
+	// INITCOND - the optional initial condition
+	if aggregate.InitialCondition != "" {
+		parts = append(parts, fmt.Sprintf("    INITCOND = %s", quoteString(aggregate.InitialCondition)))
+	}
+
+	stmt.WriteString(strings.Join(parts, ",\n"))
+	stmt.WriteString("\n);")
+
+	return stmt.String()
+}
+
+// generateAggregateComment generates a COMMENT ON AGGREGATE statement
+func generateAggregateComment(aggregate *ir.Aggregate, targetSchema string, operation DiffOperation, collector *diffCollector) {
+	aggregateName := qualifyEntityName(aggregate.Schema, aggregate.Name, targetSchema)
+	argsClause := aggregateArgsClause(aggregate)
+
+	var sql string
+	if aggregate.Comment == "" {
+		sql = fmt.Sprintf("COMMENT ON AGGREGATE %s(%s) IS NULL;", aggregateName, argsClause)
+	} else {
+		sql = fmt.Sprintf("COMMENT ON AGGREGATE %s(%s) IS %s;", aggregateName, argsClause, quoteString(aggregate.Comment))
+	}
+
+	context := &diffContext{
+		Type:                DiffTypeAggregate,
+		Operation:           operation,
+		Path:                fmt.Sprintf("%s.%s", aggregate.Schema, aggregate.Name),
+		Source:              aggregate,
+		CanRunInTransaction: true,
+	}
+	collector.collect(context, sql)
+}
+
+// aggregatesEqual compares two aggregates for equality
+func aggregatesEqual(old, new *ir.Aggregate) bool {
+	return aggregatesEqualExceptComment(old, new) && old.Comment == new.Comment
+}
+
+// aggregatesEqualExceptComment compares two aggregates ignoring comment differences
+func aggregatesEqualExceptComment(old, new *ir.Aggregate) bool {
+	return old.Schema == new.Schema &&
+		old.Name == new.Name &&
+		old.Arguments == new.Arguments &&
+		old.ReturnType == new.ReturnType &&
+		old.TransitionFunction == new.TransitionFunction &&
+		old.TransitionFunctionSchema == new.TransitionFunctionSchema &&
+		old.StateType == new.StateType &&
+		old.InitialCondition == new.InitialCondition &&
+		old.FinalFunction == new.FinalFunction &&
+		old.FinalFunctionSchema == new.FinalFunctionSchema
+}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1676,10 +1676,6 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	// Create procedures (procedures may depend on tables and domains)
 	generateCreateProceduresSQL(d.addedProcedures, targetSchema, collector)
 
-	// Create aggregates after their transition/final functions exist, and before
-	// views (which may reference the aggregates in their definitions).
-	generateCreateAggregatesSQL(d.addedAggregates, targetSchema, collector)
-
 	// Create tables WITH function/domain dependencies (now that functions and deferred domains exist)
 	deferredPolicies2, deferredConstraints2 := generateCreateTablesSQL(tablesWithDeps, targetSchema, collector, existingTables, shouldDeferPolicy)
 
@@ -1687,6 +1683,11 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	// This ensures FK references to tables in the second batch (function-dependent tables) work correctly
 	allDeferredConstraints := append(deferredConstraints1, deferredConstraints2...)
 	generateDeferredConstraintsSQL(allDeferredConstraints, targetSchema, collector)
+
+	// Create aggregates after their transition/final functions AND all tables exist
+	// (an aggregate may use a new table's row type as an argument or state type), and
+	// before views, which may reference the aggregates in their definitions.
+	generateCreateAggregatesSQL(d.addedAggregates, targetSchema, collector)
 
 	// Merge deferred policies from both batches
 	allDeferredPolicies := append(deferredPolicies1, deferredPolicies2...)

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -34,6 +34,7 @@ const (
 	DiffTypeMaterializedViewIndexComment
 	DiffTypeFunction
 	DiffTypeProcedure
+	DiffTypeAggregate
 	DiffTypeSequence
 	DiffTypeType
 	DiffTypeDomain
@@ -87,6 +88,8 @@ func (d DiffType) String() string {
 		return "function"
 	case DiffTypeProcedure:
 		return "procedure"
+	case DiffTypeAggregate:
+		return "aggregate"
 	case DiffTypeSequence:
 		return "sequence"
 	case DiffTypeType:
@@ -161,6 +164,8 @@ func (d *DiffType) UnmarshalJSON(data []byte) error {
 		*d = DiffTypeFunction
 	case "procedure":
 		*d = DiffTypeProcedure
+	case "aggregate":
+		*d = DiffTypeAggregate
 	case "sequence":
 		*d = DiffTypeSequence
 	case "type":
@@ -276,6 +281,9 @@ type ddlDiff struct {
 	addedProcedures           []*ir.Procedure
 	droppedProcedures         []*ir.Procedure
 	modifiedProcedures        []*procedureDiff
+	addedAggregates           []*ir.Aggregate
+	droppedAggregates         []*ir.Aggregate
+	modifiedAggregates        []*aggregateDiff
 	addedTypes                []*ir.Type
 	droppedTypes              []*ir.Type
 	modifiedTypes             []*typeDiff
@@ -319,6 +327,12 @@ type functionDiff struct {
 type procedureDiff struct {
 	Old *ir.Procedure
 	New *ir.Procedure
+}
+
+// aggregateDiff represents changes to an aggregate
+type aggregateDiff struct {
+	Old *ir.Aggregate
+	New *ir.Aggregate
 }
 
 // typeDiff represents changes to a type
@@ -448,6 +462,9 @@ func GenerateMigration(oldIR, newIR *ir.IR, targetSchema string) []Diff {
 		addedProcedures:            []*ir.Procedure{},
 		droppedProcedures:          []*ir.Procedure{},
 		modifiedProcedures:         []*procedureDiff{},
+		addedAggregates:            []*ir.Aggregate{},
+		droppedAggregates:          []*ir.Aggregate{},
+		modifiedAggregates:         []*aggregateDiff{},
 		addedTypes:                 []*ir.Type{},
 		droppedTypes:               []*ir.Type{},
 		modifiedTypes:              []*typeDiff{},
@@ -685,6 +702,63 @@ func GenerateMigration(oldIR, newIR *ir.IR, targetSchema string) []Diff {
 				diff.modifiedProcedures = append(diff.modifiedProcedures, &procedureDiff{
 					Old: oldProcedure,
 					New: newProcedure,
+				})
+			}
+		}
+	}
+
+	// Compare aggregates across all schemas
+	oldAggregates := make(map[string]*ir.Aggregate)
+	newAggregates := make(map[string]*ir.Aggregate)
+
+	// Extract aggregates from all schemas in oldIR in deterministic order
+	for _, dbSchema := range oldIR.Schemas {
+		aggNames := sortedKeys(dbSchema.Aggregates)
+		for _, aggName := range aggNames {
+			aggregate := dbSchema.Aggregates[aggName]
+			// aggName already contains signature as name(arguments) from inspector
+			key := aggregate.Schema + "." + aggName
+			oldAggregates[key] = aggregate
+		}
+	}
+
+	// Extract aggregates from all schemas in newIR in deterministic order
+	for _, dbSchema := range newIR.Schemas {
+		aggNames := sortedKeys(dbSchema.Aggregates)
+		for _, aggName := range aggNames {
+			aggregate := dbSchema.Aggregates[aggName]
+			// aggName already contains signature as name(arguments) from inspector
+			key := aggregate.Schema + "." + aggName
+			newAggregates[key] = aggregate
+		}
+	}
+
+	// Find added aggregates in deterministic order
+	aggregateKeys := sortedKeys(newAggregates)
+	for _, key := range aggregateKeys {
+		aggregate := newAggregates[key]
+		if _, exists := oldAggregates[key]; !exists {
+			diff.addedAggregates = append(diff.addedAggregates, aggregate)
+		}
+	}
+
+	// Find dropped aggregates in deterministic order
+	oldAggregateKeys := sortedKeys(oldAggregates)
+	for _, key := range oldAggregateKeys {
+		aggregate := oldAggregates[key]
+		if _, exists := newAggregates[key]; !exists {
+			diff.droppedAggregates = append(diff.droppedAggregates, aggregate)
+		}
+	}
+
+	// Find modified aggregates in deterministic order
+	for _, key := range aggregateKeys {
+		newAggregate := newAggregates[key]
+		if oldAggregate, exists := oldAggregates[key]; exists {
+			if !aggregatesEqual(oldAggregate, newAggregate) {
+				diff.modifiedAggregates = append(diff.modifiedAggregates, &aggregateDiff{
+					Old: oldAggregate,
+					New: newAggregate,
 				})
 			}
 		}
@@ -1602,6 +1676,10 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	// Create procedures (procedures may depend on tables and domains)
 	generateCreateProceduresSQL(d.addedProcedures, targetSchema, collector)
 
+	// Create aggregates after their transition/final functions exist, and before
+	// views (which may reference the aggregates in their definitions).
+	generateCreateAggregatesSQL(d.addedAggregates, targetSchema, collector)
+
 	// Create tables WITH function/domain dependencies (now that functions and deferred domains exist)
 	deferredPolicies2, deferredConstraints2 := generateCreateTablesSQL(tablesWithDeps, targetSchema, collector, existingTables, shouldDeferPolicy)
 
@@ -1742,6 +1820,9 @@ func (d *ddlDiff) generateModifySQL(targetSchema string, collector *diffCollecto
 	// Modify procedures
 	generateModifyProceduresSQL(d.modifiedProcedures, targetSchema, collector)
 
+	// Modify aggregates (DROP + CREATE for definitional changes)
+	generateModifyAggregatesSQL(d.modifiedAggregates, targetSchema, collector)
+
 	// Modify default privileges
 	generateModifyDefaultPrivilegesSQL(d.modifiedDefaultPrivileges, targetSchema, collector)
 
@@ -1769,6 +1850,10 @@ func (d *ddlDiff) generateDropSQL(targetSchema string, collector *diffCollector,
 	// Drop triggers from modified tables and views first (triggers depend on functions)
 	generateDropTriggersFromModifiedTables(d.modifiedTables, targetSchema, collector)
 	generateDropTriggersFromModifiedViews(d.modifiedViews, targetSchema, collector)
+
+	// Drop aggregates before functions, since an aggregate depends on its
+	// transition/final functions (issue #416).
+	generateDropAggregatesSQL(d.droppedAggregates, targetSchema, collector)
 
 	// Drop functions
 	generateDropFunctionsSQL(d.droppedFunctions, targetSchema, collector)
@@ -2228,6 +2313,7 @@ func referencesNewFunction(expr, defaultSchema string, newFunctions map[string]s
 func (d *schemaDiff) GetObjectName() string     { return d.New.Name }
 func (d *functionDiff) GetObjectName() string   { return d.New.Name }
 func (d *procedureDiff) GetObjectName() string  { return d.New.Name }
+func (d *aggregateDiff) GetObjectName() string  { return d.New.Name }
 func (d *typeDiff) GetObjectName() string       { return d.New.Name }
 func (d *sequenceDiff) GetObjectName() string   { return d.New.Name }
 func (d *triggerDiff) GetObjectName() string    { return d.New.Name }

--- a/internal/dump/formatter.go
+++ b/internal/dump/formatter.go
@@ -116,7 +116,9 @@ func (f *DumpFormatter) FormatMultiFile(diffs []diff.Diff, outputPath string) er
 	}
 
 	// Create files in dependency order
-	orderedDirs := []string{"types", "domains", "sequences", "functions", "procedures", "aggregates", "tables", "views", "materialized_views", "default_privileges", "privileges"}
+	// Aggregates come after tables (an aggregate may reference a table's row type) and
+	// before views (which may reference the aggregate), matching the diff create order.
+	orderedDirs := []string{"types", "domains", "sequences", "functions", "procedures", "tables", "aggregates", "views", "materialized_views", "default_privileges", "privileges"}
 
 	for _, dir := range orderedDirs {
 		if objects, exists := filesByType[dir]; exists {

--- a/internal/dump/formatter.go
+++ b/internal/dump/formatter.go
@@ -116,7 +116,7 @@ func (f *DumpFormatter) FormatMultiFile(diffs []diff.Diff, outputPath string) er
 	}
 
 	// Create files in dependency order
-	orderedDirs := []string{"types", "domains", "sequences", "functions", "procedures", "tables", "views", "materialized_views", "default_privileges", "privileges"}
+	orderedDirs := []string{"types", "domains", "sequences", "functions", "procedures", "aggregates", "tables", "views", "materialized_views", "default_privileges", "privileges"}
 
 	for _, dir := range orderedDirs {
 		if objects, exists := filesByType[dir]; exists {
@@ -245,6 +245,8 @@ func (f *DumpFormatter) getObjectDirectory(objectType string) string {
 		return "functions"
 	case "procedure":
 		return "procedures"
+	case "aggregate":
+		return "aggregates"
 	case "table":
 		return "tables"
 	case "view":
@@ -477,6 +479,12 @@ func (f *DumpFormatter) formatObjectCommentHeader(step diff.Diff) string {
 		objectName = obj.Name + "(" + obj.GetArguments() + ")"
 	case *ir.Procedure:
 		objectName = obj.Name + "(" + obj.GetArguments() + ")"
+	case *ir.Aggregate:
+		argsClause := obj.Arguments
+		if argsClause == "" {
+			argsClause = "*"
+		}
+		objectName = obj.Name + "(" + argsClause + ")"
 	default:
 		// Use the GetObjectName interface method for all other types
 		objectName = step.Source.GetObjectName()

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -91,6 +91,7 @@ const (
 	TypeType                    Type = "types"
 	TypeFunction                Type = "functions"
 	TypeProcedure               Type = "procedures"
+	TypeAggregate               Type = "aggregates"
 	TypeSequence                Type = "sequences"
 	TypeTable                   Type = "tables"
 	TypeView                    Type = "views"
@@ -124,6 +125,7 @@ func getObjectOrder() []Type {
 		TypeType,
 		TypeFunction,
 		TypeProcedure,
+		TypeAggregate,
 		TypeSequence,
 		TypeTable,
 		TypeView,

--- a/ir/ignore.go
+++ b/ir/ignore.go
@@ -20,6 +20,7 @@ type IgnoreConfig struct {
 	Views             []string `toml:"views,omitempty"`
 	Functions         []string `toml:"functions,omitempty"`
 	Procedures        []string `toml:"procedures,omitempty"`
+	Aggregates        []string `toml:"aggregates,omitempty"`
 	Types             []string `toml:"types,omitempty"`
 	Sequences         []string `toml:"sequences,omitempty"`
 	Indexes           []string `toml:"indexes,omitempty"`
@@ -59,6 +60,14 @@ func (c *IgnoreConfig) ShouldIgnoreProcedure(procedureName string) bool {
 		return false
 	}
 	return c.shouldIgnore(procedureName, c.Procedures)
+}
+
+// ShouldIgnoreAggregate checks if an aggregate should be ignored based on the patterns
+func (c *IgnoreConfig) ShouldIgnoreAggregate(aggregateName string) bool {
+	if c == nil {
+		return false
+	}
+	return c.shouldIgnore(aggregateName, c.Aggregates)
 }
 
 // ShouldIgnoreType checks if a type should be ignored based on the patterns

--- a/ir/ignore_test.go
+++ b/ir/ignore_test.go
@@ -105,6 +105,7 @@ func TestIgnoreConfig_AllObjectTypes(t *testing.T) {
 		Views:       []string{"view_*"},
 		Functions:   []string{"fn_*"},
 		Procedures:  []string{"sp_*"},
+		Aggregates:  []string{"agg_*"},
 		Types:       []string{"type_*"},
 		Sequences:   []string{"seq_*"},
 		Indexes:     []string{"idx_*"},
@@ -126,6 +127,8 @@ func TestIgnoreConfig_AllObjectTypes(t *testing.T) {
 		{config.ShouldIgnoreFunction, "get_user", false},
 		{config.ShouldIgnoreProcedure, "sp_temp", true},
 		{config.ShouldIgnoreProcedure, "process_data", false},
+		{config.ShouldIgnoreAggregate, "agg_temp", true},
+		{config.ShouldIgnoreAggregate, "group_concat", false},
 		{config.ShouldIgnoreType, "type_temp", true},
 		{config.ShouldIgnoreType, "user_status", false},
 		{config.ShouldIgnoreSequence, "seq_temp", true},
@@ -161,6 +164,9 @@ func TestIgnoreConfig_NilConfig(t *testing.T) {
 	}
 	if config.ShouldIgnoreProcedure("any_procedure") {
 		t.Error("nil config should not ignore any procedure")
+	}
+	if config.ShouldIgnoreAggregate("any_aggregate") {
+		t.Error("nil config should not ignore any aggregate")
 	}
 	if config.ShouldIgnoreType("any_type") {
 		t.Error("nil config should not ignore any type")

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -1347,6 +1347,19 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 		// Identity args (types only) drive the DROP/COMMENT signature and the overload key.
 		identityArgs := i.safeInterfaceToString(agg.AggregateIdentityArgs)
 
+		// agginitval/aggminitval are nullable: preserve NULL (nil) vs explicit '' so an
+		// INITCOND/MINITCOND of empty string is not silently dropped.
+		var initialCondition *string
+		if agg.InitialCondition.Valid {
+			v := agg.InitialCondition.String
+			initialCondition = &v
+		}
+		var minitialCondition *string
+		if agg.MinitialCondition.Valid {
+			v := agg.MinitialCondition.String
+			minitialCondition = &v
+		}
+
 		dbSchema := schema.getOrCreateSchema(schemaName)
 
 		aggregate := &Aggregate{
@@ -1361,7 +1374,7 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 			TransitionFunction: i.safeInterfaceToString(agg.TransitionFunction),
 			StateType:          i.safeInterfaceToString(agg.StateType),
 			StateSpace:         int(agg.StateSpace),
-			InitialCondition:   i.safeInterfaceToString(agg.InitialCondition),
+			InitialCondition:   initialCondition,
 
 			FinalFunction:   i.safeInterfaceToString(agg.FinalFunction),
 			FinalFuncExtra:  agg.FinalFuncExtra,
@@ -1378,7 +1391,7 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 			MFinalFunction:         i.safeInterfaceToString(agg.MfinalFunction),
 			MFinalFuncExtra:        agg.MfinalFuncExtra,
 			MFinalFuncModify:       i.safeInterfaceToString(agg.MfinalFuncModify),
-			MInitialCondition:      i.safeInterfaceToString(agg.MinitialCondition),
+			MInitialCondition:      minitialCondition,
 
 			SortOperator: i.safeInterfaceToString(agg.SortOperator),
 

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -1343,41 +1343,56 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 	for _, agg := range aggregates {
 		schemaName := agg.AggregateSchema
 		aggregateName := agg.AggregateName
-		comment := ""
-		if agg.AggregateComment.Valid {
-			comment = agg.AggregateComment.String
-		}
-		arguments := ""
-		if agg.AggregateArguments.Valid {
-			arguments = agg.AggregateArguments.String
-		}
-		returnType := i.safeInterfaceToString(agg.AggregateReturnType)
-		transitionFunction := i.safeInterfaceToString(agg.TransitionFunction)
-		transitionFunctionSchema := i.safeInterfaceToString(agg.TransitionFunctionSchema)
-		stateType := i.safeInterfaceToString(agg.StateType)
-		initialCondition := i.safeInterfaceToString(agg.InitialCondition)
-		finalFunction := i.safeInterfaceToString(agg.FinalFunction)
-		finalFunctionSchema := i.safeInterfaceToString(agg.FinalFunctionSchema)
+
+		// Identity args (types only) drive the DROP/COMMENT signature and the overload key.
+		identityArgs := i.safeInterfaceToString(agg.AggregateIdentityArgs)
 
 		dbSchema := schema.getOrCreateSchema(schemaName)
 
 		aggregate := &Aggregate{
-			Schema:                   schemaName,
-			Name:                     aggregateName,
-			Arguments:                arguments,
-			ReturnType:               returnType,
-			TransitionFunction:       transitionFunction,
-			TransitionFunctionSchema: transitionFunctionSchema,
-			StateType:                stateType,
-			InitialCondition:         initialCondition,
-			FinalFunction:            finalFunction,
-			FinalFunctionSchema:      finalFunctionSchema,
-			Comment:                  comment,
+			Schema:     schemaName,
+			Name:       aggregateName,
+			Arguments:  identityArgs,
+			Signature:  i.safeInterfaceToString(agg.AggregateSignature),
+			Kind:       i.safeInterfaceToString(agg.AggregateKind),
+			ReturnType: i.safeInterfaceToString(agg.AggregateReturnType),
+			Parallel:   i.safeInterfaceToString(agg.Parallel),
+
+			TransitionFunction: i.safeInterfaceToString(agg.TransitionFunction),
+			StateType:          i.safeInterfaceToString(agg.StateType),
+			StateSpace:         int(agg.StateSpace),
+			InitialCondition:   i.safeInterfaceToString(agg.InitialCondition),
+
+			FinalFunction:   i.safeInterfaceToString(agg.FinalFunction),
+			FinalFuncExtra:  agg.FinalFuncExtra,
+			FinalFuncModify: i.safeInterfaceToString(agg.FinalFuncModify),
+
+			CombineFunction:  i.safeInterfaceToString(agg.CombineFunction),
+			SerialFunction:   i.safeInterfaceToString(agg.SerialFunction),
+			DeserialFunction: i.safeInterfaceToString(agg.DeserialFunction),
+
+			MTransitionFunction:    i.safeInterfaceToString(agg.MtransitionFunction),
+			MInvTransitionFunction: i.safeInterfaceToString(agg.MinvTransitionFunction),
+			MStateType:             i.safeInterfaceToString(agg.MstateType),
+			MStateSpace:            int(agg.MstateSpace),
+			MFinalFunction:         i.safeInterfaceToString(agg.MfinalFunction),
+			MFinalFuncExtra:        agg.MfinalFuncExtra,
+			MFinalFuncModify:       i.safeInterfaceToString(agg.MfinalFuncModify),
+			MInitialCondition:      i.safeInterfaceToString(agg.MinitialCondition),
+
+			SortOperator: i.safeInterfaceToString(agg.SortOperator),
+
+			Comment: i.safeInterfaceToString(agg.AggregateComment),
+		}
+
+		// Check if aggregate should be ignored
+		if i.ignoreConfig != nil && i.ignoreConfig.ShouldIgnoreAggregate(aggregateName) {
+			continue
 		}
 
 		// Use name(arguments) as key to support aggregate overloading,
 		// mirroring how functions and procedures are keyed.
-		aggregateKey := aggregateName + "(" + arguments + ")"
+		aggregateKey := aggregateName + "(" + identityArgs + ")"
 		dbSchema.SetAggregate(aggregateKey, aggregate)
 	}
 

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -1347,6 +1347,10 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 		if agg.AggregateComment.Valid {
 			comment = agg.AggregateComment.String
 		}
+		arguments := ""
+		if agg.AggregateArguments.Valid {
+			arguments = agg.AggregateArguments.String
+		}
 		returnType := i.safeInterfaceToString(agg.AggregateReturnType)
 		transitionFunction := i.safeInterfaceToString(agg.TransitionFunction)
 		transitionFunctionSchema := i.safeInterfaceToString(agg.TransitionFunctionSchema)
@@ -1360,6 +1364,7 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 		aggregate := &Aggregate{
 			Schema:                   schemaName,
 			Name:                     aggregateName,
+			Arguments:                arguments,
 			ReturnType:               returnType,
 			TransitionFunction:       transitionFunction,
 			TransitionFunctionSchema: transitionFunctionSchema,
@@ -1370,7 +1375,10 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 			Comment:                  comment,
 		}
 
-		dbSchema.SetAggregate(aggregateName, aggregate)
+		// Use name(arguments) as key to support aggregate overloading,
+		// mirroring how functions and procedures are keyed.
+		aggregateKey := aggregateName + "(" + arguments + ")"
+		dbSchema.SetAggregate(aggregateKey, aggregate)
 	}
 
 	return nil

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -391,6 +391,7 @@ type Type struct {
 type Aggregate struct {
 	Schema                   string `json:"schema"`
 	Name                     string `json:"name"`
+	Arguments                string `json:"arguments,omitempty"` // input argument types, e.g. "text" or "geometry"
 	ReturnType               string `json:"return_type"`
 	TransitionFunction       string `json:"transition_function"`
 	TransitionFunctionSchema string `json:"transition_function_schema,omitempty"`
@@ -710,4 +711,5 @@ func (p *Procedure) GetObjectName() string  { return p.Name }
 func (v *View) GetObjectName() string       { return v.Name }
 func (s *Sequence) GetObjectName() string   { return s.Name }
 func (t *Type) GetObjectName() string       { return t.Name }
+func (a *Aggregate) GetObjectName() string  { return a.Name }
 

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -23,18 +23,18 @@ type Schema struct {
 	Name  string `json:"name"`
 	Owner string `json:"owner"` // Schema owner
 	// Note: Indexes, Triggers, and RLS Policies are stored at table level (Table.Indexes, Table.Triggers, Table.Policies)
-	Tables                   map[string]*Table        `json:"tables"`                            // table_name -> Table
-	Views                    map[string]*View         `json:"views"`                             // view_name -> View
-	Functions                map[string]*Function     `json:"functions"`                         // function_name -> Function
-	Procedures               map[string]*Procedure    `json:"procedures"`                        // procedure_name -> Procedure
-	Aggregates               map[string]*Aggregate    `json:"aggregates"`                        // aggregate_name -> Aggregate
-	Sequences                map[string]*Sequence     `json:"sequences"`                         // sequence_name -> Sequence
-	Types                    map[string]*Type         `json:"types"`                             // type_name -> Type
-	DefaultPrivileges        []*DefaultPrivilege        `json:"default_privileges,omitempty"`        // Default privileges for future objects
-	Privileges               []*Privilege               `json:"privileges,omitempty"`                // Explicit privilege grants on objects
-	ColumnPrivileges         []*ColumnPrivilege         `json:"column_privileges,omitempty"`         // Column-level privilege grants
+	Tables                   map[string]*Table          `json:"tables"`                               // table_name -> Table
+	Views                    map[string]*View           `json:"views"`                                // view_name -> View
+	Functions                map[string]*Function       `json:"functions"`                            // function_name -> Function
+	Procedures               map[string]*Procedure      `json:"procedures"`                           // procedure_name -> Procedure
+	Aggregates               map[string]*Aggregate      `json:"aggregates"`                           // aggregate_name -> Aggregate
+	Sequences                map[string]*Sequence       `json:"sequences"`                            // sequence_name -> Sequence
+	Types                    map[string]*Type           `json:"types"`                                // type_name -> Type
+	DefaultPrivileges        []*DefaultPrivilege        `json:"default_privileges,omitempty"`         // Default privileges for future objects
+	Privileges               []*Privilege               `json:"privileges,omitempty"`                 // Explicit privilege grants on objects
+	ColumnPrivileges         []*ColumnPrivilege         `json:"column_privileges,omitempty"`          // Column-level privilege grants
 	RevokedDefaultPrivileges []*RevokedDefaultPrivilege `json:"revoked_default_privileges,omitempty"` // Explicit revokes of default PUBLIC privileges
-	mu                       sync.RWMutex             // Protects concurrent access to all maps
+	mu                       sync.RWMutex               // Protects concurrent access to all maps
 }
 
 // LikeClause represents a LIKE clause in CREATE TABLE statement
@@ -48,7 +48,7 @@ type LikeClause struct {
 type Table struct {
 	Schema            string                 `json:"schema"`
 	Name              string                 `json:"name"`
-	Type              TableType              `json:"type"` // BASE_TABLE, VIEW, etc.
+	Type              TableType              `json:"type"`                  // BASE_TABLE, VIEW, etc.
 	IsExternal        bool                   `json:"is_external,omitempty"` // True if table is externally managed (e.g., in ignored schemas)
 	Columns           []*Column              `json:"columns"`
 	Constraints       map[string]*Constraint `json:"constraints"` // constraint_name -> Constraint
@@ -68,18 +68,18 @@ type Table struct {
 
 // Column represents a table column
 type Column struct {
-	Name           string    `json:"name"`
-	Position       int       `json:"position"` // ordinal_position
-	DataType       string    `json:"data_type"`
-	IsNullable     bool      `json:"is_nullable"`
-	DefaultValue   *string   `json:"default_value,omitempty"`
-	MaxLength      *int      `json:"max_length,omitempty"`
-	Precision      *int      `json:"precision,omitempty"`
-	Scale          *int      `json:"scale,omitempty"`
-	Comment        string    `json:"comment,omitempty"`
-	Identity       *Identity `json:"identity,omitempty"`
-	GeneratedExpr  *string   `json:"generated_expr,omitempty"`  // Expression for generated columns
-	IsGenerated    bool      `json:"is_generated,omitempty"`    // True if this is a generated column
+	Name          string    `json:"name"`
+	Position      int       `json:"position"` // ordinal_position
+	DataType      string    `json:"data_type"`
+	IsNullable    bool      `json:"is_nullable"`
+	DefaultValue  *string   `json:"default_value,omitempty"`
+	MaxLength     *int      `json:"max_length,omitempty"`
+	Precision     *int      `json:"precision,omitempty"`
+	Scale         *int      `json:"scale,omitempty"`
+	Comment       string    `json:"comment,omitempty"`
+	Identity      *Identity `json:"identity,omitempty"`
+	GeneratedExpr *string   `json:"generated_expr,omitempty"` // Expression for generated columns
+	IsGenerated   bool      `json:"is_generated,omitempty"`   // True if this is a generated column
 }
 
 // Identity represents PostgreSQL identity column configuration
@@ -123,12 +123,12 @@ type View struct {
 	Schema       string              `json:"schema"`
 	Name         string              `json:"name"`
 	Definition   string              `json:"definition"`
-	Columns      []string            `json:"columns,omitempty"`   // Ordered list of output column names
-	Options      []string            `json:"options,omitempty"`   // View options (e.g., "security_invoker=true", "security_barrier=true")
+	Columns      []string            `json:"columns,omitempty"` // Ordered list of output column names
+	Options      []string            `json:"options,omitempty"` // View options (e.g., "security_invoker=true", "security_barrier=true")
 	Comment      string              `json:"comment,omitempty"`
 	Materialized bool                `json:"materialized,omitempty"`
-	Indexes      map[string]*Index   `json:"indexes,omitempty"`   // For materialized views only
-	Triggers     map[string]*Trigger `json:"triggers,omitempty"`  // For INSTEAD OF triggers on views
+	Indexes      map[string]*Index   `json:"indexes,omitempty"`  // For materialized views only
+	Triggers     map[string]*Trigger `json:"triggers,omitempty"` // For INSTEAD OF triggers on views
 }
 
 // Function represents a database function
@@ -248,19 +248,19 @@ const (
 
 // Index represents a database index
 type Index struct {
-	Schema       string         `json:"schema"`
-	Table        string         `json:"table"`
-	Name         string         `json:"name"`
-	Type         IndexType      `json:"type"`
-	Method       string         `json:"method"` // btree, hash, gin, gist, etc.
-	Columns      []*IndexColumn `json:"columns"`
-	IncludeColumns   []string `json:"include_columns,omitempty"`     // INCLUDE columns (non-key)
-	IsPartial        bool     `json:"is_partial"`                   // has a WHERE clause
-	IsExpression     bool     `json:"is_expression"`                // functional/expression index
-	Where            string   `json:"where,omitempty"`              // partial index condition
-	NullsNotDistinct bool     `json:"nulls_not_distinct,omitempty"` // NULLS NOT DISTINCT (PG15+)
-	IsPartitioned    bool     `json:"is_partitioned,omitempty"`     // index target is a partitioned parent (relkind 'p')
-	Comment          string   `json:"comment,omitempty"`
+	Schema           string         `json:"schema"`
+	Table            string         `json:"table"`
+	Name             string         `json:"name"`
+	Type             IndexType      `json:"type"`
+	Method           string         `json:"method"` // btree, hash, gin, gist, etc.
+	Columns          []*IndexColumn `json:"columns"`
+	IncludeColumns   []string       `json:"include_columns,omitempty"`    // INCLUDE columns (non-key)
+	IsPartial        bool           `json:"is_partial"`                   // has a WHERE clause
+	IsExpression     bool           `json:"is_expression"`                // functional/expression index
+	Where            string         `json:"where,omitempty"`              // partial index condition
+	NullsNotDistinct bool           `json:"nulls_not_distinct,omitempty"` // NULLS NOT DISTINCT (PG15+)
+	IsPartitioned    bool           `json:"is_partitioned,omitempty"`     // index target is a partitioned parent (relkind 'p')
+	Comment          string         `json:"comment,omitempty"`
 }
 
 // IndexColumn represents a column within an index
@@ -285,18 +285,18 @@ type Trigger struct {
 	Schema            string         `json:"schema"`
 	Table             string         `json:"table"`
 	Name              string         `json:"name"`
-	Timing            TriggerTiming  `json:"timing"` // BEFORE, AFTER, INSTEAD OF
-	Events            []TriggerEvent `json:"events"`                        // INSERT, UPDATE, DELETE
-	UpdateColumns     []string       `json:"update_columns,omitempty"`      // Column names for UPDATE OF
-	Level             TriggerLevel   `json:"level"`                         // ROW, STATEMENT
+	Timing            TriggerTiming  `json:"timing"`                   // BEFORE, AFTER, INSTEAD OF
+	Events            []TriggerEvent `json:"events"`                   // INSERT, UPDATE, DELETE
+	UpdateColumns     []string       `json:"update_columns,omitempty"` // Column names for UPDATE OF
+	Level             TriggerLevel   `json:"level"`                    // ROW, STATEMENT
 	Function          string         `json:"function"`
 	Condition         string         `json:"condition,omitempty"` // WHEN condition
 	Comment           string         `json:"comment,omitempty"`
-	IsConstraint      bool           `json:"is_constraint,omitempty"`       // Whether this is a constraint trigger
-	Deferrable        bool           `json:"deferrable,omitempty"`          // Can be deferred until end of transaction
-	InitiallyDeferred bool           `json:"initially_deferred,omitempty"`  // Whether deferred by default
-	OldTable          string         `json:"old_table,omitempty"`           // REFERENCING OLD TABLE AS name
-	NewTable          string         `json:"new_table,omitempty"`           // REFERENCING NEW TABLE AS name
+	IsConstraint      bool           `json:"is_constraint,omitempty"`      // Whether this is a constraint trigger
+	Deferrable        bool           `json:"deferrable,omitempty"`         // Can be deferred until end of transaction
+	InitiallyDeferred bool           `json:"initially_deferred,omitempty"` // Whether deferred by default
+	OldTable          string         `json:"old_table,omitempty"`          // REFERENCING OLD TABLE AS name
+	NewTable          string         `json:"new_table,omitempty"`          // REFERENCING NEW TABLE AS name
 }
 
 // TriggerTiming represents the timing of trigger execution
@@ -325,7 +325,6 @@ const (
 	TriggerLevelRow       TriggerLevel = "ROW"
 	TriggerLevelStatement TriggerLevel = "STATEMENT"
 )
-
 
 // RLSPolicy represents a Row Level Security policy
 type RLSPolicy struct {
@@ -406,7 +405,10 @@ type Aggregate struct {
 	TransitionFunction string `json:"transition_function"`
 	StateType          string `json:"state_type"`
 	StateSpace         int    `json:"state_space,omitempty"`
-	InitialCondition   string `json:"initial_condition,omitempty"`
+	// InitialCondition is a pointer so a genuine NULL agginitval (nil) is distinct from
+	// an explicit empty-string initial condition (INITCOND = ''), which are semantically
+	// different in PostgreSQL.
+	InitialCondition *string `json:"initial_condition,omitempty"`
 
 	// Final function
 	FinalFunction   string `json:"final_function,omitempty"`
@@ -419,14 +421,14 @@ type Aggregate struct {
 	DeserialFunction string `json:"deserial_function,omitempty"`
 
 	// Moving-aggregate support functions and state
-	MTransitionFunction    string `json:"mtransition_function,omitempty"`
-	MInvTransitionFunction string `json:"minv_transition_function,omitempty"`
-	MStateType             string `json:"mstate_type,omitempty"`
-	MStateSpace            int    `json:"mstate_space,omitempty"`
-	MFinalFunction         string `json:"mfinal_function,omitempty"`
-	MFinalFuncExtra        bool   `json:"mfinal_func_extra,omitempty"`
-	MFinalFuncModify       string `json:"mfinal_func_modify,omitempty"`
-	MInitialCondition      string `json:"minitial_condition,omitempty"`
+	MTransitionFunction    string  `json:"mtransition_function,omitempty"`
+	MInvTransitionFunction string  `json:"minv_transition_function,omitempty"`
+	MStateType             string  `json:"mstate_type,omitempty"`
+	MStateSpace            int     `json:"mstate_space,omitempty"`
+	MFinalFunction         string  `json:"mfinal_function,omitempty"`
+	MFinalFuncExtra        bool    `json:"mfinal_func_extra,omitempty"`
+	MFinalFuncModify       string  `json:"mfinal_func_modify,omitempty"`
+	MInitialCondition      *string `json:"minitial_condition,omitempty"` // pointer: nil NULL vs explicit '' (see InitialCondition)
 
 	// Sort operator (preformatted as OPERATOR(...); only meaningful for normal aggregates)
 	SortOperator string `json:"sort_operator,omitempty"`
@@ -744,4 +746,3 @@ func (v *View) GetObjectName() string       { return v.Name }
 func (s *Sequence) GetObjectName() string   { return s.Name }
 func (t *Type) GetObjectName() string       { return t.Name }
 func (a *Aggregate) GetObjectName() string  { return a.Name }
-

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -27,7 +27,7 @@ type Schema struct {
 	Views                    map[string]*View           `json:"views"`                                // view_name -> View
 	Functions                map[string]*Function       `json:"functions"`                            // function_name -> Function
 	Procedures               map[string]*Procedure      `json:"procedures"`                           // procedure_name -> Procedure
-	Aggregates               map[string]*Aggregate      `json:"aggregates"`                           // aggregate_name -> Aggregate
+	Aggregates               map[string]*Aggregate      `json:"aggregates"`                           // "name(arguments)" -> Aggregate (keyed by signature for overloading)
 	Sequences                map[string]*Sequence       `json:"sequences"`                            // sequence_name -> Sequence
 	Types                    map[string]*Type           `json:"types"`                                // type_name -> Type
 	DefaultPrivileges        []*DefaultPrivilege        `json:"default_privileges,omitempty"`         // Default privileges for future objects

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -387,19 +387,51 @@ type Type struct {
 	Constraints []*DomainConstraint `json:"constraints,omitempty"` // For DOMAIN types
 }
 
-// Aggregate represents a database aggregate function
+// Aggregate represents a database aggregate function.
+//
+// Support-function references (TransitionFunction, FinalFunction, ...) are stored
+// pre-quoted and schema-qualified only when they live in a different schema than the
+// aggregate itself (see GetAggregatesForSchema). They are therefore emitted verbatim in
+// the generated DDL and need no schema normalization.
 type Aggregate struct {
-	Schema                   string `json:"schema"`
-	Name                     string `json:"name"`
-	Arguments                string `json:"arguments,omitempty"` // input argument types, e.g. "text" or "geometry"
-	ReturnType               string `json:"return_type"`
-	TransitionFunction       string `json:"transition_function"`
-	TransitionFunctionSchema string `json:"transition_function_schema,omitempty"`
-	StateType                string `json:"state_type"`
-	InitialCondition         string `json:"initial_condition,omitempty"`
-	FinalFunction            string `json:"final_function,omitempty"`
-	FinalFunctionSchema      string `json:"final_function_schema,omitempty"`
-	Comment                  string `json:"comment,omitempty"`
+	Schema     string `json:"schema"`
+	Name       string `json:"name"`
+	Arguments  string `json:"arguments,omitempty"` // identity arg types (for DROP/COMMENT and the overload key)
+	Signature  string `json:"signature,omitempty"` // full arg list incl. ORDER BY for ordered-set (for CREATE)
+	Kind       string `json:"kind,omitempty"`      // 'n' normal, 'o' ordered-set, 'h' hypothetical-set
+	ReturnType string `json:"return_type"`
+	Parallel   string `json:"parallel,omitempty"` // 's' safe, 'r' restricted, 'u' unsafe (default)
+
+	// Transition (state) function and state value
+	TransitionFunction string `json:"transition_function"`
+	StateType          string `json:"state_type"`
+	StateSpace         int    `json:"state_space,omitempty"`
+	InitialCondition   string `json:"initial_condition,omitempty"`
+
+	// Final function
+	FinalFunction   string `json:"final_function,omitempty"`
+	FinalFuncExtra  bool   `json:"final_func_extra,omitempty"`
+	FinalFuncModify string `json:"final_func_modify,omitempty"` // 'r' read_only (default), 's' shareable, 'w' read_write
+
+	// Parallel-aggregation support functions
+	CombineFunction  string `json:"combine_function,omitempty"`
+	SerialFunction   string `json:"serial_function,omitempty"`
+	DeserialFunction string `json:"deserial_function,omitempty"`
+
+	// Moving-aggregate support functions and state
+	MTransitionFunction    string `json:"mtransition_function,omitempty"`
+	MInvTransitionFunction string `json:"minv_transition_function,omitempty"`
+	MStateType             string `json:"mstate_type,omitempty"`
+	MStateSpace            int    `json:"mstate_space,omitempty"`
+	MFinalFunction         string `json:"mfinal_function,omitempty"`
+	MFinalFuncExtra        bool   `json:"mfinal_func_extra,omitempty"`
+	MFinalFuncModify       string `json:"mfinal_func_modify,omitempty"`
+	MInitialCondition      string `json:"minitial_condition,omitempty"`
+
+	// Sort operator (preformatted as OPERATOR(...); only meaningful for normal aggregates)
+	SortOperator string `json:"sort_operator,omitempty"`
+
+	Comment string `json:"comment,omitempty"`
 }
 
 // Procedure represents a database procedure

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -1060,25 +1060,60 @@ WHERE r.routine_schema = $1
     AND d.objid IS NULL  -- Exclude procedures that are extension members
 ORDER BY r.routine_schema, r.routine_name;
 
--- GetAggregatesForSchema retrieves all user-defined aggregates for a specific schema
+-- GetAggregatesForSchema retrieves all user-defined aggregates for a specific schema.
+-- Support-function references (SFUNC, FINALFUNC, COMBINEFUNC, ...) are pre-quoted and
+-- schema-qualified only when they live in a different schema than the aggregate, so the
+-- desired/current IR keys line up and the plan normalizer never has to rewrite them.
 -- name: GetAggregatesForSchema :many
-SELECT 
+SELECT
     n.nspname AS aggregate_schema,
     p.proname AS aggregate_name,
-    pg_get_function_arguments(p.oid) AS aggregate_signature,
-    oidvectortypes(p.proargtypes) AS aggregate_arguments,
+    a.aggkind AS aggregate_kind,                                  -- 'n' normal, 'o' ordered-set, 'h' hypothetical-set
+    pg_get_function_arguments(p.oid) AS aggregate_signature,      -- aggregate-aware: emits ORDER BY for ordered/hypothetical
+    pg_get_function_identity_arguments(p.oid) AS aggregate_identity_args,
     format_type(p.prorettype, NULL) AS aggregate_return_type,
-    -- Get transition function
-    COALESCE(tf.proname, '') AS transition_function,
-    COALESCE(tfn.nspname, '') AS transition_function_schema,
-    -- Get state type
+    p.proparallel AS parallel,                                    -- 's' safe, 'r' restricted, 'u' unsafe (default)
+    -- Transition function and state
+    CASE WHEN tfn.nspname = n.nspname THEN quote_ident(tf.proname)
+         ELSE quote_ident(tfn.nspname) || '.' || quote_ident(tf.proname) END AS transition_function,
     format_type(a.aggtranstype, NULL) AS state_type,
-    -- Get initial condition
+    a.aggtransspace AS state_space,
     a.agginitval AS initial_condition,
-    -- Get final function if exists
-    COALESCE(ff.proname, '') AS final_function,
-    COALESCE(ffn.nspname, '') AS final_function_schema,
-    -- Comment
+    -- Final function
+    CASE WHEN a.aggfinalfn = 0 THEN ''
+         WHEN ffn.nspname = n.nspname THEN quote_ident(ff.proname)
+         ELSE quote_ident(ffn.nspname) || '.' || quote_ident(ff.proname) END AS final_function,
+    a.aggfinalextra AS final_func_extra,
+    a.aggfinalmodify AS final_func_modify,                        -- 'r' read_only (default), 's' shareable, 'w' read_write
+    -- Parallel-aggregation support functions
+    CASE WHEN a.aggcombinefn = 0 THEN ''
+         WHEN cfn.nspname = n.nspname THEN quote_ident(cf.proname)
+         ELSE quote_ident(cfn.nspname) || '.' || quote_ident(cf.proname) END AS combine_function,
+    CASE WHEN a.aggserialfn = 0 THEN ''
+         WHEN sfn.nspname = n.nspname THEN quote_ident(sf.proname)
+         ELSE quote_ident(sfn.nspname) || '.' || quote_ident(sf.proname) END AS serial_function,
+    CASE WHEN a.aggdeserialfn = 0 THEN ''
+         WHEN dfn.nspname = n.nspname THEN quote_ident(df.proname)
+         ELSE quote_ident(dfn.nspname) || '.' || quote_ident(df.proname) END AS deserial_function,
+    -- Moving-aggregate support functions and state
+    CASE WHEN a.aggmtransfn = 0 THEN ''
+         WHEN mtfn.nspname = n.nspname THEN quote_ident(mtf.proname)
+         ELSE quote_ident(mtfn.nspname) || '.' || quote_ident(mtf.proname) END AS mtransition_function,
+    CASE WHEN a.aggminvtransfn = 0 THEN ''
+         WHEN mitfn.nspname = n.nspname THEN quote_ident(mitf.proname)
+         ELSE quote_ident(mitfn.nspname) || '.' || quote_ident(mitf.proname) END AS minv_transition_function,
+    CASE WHEN a.aggmtransfn = 0 THEN '' ELSE format_type(a.aggmtranstype, NULL) END AS mstate_type,
+    a.aggmtransspace AS mstate_space,
+    CASE WHEN a.aggmfinalfn = 0 THEN ''
+         WHEN mffn.nspname = n.nspname THEN quote_ident(mff.proname)
+         ELSE quote_ident(mffn.nspname) || '.' || quote_ident(mff.proname) END AS mfinal_function,
+    a.aggmfinalextra AS mfinal_func_extra,
+    a.aggmfinalmodify AS mfinal_func_modify,
+    a.aggminitval AS minitial_condition,
+    -- Sort operator (only meaningful for normal aggregates)
+    CASE WHEN a.aggsortop = 0 THEN ''
+         WHEN opn.nspname = n.nspname THEN format('OPERATOR(%s)', op.oprname)
+         ELSE format('OPERATOR(%s.%s)', quote_ident(opn.nspname), op.oprname) END AS sort_operator,
     COALESCE(d.description, '') AS aggregate_comment
 FROM pg_proc p
 JOIN pg_namespace n ON p.pronamespace = n.oid
@@ -1087,11 +1122,25 @@ LEFT JOIN pg_proc tf ON a.aggtransfn = tf.oid
 LEFT JOIN pg_namespace tfn ON tf.pronamespace = tfn.oid
 LEFT JOIN pg_proc ff ON a.aggfinalfn = ff.oid
 LEFT JOIN pg_namespace ffn ON ff.pronamespace = ffn.oid
-LEFT JOIN pg_description d ON d.objoid = p.oid AND d.classoid = 'pg_proc'::regclass
+LEFT JOIN pg_proc cf ON a.aggcombinefn = cf.oid
+LEFT JOIN pg_namespace cfn ON cf.pronamespace = cfn.oid
+LEFT JOIN pg_proc sf ON a.aggserialfn = sf.oid
+LEFT JOIN pg_namespace sfn ON sf.pronamespace = sfn.oid
+LEFT JOIN pg_proc df ON a.aggdeserialfn = df.oid
+LEFT JOIN pg_namespace dfn ON df.pronamespace = dfn.oid
+LEFT JOIN pg_proc mtf ON a.aggmtransfn = mtf.oid
+LEFT JOIN pg_namespace mtfn ON mtf.pronamespace = mtfn.oid
+LEFT JOIN pg_proc mitf ON a.aggminvtransfn = mitf.oid
+LEFT JOIN pg_namespace mitfn ON mitf.pronamespace = mitfn.oid
+LEFT JOIN pg_proc mff ON a.aggmfinalfn = mff.oid
+LEFT JOIN pg_namespace mffn ON mff.pronamespace = mffn.oid
+LEFT JOIN pg_operator op ON op.oid = a.aggsortop
+LEFT JOIN pg_namespace opn ON op.oprnamespace = opn.oid
+LEFT JOIN pg_description d ON d.objoid = p.oid AND d.classoid = 'pg_proc'::regclass AND d.objsubid = 0
 WHERE p.prokind = 'a'  -- Only aggregates
     AND n.nspname = $1
     AND NOT EXISTS (
-        SELECT 1 FROM pg_depend dep 
+        SELECT 1 FROM pg_depend dep
         WHERE dep.objid = p.oid AND dep.deptype = 'e'
     )  -- Exclude extension members
 ORDER BY n.nspname, p.proname;

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -103,23 +103,55 @@ func (q *Queries) GetAggregates(ctx context.Context) ([]GetAggregatesRow, error)
 }
 
 const getAggregatesForSchema = `-- name: GetAggregatesForSchema :many
-SELECT 
+SELECT
     n.nspname AS aggregate_schema,
     p.proname AS aggregate_name,
-    pg_get_function_arguments(p.oid) AS aggregate_signature,
-    oidvectortypes(p.proargtypes) AS aggregate_arguments,
+    a.aggkind AS aggregate_kind,                                  -- 'n' normal, 'o' ordered-set, 'h' hypothetical-set
+    pg_get_function_arguments(p.oid) AS aggregate_signature,      -- aggregate-aware: emits ORDER BY for ordered/hypothetical
+    pg_get_function_identity_arguments(p.oid) AS aggregate_identity_args,
     format_type(p.prorettype, NULL) AS aggregate_return_type,
-    -- Get transition function
-    COALESCE(tf.proname, '') AS transition_function,
-    COALESCE(tfn.nspname, '') AS transition_function_schema,
-    -- Get state type
+    p.proparallel AS parallel,                                    -- 's' safe, 'r' restricted, 'u' unsafe (default)
+    -- Transition function and state
+    CASE WHEN tfn.nspname = n.nspname THEN quote_ident(tf.proname)
+         ELSE quote_ident(tfn.nspname) || '.' || quote_ident(tf.proname) END AS transition_function,
     format_type(a.aggtranstype, NULL) AS state_type,
-    -- Get initial condition
+    a.aggtransspace AS state_space,
     a.agginitval AS initial_condition,
-    -- Get final function if exists
-    COALESCE(ff.proname, '') AS final_function,
-    COALESCE(ffn.nspname, '') AS final_function_schema,
-    -- Comment
+    -- Final function
+    CASE WHEN a.aggfinalfn = 0 THEN ''
+         WHEN ffn.nspname = n.nspname THEN quote_ident(ff.proname)
+         ELSE quote_ident(ffn.nspname) || '.' || quote_ident(ff.proname) END AS final_function,
+    a.aggfinalextra AS final_func_extra,
+    a.aggfinalmodify AS final_func_modify,                        -- 'r' read_only (default), 's' shareable, 'w' read_write
+    -- Parallel-aggregation support functions
+    CASE WHEN a.aggcombinefn = 0 THEN ''
+         WHEN cfn.nspname = n.nspname THEN quote_ident(cf.proname)
+         ELSE quote_ident(cfn.nspname) || '.' || quote_ident(cf.proname) END AS combine_function,
+    CASE WHEN a.aggserialfn = 0 THEN ''
+         WHEN sfn.nspname = n.nspname THEN quote_ident(sf.proname)
+         ELSE quote_ident(sfn.nspname) || '.' || quote_ident(sf.proname) END AS serial_function,
+    CASE WHEN a.aggdeserialfn = 0 THEN ''
+         WHEN dfn.nspname = n.nspname THEN quote_ident(df.proname)
+         ELSE quote_ident(dfn.nspname) || '.' || quote_ident(df.proname) END AS deserial_function,
+    -- Moving-aggregate support functions and state
+    CASE WHEN a.aggmtransfn = 0 THEN ''
+         WHEN mtfn.nspname = n.nspname THEN quote_ident(mtf.proname)
+         ELSE quote_ident(mtfn.nspname) || '.' || quote_ident(mtf.proname) END AS mtransition_function,
+    CASE WHEN a.aggminvtransfn = 0 THEN ''
+         WHEN mitfn.nspname = n.nspname THEN quote_ident(mitf.proname)
+         ELSE quote_ident(mitfn.nspname) || '.' || quote_ident(mitf.proname) END AS minv_transition_function,
+    CASE WHEN a.aggmtransfn = 0 THEN '' ELSE format_type(a.aggmtranstype, NULL) END AS mstate_type,
+    a.aggmtransspace AS mstate_space,
+    CASE WHEN a.aggmfinalfn = 0 THEN ''
+         WHEN mffn.nspname = n.nspname THEN quote_ident(mff.proname)
+         ELSE quote_ident(mffn.nspname) || '.' || quote_ident(mff.proname) END AS mfinal_function,
+    a.aggmfinalextra AS mfinal_func_extra,
+    a.aggmfinalmodify AS mfinal_func_modify,
+    a.aggminitval AS minitial_condition,
+    -- Sort operator (only meaningful for normal aggregates)
+    CASE WHEN a.aggsortop = 0 THEN ''
+         WHEN opn.nspname = n.nspname THEN format('OPERATOR(%s)', op.oprname)
+         ELSE format('OPERATOR(%s.%s)', quote_ident(opn.nspname), op.oprname) END AS sort_operator,
     COALESCE(d.description, '') AS aggregate_comment
 FROM pg_proc p
 JOIN pg_namespace n ON p.pronamespace = n.oid
@@ -128,32 +160,64 @@ LEFT JOIN pg_proc tf ON a.aggtransfn = tf.oid
 LEFT JOIN pg_namespace tfn ON tf.pronamespace = tfn.oid
 LEFT JOIN pg_proc ff ON a.aggfinalfn = ff.oid
 LEFT JOIN pg_namespace ffn ON ff.pronamespace = ffn.oid
-LEFT JOIN pg_description d ON d.objoid = p.oid AND d.classoid = 'pg_proc'::regclass
+LEFT JOIN pg_proc cf ON a.aggcombinefn = cf.oid
+LEFT JOIN pg_namespace cfn ON cf.pronamespace = cfn.oid
+LEFT JOIN pg_proc sf ON a.aggserialfn = sf.oid
+LEFT JOIN pg_namespace sfn ON sf.pronamespace = sfn.oid
+LEFT JOIN pg_proc df ON a.aggdeserialfn = df.oid
+LEFT JOIN pg_namespace dfn ON df.pronamespace = dfn.oid
+LEFT JOIN pg_proc mtf ON a.aggmtransfn = mtf.oid
+LEFT JOIN pg_namespace mtfn ON mtf.pronamespace = mtfn.oid
+LEFT JOIN pg_proc mitf ON a.aggminvtransfn = mitf.oid
+LEFT JOIN pg_namespace mitfn ON mitf.pronamespace = mitfn.oid
+LEFT JOIN pg_proc mff ON a.aggmfinalfn = mff.oid
+LEFT JOIN pg_namespace mffn ON mff.pronamespace = mffn.oid
+LEFT JOIN pg_operator op ON op.oid = a.aggsortop
+LEFT JOIN pg_namespace opn ON op.oprnamespace = opn.oid
+LEFT JOIN pg_description d ON d.objoid = p.oid AND d.classoid = 'pg_proc'::regclass AND d.objsubid = 0
 WHERE p.prokind = 'a'  -- Only aggregates
     AND n.nspname = $1
     AND NOT EXISTS (
-        SELECT 1 FROM pg_depend dep 
+        SELECT 1 FROM pg_depend dep
         WHERE dep.objid = p.oid AND dep.deptype = 'e'
     )  -- Exclude extension members
 ORDER BY n.nspname, p.proname
 `
 
 type GetAggregatesForSchemaRow struct {
-	AggregateSchema          string         `db:"aggregate_schema" json:"aggregate_schema"`
-	AggregateName            string         `db:"aggregate_name" json:"aggregate_name"`
-	AggregateSignature       sql.NullString `db:"aggregate_signature" json:"aggregate_signature"`
-	AggregateArguments       sql.NullString `db:"aggregate_arguments" json:"aggregate_arguments"`
-	AggregateReturnType      sql.NullString `db:"aggregate_return_type" json:"aggregate_return_type"`
-	TransitionFunction       sql.NullString `db:"transition_function" json:"transition_function"`
-	TransitionFunctionSchema sql.NullString `db:"transition_function_schema" json:"transition_function_schema"`
-	StateType                sql.NullString `db:"state_type" json:"state_type"`
-	InitialCondition         sql.NullString `db:"initial_condition" json:"initial_condition"`
-	FinalFunction            sql.NullString `db:"final_function" json:"final_function"`
-	FinalFunctionSchema      sql.NullString `db:"final_function_schema" json:"final_function_schema"`
-	AggregateComment         sql.NullString `db:"aggregate_comment" json:"aggregate_comment"`
+	AggregateSchema        string         `db:"aggregate_schema" json:"aggregate_schema"`
+	AggregateName          string         `db:"aggregate_name" json:"aggregate_name"`
+	AggregateKind          interface{}    `db:"aggregate_kind" json:"aggregate_kind"`
+	AggregateSignature     sql.NullString `db:"aggregate_signature" json:"aggregate_signature"`
+	AggregateIdentityArgs  sql.NullString `db:"aggregate_identity_args" json:"aggregate_identity_args"`
+	AggregateReturnType    sql.NullString `db:"aggregate_return_type" json:"aggregate_return_type"`
+	Parallel               interface{}    `db:"parallel" json:"parallel"`
+	TransitionFunction     sql.NullString `db:"transition_function" json:"transition_function"`
+	StateType              sql.NullString `db:"state_type" json:"state_type"`
+	StateSpace             int32          `db:"state_space" json:"state_space"`
+	InitialCondition       sql.NullString `db:"initial_condition" json:"initial_condition"`
+	FinalFunction          sql.NullString `db:"final_function" json:"final_function"`
+	FinalFuncExtra         bool           `db:"final_func_extra" json:"final_func_extra"`
+	FinalFuncModify        interface{}    `db:"final_func_modify" json:"final_func_modify"`
+	CombineFunction        sql.NullString `db:"combine_function" json:"combine_function"`
+	SerialFunction         sql.NullString `db:"serial_function" json:"serial_function"`
+	DeserialFunction       sql.NullString `db:"deserial_function" json:"deserial_function"`
+	MtransitionFunction    sql.NullString `db:"mtransition_function" json:"mtransition_function"`
+	MinvTransitionFunction sql.NullString `db:"minv_transition_function" json:"minv_transition_function"`
+	MstateType             sql.NullString `db:"mstate_type" json:"mstate_type"`
+	MstateSpace            int32          `db:"mstate_space" json:"mstate_space"`
+	MfinalFunction         sql.NullString `db:"mfinal_function" json:"mfinal_function"`
+	MfinalFuncExtra        bool           `db:"mfinal_func_extra" json:"mfinal_func_extra"`
+	MfinalFuncModify       interface{}    `db:"mfinal_func_modify" json:"mfinal_func_modify"`
+	MinitialCondition      sql.NullString `db:"minitial_condition" json:"minitial_condition"`
+	SortOperator           sql.NullString `db:"sort_operator" json:"sort_operator"`
+	AggregateComment       sql.NullString `db:"aggregate_comment" json:"aggregate_comment"`
 }
 
-// GetAggregatesForSchema retrieves all user-defined aggregates for a specific schema
+// GetAggregatesForSchema retrieves all user-defined aggregates for a specific schema.
+// Support-function references (SFUNC, FINALFUNC, COMBINEFUNC, ...) are pre-quoted and
+// schema-qualified only when they live in a different schema than the aggregate, so the
+// desired/current IR keys line up and the plan normalizer never has to rewrite them.
 func (q *Queries) GetAggregatesForSchema(ctx context.Context, dollar_1 sql.NullString) ([]GetAggregatesForSchemaRow, error) {
 	rows, err := q.db.QueryContext(ctx, getAggregatesForSchema, dollar_1)
 	if err != nil {
@@ -166,15 +230,30 @@ func (q *Queries) GetAggregatesForSchema(ctx context.Context, dollar_1 sql.NullS
 		if err := rows.Scan(
 			&i.AggregateSchema,
 			&i.AggregateName,
+			&i.AggregateKind,
 			&i.AggregateSignature,
-			&i.AggregateArguments,
+			&i.AggregateIdentityArgs,
 			&i.AggregateReturnType,
+			&i.Parallel,
 			&i.TransitionFunction,
-			&i.TransitionFunctionSchema,
 			&i.StateType,
+			&i.StateSpace,
 			&i.InitialCondition,
 			&i.FinalFunction,
-			&i.FinalFunctionSchema,
+			&i.FinalFuncExtra,
+			&i.FinalFuncModify,
+			&i.CombineFunction,
+			&i.SerialFunction,
+			&i.DeserialFunction,
+			&i.MtransitionFunction,
+			&i.MinvTransitionFunction,
+			&i.MstateType,
+			&i.MstateSpace,
+			&i.MfinalFunction,
+			&i.MfinalFuncExtra,
+			&i.MfinalFuncModify,
+			&i.MinitialCondition,
+			&i.SortOperator,
 			&i.AggregateComment,
 		); err != nil {
 			return nil, err

--- a/testdata/diff/comment/add_aggregate_comment/diff.sql
+++ b/testdata/diff/comment/add_aggregate_comment/diff.sql
@@ -1,0 +1,1 @@
+COMMENT ON AGGREGATE group_concat(text) IS 'Concatenates text values with commas';

--- a/testdata/diff/comment/add_aggregate_comment/new.sql
+++ b/testdata/diff/comment/add_aggregate_comment/new.sql
@@ -1,0 +1,10 @@
+CREATE FUNCTION public._group_concat(text, text) RETURNS text
+    LANGUAGE sql IMMUTABLE
+    AS $$ SELECT CASE WHEN $2 IS NULL THEN $1 WHEN $1 IS NULL THEN $2 ELSE $1 || ',' || $2 END $$;
+
+CREATE AGGREGATE public.group_concat(text) (
+    SFUNC = public._group_concat,
+    STYPE = text
+);
+
+COMMENT ON AGGREGATE public.group_concat(text) IS 'Concatenates text values with commas';

--- a/testdata/diff/comment/add_aggregate_comment/old.sql
+++ b/testdata/diff/comment/add_aggregate_comment/old.sql
@@ -1,0 +1,8 @@
+CREATE FUNCTION public._group_concat(text, text) RETURNS text
+    LANGUAGE sql IMMUTABLE
+    AS $$ SELECT CASE WHEN $2 IS NULL THEN $1 WHEN $1 IS NULL THEN $2 ELSE $1 || ',' || $2 END $$;
+
+CREATE AGGREGATE public.group_concat(text) (
+    SFUNC = public._group_concat,
+    STYPE = text
+);

--- a/testdata/diff/comment/add_aggregate_comment/plan.json
+++ b/testdata/diff/comment/add_aggregate_comment/plan.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.11.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "7b2eb96c07771d120f4c68b0458da62cb746d8b904863cbf300a5c1428a3fa33"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "COMMENT ON AGGREGATE group_concat(text) IS 'Concatenates text values with commas';",
+          "type": "aggregate",
+          "operation": "alter",
+          "path": "public.group_concat"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/comment/add_aggregate_comment/plan.json
+++ b/testdata/diff/comment/add_aggregate_comment/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.11.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "7b2eb96c07771d120f4c68b0458da62cb746d8b904863cbf300a5c1428a3fa33"
+    "hash": "413262c4379685baf2c21465df680ea75d8d993106048b4491d518a2a62163e6"
   },
   "groups": [
     {

--- a/testdata/diff/comment/add_aggregate_comment/plan.sql
+++ b/testdata/diff/comment/add_aggregate_comment/plan.sql
@@ -1,0 +1,1 @@
+COMMENT ON AGGREGATE group_concat(text) IS 'Concatenates text values with commas';

--- a/testdata/diff/comment/add_aggregate_comment/plan.txt
+++ b/testdata/diff/comment/add_aggregate_comment/plan.txt
@@ -1,0 +1,12 @@
+Plan: 1 to modify.
+
+Summary by type:
+  aggregates: 1 to modify
+
+Aggregates:
+  ~ group_concat
+
+DDL to be executed:
+--------------------------------------------------
+
+COMMENT ON AGGREGATE group_concat(text) IS 'Concatenates text values with commas';

--- a/testdata/diff/create_aggregate/add_aggregate/diff.sql
+++ b/testdata/diff/create_aggregate/add_aggregate/diff.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE FUNCTION numeric_accum(
+    numeric[],
+    numeric
+)
+RETURNS numeric[]
+LANGUAGE sql
+IMMUTABLE
+AS $_$ SELECT array_append($1, $2)
+$_$;
+
+CREATE OR REPLACE FUNCTION numeric_first(
+    numeric[]
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+AS $_$ SELECT $1[1]
+$_$;
+
+CREATE AGGREGATE my_agg(numeric) (
+    SFUNC = numeric_accum,
+    STYPE = numeric[],
+    FINALFUNC = numeric_first,
+    INITCOND = '{}'
+);

--- a/testdata/diff/create_aggregate/add_aggregate/new.sql
+++ b/testdata/diff/create_aggregate/add_aggregate/new.sql
@@ -1,0 +1,14 @@
+CREATE FUNCTION numeric_accum(numeric[], numeric) RETURNS numeric[]
+    LANGUAGE sql IMMUTABLE
+    AS $$ SELECT array_append($1, $2) $$;
+
+CREATE FUNCTION numeric_first(numeric[]) RETURNS numeric
+    LANGUAGE sql IMMUTABLE
+    AS $$ SELECT $1[1] $$;
+
+CREATE AGGREGATE my_agg(numeric) (
+    SFUNC = numeric_accum,
+    STYPE = numeric[],
+    FINALFUNC = numeric_first,
+    INITCOND = '{}'
+);

--- a/testdata/diff/create_aggregate/add_aggregate/old.sql
+++ b/testdata/diff/create_aggregate/add_aggregate/old.sql
@@ -1,0 +1,1 @@
+-- Empty schema (no aggregates)

--- a/testdata/diff/create_aggregate/add_aggregate/plan.json
+++ b/testdata/diff/create_aggregate/add_aggregate/plan.json
@@ -1,0 +1,32 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.11.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE OR REPLACE FUNCTION numeric_accum(\n    numeric[],\n    numeric\n)\nRETURNS numeric[]\nLANGUAGE sql\nIMMUTABLE\nAS $_$ SELECT array_append($1, $2)\n$_$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.numeric_accum"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION numeric_first(\n    numeric[]\n)\nRETURNS numeric\nLANGUAGE sql\nIMMUTABLE\nAS $_$ SELECT $1[1]\n$_$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.numeric_first"
+        },
+        {
+          "sql": "CREATE AGGREGATE my_agg(numeric) (\n    SFUNC = numeric_accum,\n    STYPE = numeric[],\n    FINALFUNC = numeric_first,\n    INITCOND = '{}'\n);",
+          "type": "aggregate",
+          "operation": "create",
+          "path": "public.my_agg"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_aggregate/add_aggregate/plan.sql
+++ b/testdata/diff/create_aggregate/add_aggregate/plan.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE FUNCTION numeric_accum(
+    numeric[],
+    numeric
+)
+RETURNS numeric[]
+LANGUAGE sql
+IMMUTABLE
+AS $_$ SELECT array_append($1, $2)
+$_$;
+
+CREATE OR REPLACE FUNCTION numeric_first(
+    numeric[]
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+AS $_$ SELECT $1[1]
+$_$;
+
+CREATE AGGREGATE my_agg(numeric) (
+    SFUNC = numeric_accum,
+    STYPE = numeric[],
+    FINALFUNC = numeric_first,
+    INITCOND = '{}'
+);

--- a/testdata/diff/create_aggregate/add_aggregate/plan.txt
+++ b/testdata/diff/create_aggregate/add_aggregate/plan.txt
@@ -1,0 +1,41 @@
+Plan: 3 to add.
+
+Summary by type:
+  functions: 2 to add
+  aggregates: 1 to add
+
+Functions:
+  + numeric_accum
+  + numeric_first
+
+Aggregates:
+  + my_agg
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE OR REPLACE FUNCTION numeric_accum(
+    numeric[],
+    numeric
+)
+RETURNS numeric[]
+LANGUAGE sql
+IMMUTABLE
+AS $_$ SELECT array_append($1, $2)
+$_$;
+
+CREATE OR REPLACE FUNCTION numeric_first(
+    numeric[]
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+AS $_$ SELECT $1[1]
+$_$;
+
+CREATE AGGREGATE my_agg(numeric) (
+    SFUNC = numeric_accum,
+    STYPE = numeric[],
+    FINALFUNC = numeric_first,
+    INITCOND = '{}'
+);

--- a/testdata/diff/create_aggregate/add_aggregate_empty_initcond/diff.sql
+++ b/testdata/diff/create_aggregate/add_aggregate_empty_initcond/diff.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE FUNCTION str_append(
+    text,
+    text
+)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $_$ SELECT $1 || $2
+$_$;
+
+CREATE AGGREGATE str_concat(text) (
+    SFUNC = str_append,
+    STYPE = text,
+    INITCOND = ''
+);

--- a/testdata/diff/create_aggregate/add_aggregate_empty_initcond/new.sql
+++ b/testdata/diff/create_aggregate/add_aggregate_empty_initcond/new.sql
@@ -1,0 +1,11 @@
+-- Aggregate with an explicit empty-string INITCOND, which is semantically distinct
+-- from a NULL initial condition and must be preserved (not dropped).
+CREATE FUNCTION str_append(text, text) RETURNS text
+    LANGUAGE sql IMMUTABLE
+    AS $$ SELECT $1 || $2 $$;
+
+CREATE AGGREGATE str_concat(text) (
+    SFUNC = str_append,
+    STYPE = text,
+    INITCOND = ''
+);

--- a/testdata/diff/create_aggregate/add_aggregate_empty_initcond/old.sql
+++ b/testdata/diff/create_aggregate/add_aggregate_empty_initcond/old.sql
@@ -1,0 +1,1 @@
+-- Empty schema (no aggregates)

--- a/testdata/diff/create_aggregate/add_aggregate_empty_initcond/plan.json
+++ b/testdata/diff/create_aggregate/add_aggregate_empty_initcond/plan.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.11.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE OR REPLACE FUNCTION str_append(\n    text,\n    text\n)\nRETURNS text\nLANGUAGE sql\nIMMUTABLE\nAS $_$ SELECT $1 || $2\n$_$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.str_append"
+        },
+        {
+          "sql": "CREATE AGGREGATE str_concat(text) (\n    SFUNC = str_append,\n    STYPE = text,\n    INITCOND = ''\n);",
+          "type": "aggregate",
+          "operation": "create",
+          "path": "public.str_concat"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_aggregate/add_aggregate_empty_initcond/plan.sql
+++ b/testdata/diff/create_aggregate/add_aggregate_empty_initcond/plan.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE FUNCTION str_append(
+    text,
+    text
+)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $_$ SELECT $1 || $2
+$_$;
+
+CREATE AGGREGATE str_concat(text) (
+    SFUNC = str_append,
+    STYPE = text,
+    INITCOND = ''
+);

--- a/testdata/diff/create_aggregate/add_aggregate_empty_initcond/plan.txt
+++ b/testdata/diff/create_aggregate/add_aggregate_empty_initcond/plan.txt
@@ -1,0 +1,30 @@
+Plan: 2 to add.
+
+Summary by type:
+  functions: 1 to add
+  aggregates: 1 to add
+
+Functions:
+  + str_append
+
+Aggregates:
+  + str_concat
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE OR REPLACE FUNCTION str_append(
+    text,
+    text
+)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $_$ SELECT $1 || $2
+$_$;
+
+CREATE AGGREGATE str_concat(text) (
+    SFUNC = str_append,
+    STYPE = text,
+    INITCOND = ''
+);

--- a/testdata/diff/create_aggregate/add_aggregate_options/diff.sql
+++ b/testdata/diff/create_aggregate/add_aggregate_options/diff.sql
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION num_add(
+    numeric,
+    numeric
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $_$ SELECT $1 + $2
+$_$;
+
+CREATE OR REPLACE FUNCTION num_sub(
+    numeric,
+    numeric
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $_$ SELECT $1 - $2
+$_$;
+
+CREATE AGGREGATE my_sum(numeric) (
+    SFUNC = num_add,
+    STYPE = numeric,
+    COMBINEFUNC = num_add,
+    INITCOND = '0',
+    MSFUNC = num_add,
+    MINVFUNC = num_sub,
+    MSTYPE = numeric,
+    MINITCOND = '0',
+    PARALLEL = SAFE
+);

--- a/testdata/diff/create_aggregate/add_aggregate_options/new.sql
+++ b/testdata/diff/create_aggregate/add_aggregate_options/new.sql
@@ -1,0 +1,21 @@
+-- Aggregate exercising the advanced options: COMBINEFUNC (parallel aggregation),
+-- the moving-aggregate group (MSFUNC/MINVFUNC/MSTYPE/MINITCOND), and PARALLEL = SAFE.
+CREATE FUNCTION num_add(numeric, numeric) RETURNS numeric
+    LANGUAGE sql IMMUTABLE PARALLEL SAFE
+    AS $$ SELECT $1 + $2 $$;
+
+CREATE FUNCTION num_sub(numeric, numeric) RETURNS numeric
+    LANGUAGE sql IMMUTABLE PARALLEL SAFE
+    AS $$ SELECT $1 - $2 $$;
+
+CREATE AGGREGATE my_sum(numeric) (
+    SFUNC = num_add,
+    STYPE = numeric,
+    COMBINEFUNC = num_add,
+    INITCOND = '0',
+    MSFUNC = num_add,
+    MINVFUNC = num_sub,
+    MSTYPE = numeric,
+    MINITCOND = '0',
+    PARALLEL = SAFE
+);

--- a/testdata/diff/create_aggregate/add_aggregate_options/old.sql
+++ b/testdata/diff/create_aggregate/add_aggregate_options/old.sql
@@ -1,0 +1,1 @@
+-- Empty schema (no aggregates)

--- a/testdata/diff/create_aggregate/add_aggregate_options/plan.json
+++ b/testdata/diff/create_aggregate/add_aggregate_options/plan.json
@@ -1,0 +1,32 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.11.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE OR REPLACE FUNCTION num_add(\n    numeric,\n    numeric\n)\nRETURNS numeric\nLANGUAGE sql\nIMMUTABLE\nPARALLEL SAFE\nAS $_$ SELECT $1 + $2\n$_$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.num_add"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION num_sub(\n    numeric,\n    numeric\n)\nRETURNS numeric\nLANGUAGE sql\nIMMUTABLE\nPARALLEL SAFE\nAS $_$ SELECT $1 - $2\n$_$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.num_sub"
+        },
+        {
+          "sql": "CREATE AGGREGATE my_sum(numeric) (\n    SFUNC = num_add,\n    STYPE = numeric,\n    COMBINEFUNC = num_add,\n    INITCOND = '0',\n    MSFUNC = num_add,\n    MINVFUNC = num_sub,\n    MSTYPE = numeric,\n    MINITCOND = '0',\n    PARALLEL = SAFE\n);",
+          "type": "aggregate",
+          "operation": "create",
+          "path": "public.my_sum"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_aggregate/add_aggregate_options/plan.sql
+++ b/testdata/diff/create_aggregate/add_aggregate_options/plan.sql
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION num_add(
+    numeric,
+    numeric
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $_$ SELECT $1 + $2
+$_$;
+
+CREATE OR REPLACE FUNCTION num_sub(
+    numeric,
+    numeric
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $_$ SELECT $1 - $2
+$_$;
+
+CREATE AGGREGATE my_sum(numeric) (
+    SFUNC = num_add,
+    STYPE = numeric,
+    COMBINEFUNC = num_add,
+    INITCOND = '0',
+    MSFUNC = num_add,
+    MINVFUNC = num_sub,
+    MSTYPE = numeric,
+    MINITCOND = '0',
+    PARALLEL = SAFE
+);

--- a/testdata/diff/create_aggregate/add_aggregate_options/plan.txt
+++ b/testdata/diff/create_aggregate/add_aggregate_options/plan.txt
@@ -1,0 +1,49 @@
+Plan: 3 to add.
+
+Summary by type:
+  functions: 2 to add
+  aggregates: 1 to add
+
+Functions:
+  + num_add
+  + num_sub
+
+Aggregates:
+  + my_sum
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE OR REPLACE FUNCTION num_add(
+    numeric,
+    numeric
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $_$ SELECT $1 + $2
+$_$;
+
+CREATE OR REPLACE FUNCTION num_sub(
+    numeric,
+    numeric
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $_$ SELECT $1 - $2
+$_$;
+
+CREATE AGGREGATE my_sum(numeric) (
+    SFUNC = num_add,
+    STYPE = numeric,
+    COMBINEFUNC = num_add,
+    INITCOND = '0',
+    MSFUNC = num_add,
+    MINVFUNC = num_sub,
+    MSTYPE = numeric,
+    MINITCOND = '0',
+    PARALLEL = SAFE
+);

--- a/testdata/diff/create_aggregate/drop_aggregate/diff.sql
+++ b/testdata/diff/create_aggregate/drop_aggregate/diff.sql
@@ -1,0 +1,3 @@
+DROP AGGREGATE IF EXISTS group_concat(text);
+
+DROP FUNCTION IF EXISTS _group_concat(text, text);

--- a/testdata/diff/create_aggregate/drop_aggregate/new.sql
+++ b/testdata/diff/create_aggregate/drop_aggregate/new.sql
@@ -1,0 +1,1 @@
+-- Empty schema (aggregate and its transition function removed)

--- a/testdata/diff/create_aggregate/drop_aggregate/old.sql
+++ b/testdata/diff/create_aggregate/drop_aggregate/old.sql
@@ -1,0 +1,8 @@
+CREATE FUNCTION _group_concat(text, text) RETURNS text
+    LANGUAGE sql IMMUTABLE
+    AS $$ SELECT CASE WHEN $2 IS NULL THEN $1 WHEN $1 IS NULL THEN $2 ELSE $1 || ',' || $2 END $$;
+
+CREATE AGGREGATE group_concat(text) (
+    SFUNC = _group_concat,
+    STYPE = text
+);

--- a/testdata/diff/create_aggregate/drop_aggregate/plan.json
+++ b/testdata/diff/create_aggregate/drop_aggregate/plan.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.11.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "7b2eb96c07771d120f4c68b0458da62cb746d8b904863cbf300a5c1428a3fa33"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "DROP AGGREGATE IF EXISTS group_concat(text);",
+          "type": "aggregate",
+          "operation": "drop",
+          "path": "public.group_concat"
+        },
+        {
+          "sql": "DROP FUNCTION IF EXISTS _group_concat(text, text);",
+          "type": "function",
+          "operation": "drop",
+          "path": "public._group_concat"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_aggregate/drop_aggregate/plan.json
+++ b/testdata/diff/create_aggregate/drop_aggregate/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.11.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "7b2eb96c07771d120f4c68b0458da62cb746d8b904863cbf300a5c1428a3fa33"
+    "hash": "413262c4379685baf2c21465df680ea75d8d993106048b4491d518a2a62163e6"
   },
   "groups": [
     {

--- a/testdata/diff/create_aggregate/drop_aggregate/plan.sql
+++ b/testdata/diff/create_aggregate/drop_aggregate/plan.sql
@@ -1,0 +1,3 @@
+DROP AGGREGATE IF EXISTS group_concat(text);
+
+DROP FUNCTION IF EXISTS _group_concat(text, text);

--- a/testdata/diff/create_aggregate/drop_aggregate/plan.txt
+++ b/testdata/diff/create_aggregate/drop_aggregate/plan.txt
@@ -1,0 +1,18 @@
+Plan: 2 to drop.
+
+Summary by type:
+  functions: 1 to drop
+  aggregates: 1 to drop
+
+Functions:
+  - _group_concat
+
+Aggregates:
+  - group_concat
+
+DDL to be executed:
+--------------------------------------------------
+
+DROP AGGREGATE IF EXISTS group_concat(text);
+
+DROP FUNCTION IF EXISTS _group_concat(text, text);

--- a/testdata/dump/sakila/pgschema.sql
+++ b/testdata/dump/sakila/pgschema.sql
@@ -863,6 +863,15 @@ END
 $_$;
 
 --
+-- Name: group_concat(text); Type: AGGREGATE; Schema: -; Owner: -
+--
+
+CREATE AGGREGATE group_concat(text) (
+    SFUNC = _group_concat,
+    STYPE = text
+);
+
+--
 -- Name: film_fulltext_trigger; Type: TRIGGER; Schema: -; Owner: -
 --
 


### PR DESCRIPTION
## Summary

Custom aggregates were inspected into the IR but **never compared in the diff package nor emitted by the dump formatter**, so `pgschema dump` silently dropped every `CREATE AGGREGATE` statement (both single-file and `--multi-file`). Because the aggregate's transition function *was* dumped but the aggregate itself was not, a later `pgschema plan` could emit a `DROP FUNCTION` for that helper, which PostgreSQL refuses via `pg_depend` — breaking dependent queries.

This adds full aggregate support to the plan/dump/apply pipeline.

### Changes

- **ir**: capture aggregate input argument types (`Arguments`) and key aggregates by `name(arguments)`, mirroring functions/procedures (supports overloading).
- **diff**: new `internal/diff/aggregate.go` generating `CREATE` / `DROP` / `ALTER` (DROP+CREATE) and `COMMENT ON AGGREGATE`; wires comparison and `DiffTypeAggregate` into `diff.go`. Ordering respects `pg_depend`:
  - created **after** their transition/final functions and **before** views that reference them;
  - dropped **before** their functions (fixes the issue's cascade).
- **dump**: emits aggregates into an `aggregates/` directory in `--multi-file` mode and with a `name(args)` signature in the object comment header.
- **plan**: registers the `aggregates` object type so it appears in plan summaries; normalizes aggregate argument types for external plan databases.

## Test plan

- `testdata/diff/create_aggregate/add_aggregate` — create helper functions + aggregate (FINALFUNC + INITCOND), verifies create ordering.
- `testdata/diff/create_aggregate/drop_aggregate` — verifies the aggregate is dropped **before** its transition function.
- `testdata/diff/comment/add_aggregate_comment` — `COMMENT ON AGGREGATE` via the ALTER path.
- Enhanced **sakila** dump fixture: now retains the `group_concat` aggregate (was previously dropped).
- Enhanced **multi-file formatter** unit test: asserts the `aggregates/` directory, include line, and signed comment header.

All pass with plan→apply→re-plan idempotency. Full `./internal/diff`, `./internal/plan`, and `./cmd/dump` suites green; no regressions.

Run:
\`\`\`bash
PGSCHEMA_TEST_FILTER="create_aggregate/" go test ./internal/diff -run TestDiffFromFiles
PGSCHEMA_TEST_FILTER="create_aggregate/" go test ./cmd -run TestPlanAndApply
go test ./cmd/dump -run TestDumpCommand_Sakila
\`\`\`

Fixes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)