### PR TITLE
fix: render policy and constraint expressions with table schema search_path (#449)

### DIFF
--- a/cmd/issue_449_integration_test.go
+++ b/cmd/issue_449_integration_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pgplex/pgschema/testutil"
+)
+
+// TestIssue449RepeatPlanIdempotency verifies that a plan generated immediately after a
+// successful apply reports no changes (https://github.com/pgplex/pgschema/issues/449).
+//
+// Two distinct drift sources are covered:
+//  1. CHECK constraints casting to a type in the managed (non-public) schema: the current
+//     state rendered the cast schema-qualified while the desired state stripped the
+//     qualifier, producing a perpetual DROP/ADD/VALIDATE cycle (also issue #445).
+//  2. RLS policy expressions on a table whose name equals the managed schema name: the
+//     same-schema qualifier stripping mistook table-qualified column references
+//     (profiles.id) for schema qualifiers and removed them from the current state only.
+func TestIssue449RepeatPlanIdempotency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	embeddedPG := testutil.SetupPostgres(t)
+	defer embeddedPG.Stop()
+	conn, host, port, dbname, user, password := testutil.ConnectToPostgres(t, embeddedPG)
+	defer conn.Close()
+
+	// applyThenReplan applies the desired state to the given schema and returns the SQL
+	// of a plan generated immediately afterwards. An idempotent plan returns "".
+	applyThenReplan := func(t *testing.T, schema, desiredSQL string) string {
+		t.Helper()
+
+		if _, err := conn.ExecContext(ctx, "CREATE SCHEMA IF NOT EXISTS "+schema); err != nil {
+			t.Fatalf("Failed to create schema %s: %v", schema, err)
+		}
+
+		desiredStateFile := filepath.Join(t.TempDir(), "desired.sql")
+		if err := os.WriteFile(desiredStateFile, []byte(desiredSQL), 0644); err != nil {
+			t.Fatalf("Failed to write desired state file: %v", err)
+		}
+
+		if err := applySchemaChanges(host, port, dbname, user, password, schema, desiredStateFile); err != nil {
+			t.Fatalf("Failed to apply desired state: %v", err)
+		}
+
+		replanOutput, err := generatePlanSQLFormatted(host, port, dbname, user, password, schema, desiredStateFile)
+		if err != nil {
+			t.Fatalf("Failed to generate repeat plan: %v", err)
+		}
+		return replanOutput
+	}
+
+	t.Run("check_constraint_same_schema_type_cast", func(t *testing.T) {
+		replan := applyThenReplan(t, "app449", `
+			CREATE TYPE item_status AS ENUM ('active', 'disabled');
+
+			CREATE TABLE items (
+				id integer PRIMARY KEY,
+				status item_status NOT NULL,
+				CONSTRAINT items_status_check CHECK (status <> 'disabled'::item_status)
+			);
+		`)
+		if replan != "" {
+			t.Errorf("Expected no changes on repeat plan after apply, but got:\n%s", replan)
+		}
+	})
+
+	t.Run("policy_schema_name_equals_table_name", func(t *testing.T) {
+		replan := applyThenReplan(t, "profiles", `
+			CREATE TABLE profiles (
+				id uuid PRIMARY KEY,
+				user_id uuid NOT NULL
+			);
+
+			CREATE TABLE profile_media (
+				id uuid PRIMARY KEY,
+				profile_id uuid NOT NULL REFERENCES profiles (id)
+			);
+
+			ALTER TABLE profile_media ENABLE ROW LEVEL SECURITY;
+
+			CREATE POLICY "Users can read their own media" ON profile_media
+				FOR SELECT
+				USING (profile_id IN (SELECT id FROM profiles));
+		`)
+		if replan != "" {
+			t.Errorf("Expected no changes on repeat plan after apply, but got:\n%s", replan)
+		}
+	})
+}

--- a/ir/normalize.go
+++ b/ir/normalize.go
@@ -82,9 +82,9 @@ func normalizeTable(table *Table) {
 		normalizeColumn(column, table.Schema)
 	}
 
-	// Normalize policies (pass table schema for context - Issue #220)
+	// Normalize policies
 	for _, policy := range table.Policies {
-		normalizePolicy(policy, table.Schema)
+		normalizePolicy(policy)
 	}
 
 	// Normalize triggers
@@ -204,8 +204,7 @@ func normalizeDefaultValue(value string, tableSchema string) string {
 }
 
 // normalizePolicy normalizes RLS policy representation
-// tableSchema is used to strip same-schema qualifiers from function calls (Issue #220)
-func normalizePolicy(policy *RLSPolicy, tableSchema string) {
+func normalizePolicy(policy *RLSPolicy) {
 	if policy == nil {
 		return
 	}
@@ -215,8 +214,8 @@ func normalizePolicy(policy *RLSPolicy, tableSchema string) {
 
 	// Normalize expressions by removing extra whitespace
 	// For policy expressions, we want to preserve parentheses as they are part of the expected format
-	policy.Using = normalizePolicyExpression(policy.Using, tableSchema)
-	policy.WithCheck = normalizePolicyExpression(policy.WithCheck, tableSchema)
+	policy.Using = normalizePolicyExpression(policy.Using)
+	policy.WithCheck = normalizePolicyExpression(policy.WithCheck)
 }
 
 // normalizePolicyRoles normalizes policy roles for consistent comparison
@@ -243,8 +242,14 @@ func normalizePolicyRoles(roles []string) []string {
 
 // normalizePolicyExpression normalizes policy expressions (USING/WITH CHECK clauses)
 // It preserves parentheses as they are part of the expected format for policies
-// tableSchema is used to strip same-schema qualifiers from function calls and table references (Issue #220, #224)
-func normalizePolicyExpression(expr string, tableSchema string) string {
+//
+// Same-schema qualifiers no longer need stripping here: GetRLSPoliciesForSchema renders
+// expressions with search_path set to the table's own schema, so same-schema references
+// (Issue #220, #224) come out unqualified on both the current and desired side, while
+// cross-schema references (Issue #427) stay qualified. Regex-stripping was also unsafe:
+// when the schema name equals a table name, it mangled table-qualified column
+// references like profiles.id (Issue #449).
+func normalizePolicyExpression(expr string) string {
 	if expr == "" {
 		return expr
 	}
@@ -252,22 +257,6 @@ func normalizePolicyExpression(expr string, tableSchema string) string {
 	// Remove extra whitespace and normalize
 	expr = strings.TrimSpace(expr)
 	expr = regexp.MustCompile(`\s+`).ReplaceAllString(expr, " ")
-
-	// Strip same-schema qualifiers from function calls (Issue #220)
-	// This matches PostgreSQL's behavior where same-schema qualifiers are stripped
-	// Example: tenant1.auth_uid() -> auth_uid() (when tableSchema is "tenant1")
-	//          util.get_status() -> util.get_status() (preserved, different schema)
-	if tableSchema != "" && strings.Contains(expr, tableSchema+".") {
-		prefix := tableSchema + "."
-		pattern := regexp.MustCompile(regexp.QuoteMeta(prefix) + `([a-zA-Z_][a-zA-Z0-9_]*)\(`)
-		expr = pattern.ReplaceAllString(expr, `${1}(`)
-
-		// Strip same-schema qualifiers from table references (Issue #224)
-		// Matches schema.identifier followed by whitespace, comma, closing paren, or end of string
-		// Example: public.users -> users (when tableSchema is "public")
-		tablePattern := regexp.MustCompile(regexp.QuoteMeta(prefix) + `([a-zA-Z_][a-zA-Z0-9_]*)(\s|,|\)|$)`)
-		expr = tablePattern.ReplaceAllString(expr, `${1}${2}`)
-	}
 
 	// Handle all parentheses normalization (adding required ones, removing unnecessary ones)
 	expr = normalizeExpressionParentheses(expr)

--- a/ir/normalize_test.go
+++ b/ir/normalize_test.go
@@ -361,30 +361,32 @@ func TestNormalizeExpressionParentheses(t *testing.T) {
 
 func TestNormalizePolicyExpression(t *testing.T) {
 	tests := []struct {
-		name        string
-		expr        string
-		tableSchema string
-		expected    string
+		name     string
+		expr     string
+		expected string
 	}{
 		{
-			name:        "nested function call in policy expression",
-			expr:        "(id IN ( SELECT unnest(get_user_assigned_projects()) AS unnest))",
-			tableSchema: "public",
-			expected:    "(id IN ( SELECT unnest(get_user_assigned_projects()) AS unnest))",
+			name:     "nested function call in policy expression",
+			expr:     "(id IN ( SELECT unnest(get_user_assigned_projects()) AS unnest))",
+			expected: "(id IN ( SELECT unnest(get_user_assigned_projects()) AS unnest))",
 		},
 		{
-			name:        "schema-qualified nested function call",
-			expr:        "(id IN ( SELECT unnest(public.get_user_assigned_projects()) AS unnest))",
-			tableSchema: "public",
-			expected:    "(id IN ( SELECT unnest(get_user_assigned_projects()) AS unnest))",
+			// Schema qualifiers are preserved as rendered: GetRLSPoliciesForSchema sets
+			// search_path to the table's schema, so qualifiers only appear for
+			// cross-schema references and must survive normalization (issue #427).
+			// Table-qualified column references (profiles.id when the schema is also
+			// named profiles) must survive too (issue #449).
+			name:     "qualified references preserved",
+			expr:     "(id IN ( SELECT profiles.id FROM profiles WHERE (profiles.user_id = auth.uid())))",
+			expected: "(id IN ( SELECT profiles.id FROM profiles WHERE (profiles.user_id = auth.uid())))",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := normalizePolicyExpression(tt.expr, tt.tableSchema)
+			result := normalizePolicyExpression(tt.expr)
 			if result != tt.expected {
-				t.Errorf("normalizePolicyExpression(%q, %q) = %q, want %q", tt.expr, tt.tableSchema, result, tt.expected)
+				t.Errorf("normalizePolicyExpression(%q) = %q, want %q", tt.expr, result, tt.expected)
 			}
 		})
 	}

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -325,8 +325,8 @@ SELECT
     COALESCE(fcl.relname, '') AS foreign_table_name,
     COALESCE(fa.attname, '') AS foreign_column_name,
     COALESCE(fa.attnum, 0) AS foreign_ordinal_position,
-    CASE WHEN c.contype = 'c' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS check_clause,
-    CASE WHEN c.contype = 'x' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS exclusion_definition,
+    cd.check_clause,
+    cd.exclusion_definition,
     CASE c.confdeltype
         WHEN 'a' THEN 'NO ACTION'
         WHEN 'r' THEN 'RESTRICT'
@@ -355,6 +355,16 @@ LEFT JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
 LEFT JOIN pg_class fcl ON c.confrelid = fcl.oid
 LEFT JOIN pg_namespace fn ON fcl.relnamespace = fn.oid
 LEFT JOIN pg_attribute fa ON fa.attrelid = c.confrelid AND fa.attnum = c.confkey[array_position(c.conkey, a.attnum)]
+LEFT JOIN LATERAL (
+    SELECT
+        -- Render with search_path set to the table's own schema so same-schema
+        -- type/function references come out unqualified while cross-schema
+        -- references stay qualified. This matches how the desired state renders
+        -- in its temporary schema, keeping both sides comparable (issue #449).
+        set_config('search_path', quote_ident(n.nspname), true) AS dummy,
+        CASE WHEN c.contype = 'c' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS check_clause,
+        CASE WHEN c.contype = 'x' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS exclusion_definition
+) cd ON true
 WHERE n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
     AND n.nspname NOT LIKE 'pg_temp_%'
     AND n.nspname NOT LIKE 'pg_toast_temp_%'
@@ -769,13 +779,12 @@ ORDER BY n.nspname, c.relname;
 
 -- GetRLSPolicies retrieves all row level security policies
 -- This replicates the pg_policies system view but computes the qual/with_check
--- expressions with a forced search_path so cross-schema references stay qualified:
--- 1. set_config sets search_path to only pg_catalog
--- 2. pg_get_expr then uses that search_path and includes schema qualifiers for any
---    function or table reference outside pg_catalog. Same-schema qualifiers are stripped
---    later by normalizePolicyExpression. Without this, references to objects on the
---    session search_path (e.g. Supabase's auth.uid()) are emitted unqualified and the
---    generated CREATE POLICY fails on apply. (Issue #427)
+-- expressions with a forced search_path so qualification is deterministic:
+-- 1. set_config sets search_path to only the table's own schema
+-- 2. pg_get_expr then renders same-schema references unqualified while cross-schema
+--    references (e.g. Supabase's auth.uid(), issue #427) stay qualified. Without this,
+--    rendering depends on the session search_path and the current/desired states
+--    compare differently (issue #449).
 -- name: GetRLSPolicies :many
 SELECT
     n.nspname AS schemaname,
@@ -805,7 +814,7 @@ JOIN pg_catalog.pg_class c ON c.oid = pol.polrelid
 JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 LEFT JOIN LATERAL (
     SELECT
-        set_config('search_path', 'pg_catalog', true) AS dummy,
+        set_config('search_path', quote_ident(n.nspname), true) AS dummy,
         pg_get_expr(pol.polqual, pol.polrelid) AS qual,
         pg_get_expr(pol.polwithcheck, pol.polrelid) AS with_check
 ) e ON true
@@ -862,7 +871,12 @@ JOIN pg_catalog.pg_class c ON c.oid = pol.polrelid
 JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 LEFT JOIN LATERAL (
     SELECT
-        set_config('search_path', 'pg_catalog', true) AS dummy,
+        -- Render with search_path set to the table's own schema so same-schema
+        -- references come out unqualified while cross-schema references (e.g.
+        -- Supabase's auth.uid(), issue #427) stay qualified. This matches how the
+        -- desired state renders in its temporary schema, so both sides compare
+        -- equal without regex-stripping qualifiers afterwards (issue #449).
+        set_config('search_path', quote_ident(n.nspname), true) AS dummy,
         pg_get_expr(pol.polqual, pol.polrelid) AS qual,
         pg_get_expr(pol.polwithcheck, pol.polrelid) AS with_check
 ) e ON true
@@ -970,8 +984,8 @@ SELECT
     COALESCE(fcl.relname, '') AS foreign_table_name,
     COALESCE(fa.attname, '') AS foreign_column_name,
     COALESCE(fa.attnum, 0) AS foreign_ordinal_position,
-    CASE WHEN c.contype = 'c' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS check_clause,
-    CASE WHEN c.contype = 'x' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS exclusion_definition,
+    cd.check_clause,
+    cd.exclusion_definition,
     CASE c.confdeltype
         WHEN 'a' THEN 'NO ACTION'
         WHEN 'r' THEN 'RESTRICT'
@@ -1004,6 +1018,16 @@ LEFT JOIN pg_class fcl ON c.confrelid = fcl.oid
 LEFT JOIN pg_namespace fn ON fcl.relnamespace = fn.oid
 LEFT JOIN pg_attribute fa ON fa.attrelid = c.confrelid AND fa.attnum = c.confkey[array_position(c.conkey, a.attnum)]
 LEFT JOIN pg_index i ON i.indexrelid = c.conindid
+LEFT JOIN LATERAL (
+    SELECT
+        -- Render with search_path set to the table's own schema so same-schema
+        -- type/function references come out unqualified while cross-schema
+        -- references stay qualified. This matches how the desired state renders
+        -- in its temporary schema, keeping both sides comparable (issue #449).
+        set_config('search_path', quote_ident(n.nspname), true) AS dummy,
+        CASE WHEN c.contype = 'c' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS check_clause,
+        CASE WHEN c.contype = 'x' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS exclusion_definition
+) cd ON true
 WHERE n.nspname = $1
     -- Skip internal per-partition FK rows (conparentid != 0) that PostgreSQL
     -- creates when a FK references a partitioned table. pg_dump omits these;

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -861,8 +861,8 @@ SELECT
     COALESCE(fcl.relname, '') AS foreign_table_name,
     COALESCE(fa.attname, '') AS foreign_column_name,
     COALESCE(fa.attnum, 0) AS foreign_ordinal_position,
-    CASE WHEN c.contype = 'c' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS check_clause,
-    CASE WHEN c.contype = 'x' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS exclusion_definition,
+    cd.check_clause,
+    cd.exclusion_definition,
     CASE c.confdeltype
         WHEN 'a' THEN 'NO ACTION'
         WHEN 'r' THEN 'RESTRICT'
@@ -891,6 +891,16 @@ LEFT JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
 LEFT JOIN pg_class fcl ON c.confrelid = fcl.oid
 LEFT JOIN pg_namespace fn ON fcl.relnamespace = fn.oid
 LEFT JOIN pg_attribute fa ON fa.attrelid = c.confrelid AND fa.attnum = c.confkey[array_position(c.conkey, a.attnum)]
+LEFT JOIN LATERAL (
+    SELECT
+        -- Render with search_path set to the table's own schema so same-schema
+        -- type/function references come out unqualified while cross-schema
+        -- references stay qualified. This matches how the desired state renders
+        -- in its temporary schema, keeping both sides comparable (issue #449).
+        set_config('search_path', quote_ident(n.nspname), true) AS dummy,
+        CASE WHEN c.contype = 'c' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS check_clause,
+        CASE WHEN c.contype = 'x' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS exclusion_definition
+) cd ON true
 WHERE n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
     AND n.nspname NOT LIKE 'pg_temp_%'
     AND n.nspname NOT LIKE 'pg_toast_temp_%'
@@ -986,8 +996,8 @@ SELECT
     COALESCE(fcl.relname, '') AS foreign_table_name,
     COALESCE(fa.attname, '') AS foreign_column_name,
     COALESCE(fa.attnum, 0) AS foreign_ordinal_position,
-    CASE WHEN c.contype = 'c' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS check_clause,
-    CASE WHEN c.contype = 'x' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS exclusion_definition,
+    cd.check_clause,
+    cd.exclusion_definition,
     CASE c.confdeltype
         WHEN 'a' THEN 'NO ACTION'
         WHEN 'r' THEN 'RESTRICT'
@@ -1020,6 +1030,16 @@ LEFT JOIN pg_class fcl ON c.confrelid = fcl.oid
 LEFT JOIN pg_namespace fn ON fcl.relnamespace = fn.oid
 LEFT JOIN pg_attribute fa ON fa.attrelid = c.confrelid AND fa.attnum = c.confkey[array_position(c.conkey, a.attnum)]
 LEFT JOIN pg_index i ON i.indexrelid = c.conindid
+LEFT JOIN LATERAL (
+    SELECT
+        -- Render with search_path set to the table's own schema so same-schema
+        -- type/function references come out unqualified while cross-schema
+        -- references stay qualified. This matches how the desired state renders
+        -- in its temporary schema, keeping both sides comparable (issue #449).
+        set_config('search_path', quote_ident(n.nspname), true) AS dummy,
+        CASE WHEN c.contype = 'c' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS check_clause,
+        CASE WHEN c.contype = 'x' THEN pg_get_constraintdef(c.oid, true) ELSE NULL END AS exclusion_definition
+) cd ON true
 WHERE n.nspname = $1
     -- Skip internal per-partition FK rows (conparentid != 0) that PostgreSQL
     -- creates when a FK references a partitioned table. pg_dump omits these;
@@ -2403,7 +2423,7 @@ JOIN pg_catalog.pg_class c ON c.oid = pol.polrelid
 JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 LEFT JOIN LATERAL (
     SELECT
-        set_config('search_path', 'pg_catalog', true) AS dummy,
+        set_config('search_path', quote_ident(n.nspname), true) AS dummy,
         pg_get_expr(pol.polqual, pol.polrelid) AS qual,
         pg_get_expr(pol.polwithcheck, pol.polrelid) AS with_check
 ) e ON true
@@ -2427,13 +2447,12 @@ type GetRLSPoliciesRow struct {
 
 // GetRLSPolicies retrieves all row level security policies
 // This replicates the pg_policies system view but computes the qual/with_check
-// expressions with a forced search_path so cross-schema references stay qualified:
-//  1. set_config sets search_path to only pg_catalog
-//  2. pg_get_expr then uses that search_path and includes schema qualifiers for any
-//     function or table reference outside pg_catalog. Same-schema qualifiers are stripped
-//     later by normalizePolicyExpression. Without this, references to objects on the
-//     session search_path (e.g. Supabase's auth.uid()) are emitted unqualified and the
-//     generated CREATE POLICY fails on apply. (Issue #427)
+// expressions with a forced search_path so qualification is deterministic:
+//  1. set_config sets search_path to only the table's own schema
+//  2. pg_get_expr then renders same-schema references unqualified while cross-schema
+//     references (e.g. Supabase's auth.uid(), issue #427) stay qualified. Without this,
+//     rendering depends on the session search_path and the current/desired states
+//     compare differently (issue #449).
 func (q *Queries) GetRLSPolicies(ctx context.Context) ([]GetRLSPoliciesRow, error) {
 	rows, err := q.db.QueryContext(ctx, getRLSPolicies)
 	if err != nil {
@@ -2495,7 +2514,12 @@ JOIN pg_catalog.pg_class c ON c.oid = pol.polrelid
 JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 LEFT JOIN LATERAL (
     SELECT
-        set_config('search_path', 'pg_catalog', true) AS dummy,
+        -- Render with search_path set to the table's own schema so same-schema
+        -- references come out unqualified while cross-schema references (e.g.
+        -- Supabase's auth.uid(), issue #427) stay qualified. This matches how the
+        -- desired state renders in its temporary schema, so both sides compare
+        -- equal without regex-stripping qualifiers afterwards (issue #449).
+        set_config('search_path', quote_ident(n.nspname), true) AS dummy,
         pg_get_expr(pol.polqual, pol.polrelid) AS qual,
         pg_get_expr(pol.polwithcheck, pol.polrelid) AS with_check
 ) e ON true


### PR DESCRIPTION
## Summary

A `pgschema plan` generated immediately after a successful `pgschema apply` reported spurious changes for RLS policies and CHECK constraints referencing same-schema objects (#449). The apply succeeded, but the plan never converged to "No changes detected", causing perpetual `ALTER POLICY` rewrites and `DROP CONSTRAINT` / `ADD ... NOT VALID` / `VALIDATE CONSTRAINT` churn on every deploy.

Two distinct root causes, both rendering-context asymmetries between the current state (target database) and the desired state (temporary plan schema):

1. **CHECK constraints** (`'disabled'::profiles.profile_status` vs `'disabled'::profile_status`): `pg_get_constraintdef()` ran under the inspector session's default search_path, so any non-public managed schema rendered same-schema type casts qualified on the current side, while `normalizeSchemaNames` stripped them on the desired side. This is the same drift reported in #445, which reproduces on main despite being closed.

2. **Policy expressions when the schema name equals a table name** (`profiles.profiles`): expressions were rendered with search_path forced to `pg_catalog` and same-schema qualifiers regex-stripped afterwards. The regex could not distinguish schema qualifiers from table qualifiers, so it mangled table-qualified column references (`profiles.id` → `id`) on the current side only.

## Fix

Render both expression kinds with search_path set to the table's own schema via a per-row `LATERAL set_config(...)` (the pattern already used for column defaults). Same-schema references then come out unqualified on **both** sides natively, while cross-schema references (e.g. Supabase's `auth.uid()`, #427) stay qualified. The now-obsolete and unsafe regex stripping in `normalizePolicyExpression` is removed; generated DDL still applies cleanly because apply sets `search_path` to the target schema.

Fixes #449
Also fixes the still-reproducible drift from #445.

## Test plan

- New `TestIssue449RepeatPlanIdempotency` integration test (`cmd/issue_449_integration_test.go`) covering both drift sources via apply-then-replan; red before the fix, green after:
  ```bash
  go test -v ./cmd -run TestIssue449RepeatPlanIdempotency
  ```
- Verified the exact reproduction from #449 end to end against PostgreSQL 17 (external plan database): repeat plan now reports "No changes detected", and the stored policy keeps `auth.uid()` schema-qualified (#427 preserved).
- Regression suites, all passing: full `TestDiffFromFiles` (150+ cases), full dump suite (`go test ./cmd/dump`), `TestPlanAndApply` for `create_policy/`, `create_table/`, `online/`, `TestNonPublicSchemaOperations`, and `./ir` unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)