### PR TITLE
fix: strip double-quotes from extracted sequence name in SERIAL ownership detection

### DIFF
--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -979,7 +979,7 @@ LEFT JOIN (
             REGEXP_REPLACE(
                 REGEXP_REPLACE(
                     REGEXP_REPLACE(col.column_default, 'nextval\(''([^'']+)''.*\)', '\1'),
-                    '^[^.]*\.', ''
+                    '^("([^"]|"")*"\.|[^.]*\.)', ''
                 ),
                 '^"(.*)"$', '\1'
             ),

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -975,12 +975,15 @@ LEFT JOIN (
     SELECT
         col.table_name,
         col.column_name,
-        REGEXP_REPLACE(
+        REPLACE(
             REGEXP_REPLACE(
-                REGEXP_REPLACE(col.column_default, 'nextval\(''([^'']+)''.*\)', '\1'),
-                '^[^.]*\.', ''
+                REGEXP_REPLACE(
+                    REGEXP_REPLACE(col.column_default, 'nextval\(''([^'']+)''.*\)', '\1'),
+                    '^[^.]*\.', ''
+                ),
+                '^"(.*)"$', '\1'
             ),
-            '^"(.*)"$', '\1'
+            '""', '"'
         ) AS sequence_name
     FROM information_schema.columns col
     WHERE col.table_schema = $1

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -972,12 +972,15 @@ LEFT JOIN pg_class dep_table ON d.refobjid = dep_table.oid
 LEFT JOIN pg_attribute dep_col ON dep_col.attrelid = dep_table.oid AND dep_col.attnum = d.refobjsubid
 -- Method 2: Find sequences used in column defaults (for nextval() patterns)
 LEFT JOIN (
-    SELECT 
+    SELECT
         col.table_name,
         col.column_name,
         REGEXP_REPLACE(
-            REGEXP_REPLACE(col.column_default, 'nextval\(''([^'']+)''.*\)', '\1'),
-            '^[^.]*\.', ''
+            REGEXP_REPLACE(
+                REGEXP_REPLACE(col.column_default, 'nextval\(''([^'']+)''.*\)', '\1'),
+                '^[^.]*\.', ''
+            ),
+            '^"(.*)"$', '\1'
         ) AS sequence_name
     FROM information_schema.columns col
     WHERE col.table_schema = $1

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -2735,12 +2735,15 @@ LEFT JOIN (
     SELECT
         col.table_name,
         col.column_name,
-        REGEXP_REPLACE(
+        REPLACE(
             REGEXP_REPLACE(
-                REGEXP_REPLACE(col.column_default, 'nextval\(''([^'']+)''.*\)', '\1'),
-                '^[^.]*\.', ''
+                REGEXP_REPLACE(
+                    REGEXP_REPLACE(col.column_default, 'nextval\(''([^'']+)''.*\)', '\1'),
+                    '^[^.]*\.', ''
+                ),
+                '^"(.*)"$', '\1'
             ),
-            '^"(.*)"$', '\1'
+            '""', '"'
         ) AS sequence_name
     FROM information_schema.columns col
     WHERE col.table_schema = $1

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -2739,7 +2739,7 @@ LEFT JOIN (
             REGEXP_REPLACE(
                 REGEXP_REPLACE(
                     REGEXP_REPLACE(col.column_default, 'nextval\(''([^'']+)''.*\)', '\1'),
-                    '^[^.]*\.', ''
+                    '^("([^"]|"")*"\.|[^.]*\.)', ''
                 ),
                 '^"(.*)"$', '\1'
             ),

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -2732,12 +2732,15 @@ LEFT JOIN pg_depend d ON d.objid = c.oid AND d.classid = 'pg_class'::regclass AN
 LEFT JOIN pg_class dep_table ON d.refobjid = dep_table.oid
 LEFT JOIN pg_attribute dep_col ON dep_col.attrelid = dep_table.oid AND dep_col.attnum = d.refobjsubid
 LEFT JOIN (
-    SELECT 
+    SELECT
         col.table_name,
         col.column_name,
         REGEXP_REPLACE(
-            REGEXP_REPLACE(col.column_default, 'nextval\(''([^'']+)''.*\)', '\1'),
-            '^[^.]*\.', ''
+            REGEXP_REPLACE(
+                REGEXP_REPLACE(col.column_default, 'nextval\(''([^'']+)''.*\)', '\1'),
+                '^[^.]*\.', ''
+            ),
+            '^"(.*)"$', '\1'
         ) AS sequence_name
     FROM information_schema.columns col
     WHERE col.table_schema = $1

--- a/ir/queries/queries_test.go
+++ b/ir/queries/queries_test.go
@@ -1,0 +1,71 @@
+package queries_test
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/pgplex/pgschema/internal/postgres"
+	"github.com/pgplex/pgschema/ir/queries"
+	"github.com/pgplex/pgschema/testutil"
+)
+
+var sharedTestPostgres *postgres.EmbeddedPostgres
+
+func TestMain(m *testing.M) {
+	sharedTestPostgres = testutil.SetupPostgres(nil)
+	defer sharedTestPostgres.Stop()
+	m.Run()
+}
+
+func TestGetSequencesForSchemaDetectsMixedCaseSequenceInColumnDefault(t *testing.T) {
+	conn, _, _, _, _, _ := testutil.ConnectToPostgres(t, sharedTestPostgres)
+	defer conn.Close()
+
+	ctx := context.Background()
+	if _, err := conn.ExecContext(ctx, `DROP TABLE IF EXISTS orders CASCADE`); err != nil {
+		t.Fatalf("failed to drop test table: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx, `CREATE TABLE orders ("orderId" SERIAL PRIMARY KEY)`); err != nil {
+		t.Fatalf("failed to create test table: %v", err)
+	}
+	// Drop the pg_depend ownership edge that SERIAL creates automatically.
+	// GetSequencesForSchema detects ownership via two paths: pg_depend (primary)
+	// and column_default parsing (fallback). Without this, pg_depend resolves
+	// ownership before the column_default regex is ever reached, so the test
+	// would pass even with the broken regex. OWNED BY NONE forces the fallback
+	// path — the one that was broken for mixed-case identifiers before this fix.
+	if _, err := conn.ExecContext(ctx, `ALTER SEQUENCE "orders_orderId_seq" OWNED BY NONE`); err != nil {
+		t.Fatalf("failed to remove sequence ownership dependency: %v", err)
+	}
+
+	rows, err := queries.New(conn).GetSequencesForSchema(ctx, sql.NullString{String: "public", Valid: true})
+	if err != nil {
+		t.Fatalf("failed to get sequences for schema: %v", err)
+	}
+
+	for _, row := range rows {
+		if row.SequenceName.String != "orders_orderId_seq" {
+			continue
+		}
+
+		if !row.OwnedByTable.Valid || row.OwnedByTable.String != "orders" {
+			t.Fatalf("OwnedByTable = %q, want %q", row.OwnedByTable.String, "orders")
+		}
+		if !row.OwnedByColumn.Valid || row.OwnedByColumn.String != "orderId" {
+			t.Fatalf("OwnedByColumn = %q, want %q", row.OwnedByColumn.String, "orderId")
+		}
+		return
+	}
+
+	t.Fatalf("sequence %q not found; got sequences: %s", "orders_orderId_seq", sequenceNames(rows))
+}
+
+func sequenceNames(rows []queries.GetSequencesForSchemaRow) string {
+	names := make([]string, 0, len(rows))
+	for _, row := range rows {
+		names = append(names, row.SequenceName.String)
+	}
+	return strings.Join(names, ", ")
+}


### PR DESCRIPTION
## Problem

When a sequence has a mixed-case quoted name (e.g. `"MyTable_myCol_seq"`), the `nextval()` column default stores it as:

nextval('schema."MyTable_myCol_seq"'::regclass)

The existing two-pass `REGEXP_REPLACE` in `getSequencesForSchema` extracted the name with double-quotes still attached — `"MyTable_myCol_seq"` — and the `col_table` JOIN compared this against `MyTable_myCol_seq` (as stored unquoted in `pg_sequences`). The join always failed for such sequences, leaving `OwnedByTable` empty.

With `OwnedByTable` empty, the skip condition in `diff.go` never fired, so pgschema emitted a standalone `CREATE SEQUENCE` for sequences already handled by `SERIAL`, causing PostgreSQL to create a duplicate with a `_seq1` suffix on every fresh database deploy.

## Fix

Add a third `REGEXP_REPLACE` pass that strips leading/trailing double-quotes from the extracted sequence name before the JOIN. This makes the JOIN match correctly, `OwnedByTable` is populated, the skip condition fires, and no standalone `CREATE SEQUENCE` is emitted for SERIAL-backed sequences.

## Testing

Verified on a schema with ~90 mixed-case SERIAL sequences across multiple tables:
- **Before:** 93 spurious `DROP SEQUENCE` operations on every second apply
- **After:** 0 sequence drops; fresh deploy is fully idempotent (second apply shows no changes)
