### PR TITLE
fix: avoid substring matches in policy table dependency detection

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -2382,17 +2382,15 @@ func policyReferencesOtherNewTable(policy *ir.RLSPolicy, newTables map[string]st
 		if expr == "" {
 			continue
 		}
-		exprLower := strings.ToLower(expr)
 		for qualifiedName := range newTables {
 			// Skip the policy's own table
 			if qualifiedName == ownQualified {
 				continue
 			}
-			// Extract the unqualified table name for substring matching.
 			// Policy expressions may use unqualified or qualified references.
 			parts := strings.SplitN(qualifiedName, ".", 2)
 			tableName := parts[len(parts)-1]
-			if strings.Contains(exprLower, tableName) {
+			if containsIdentifier(expr, tableName) || containsIdentifier(expr, qualifiedName) {
 				return true
 			}
 		}

--- a/internal/diff/policy_dependency_test.go
+++ b/internal/diff/policy_dependency_test.go
@@ -59,3 +59,27 @@ func TestPolicyReferencesNewFunction_BuiltInIgnored(t *testing.T) {
 		t.Fatalf("expected policy referencing only built-in functions to remain inline")
 	}
 }
+
+func TestPolicyReferencesOtherNewTable_IdentifierAware(t *testing.T) {
+	lookup := map[string]struct{}{
+		"public.orders": {},
+		"public.users":  {},
+		"public.user":   {},
+	}
+
+	if !policyReferencesOtherNewTable(&ir.RLSPolicy{
+		Schema: "public",
+		Table:  "orders",
+		Using:  "EXISTS (SELECT 1 FROM users u WHERE u.id = orders.user_id)",
+	}, lookup) {
+		t.Fatalf("expected policy referencing another new table to be deferred")
+	}
+
+	if policyReferencesOtherNewTable(&ir.RLSPolicy{
+		Schema: "public",
+		Table:  "orders",
+		Using:  "orders_archive.user_id = 1",
+	}, lookup) {
+		t.Fatalf("did not expect substring-only matches inside longer identifiers")
+	}
+}

--- a/testdata/diff/dependency/policy_identifier_substring_false_positive/diff.sql
+++ b/testdata/diff/dependency/policy_identifier_substring_false_positive/diff.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS orders (
+    id integer NOT NULL,
+    user_name text NOT NULL
+);
+
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY orders_current_user_scope ON orders FOR SELECT TO PUBLIC USING (user_name = CURRENT_USER);
+
+CREATE TABLE IF NOT EXISTS "user" (
+    id integer NOT NULL
+);

--- a/testdata/diff/dependency/policy_identifier_substring_false_positive/new.sql
+++ b/testdata/diff/dependency/policy_identifier_substring_false_positive/new.sql
@@ -1,0 +1,15 @@
+CREATE TABLE orders (
+    id int NOT NULL,
+    user_name text NOT NULL
+);
+
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY orders_current_user_scope ON orders
+    FOR SELECT
+    TO PUBLIC
+    USING (user_name = CURRENT_USER);
+
+CREATE TABLE "user" (
+    id int NOT NULL
+);

--- a/testdata/diff/dependency/policy_identifier_substring_false_positive/old.sql
+++ b/testdata/diff/dependency/policy_identifier_substring_false_positive/old.sql
@@ -1,0 +1,1 @@
+-- Empty schema (no tables)

--- a/testdata/diff/dependency/policy_identifier_substring_false_positive/plan.json
+++ b/testdata/diff/dependency/policy_identifier_substring_false_positive/plan.json
@@ -1,0 +1,38 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.11.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS orders (\n    id integer NOT NULL,\n    user_name text NOT NULL\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.orders"
+        },
+        {
+          "sql": "ALTER TABLE orders ENABLE ROW LEVEL SECURITY;",
+          "type": "table.rls",
+          "operation": "alter",
+          "path": "public.orders"
+        },
+        {
+          "sql": "CREATE POLICY orders_current_user_scope ON orders FOR SELECT TO PUBLIC USING (user_name = CURRENT_USER);",
+          "type": "table.policy",
+          "operation": "create",
+          "path": "public.orders.orders_current_user_scope"
+        },
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS \"user\" (\n    id integer NOT NULL\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.user"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/dependency/policy_identifier_substring_false_positive/plan.sql
+++ b/testdata/diff/dependency/policy_identifier_substring_false_positive/plan.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS orders (
+    id integer NOT NULL,
+    user_name text NOT NULL
+);
+
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY orders_current_user_scope ON orders FOR SELECT TO PUBLIC USING (user_name = CURRENT_USER);
+
+CREATE TABLE IF NOT EXISTS "user" (
+    id integer NOT NULL
+);

--- a/testdata/diff/dependency/policy_identifier_substring_false_positive/plan.txt
+++ b/testdata/diff/dependency/policy_identifier_substring_false_positive/plan.txt
@@ -1,0 +1,26 @@
+Plan: 2 to add.
+
+Summary by type:
+  tables: 2 to add
+
+Tables:
+  + orders
+    + orders_current_user_scope (policy)
+    ~ orders (rls)
+  + user
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS orders (
+    id integer NOT NULL,
+    user_name text NOT NULL
+);
+
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY orders_current_user_scope ON orders FOR SELECT TO PUBLIC USING (user_name = CURRENT_USER);
+
+CREATE TABLE IF NOT EXISTS "user" (
+    id integer NOT NULL
+);


### PR DESCRIPTION
Fix false positives when detecting whether an RLS policy depends on another newly added table.

Previously, table names were matched by substring, so identifiers like CURRENT_USER or user_name could be mistaken for references to a new table named `user`.

This change switches policy dependency detection to identifier-aware matching and adds a focused regression test plus a file-based fixture.