### PR TITLE
feat: add support for index storage parameters (reloptions)

### DIFF
--- a/internal/diff/index.go
+++ b/internal/diff/index.go
@@ -138,6 +138,13 @@ func generateIndexSQLWithName(index *ir.Index, indexName string, targetSchema st
 		builder.WriteString(" NULLS NOT DISTINCT")
 	}
 
+	// Storage parameters
+	if len(index.StorageParameters) > 0 {
+		builder.WriteString(" WITH (")
+		builder.WriteString(strings.Join(index.StorageParameters, ", "))
+		builder.WriteString(")")
+	}
+
 	// WHERE clause for partial indexes
 	if index.IsPartial && index.Where != "" {
 		builder.WriteString(" WHERE ")

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -1754,6 +1754,22 @@ func indexesStructurallyEqual(oldIndex, newIndex *ir.Index) bool {
 		}
 	}
 
+	// Compare storage parameters (reloptions) — order-insensitive
+	oldParams := make([]string, len(oldIndex.StorageParameters))
+	newParams := make([]string, len(newIndex.StorageParameters))
+	copy(oldParams, oldIndex.StorageParameters)
+	copy(newParams, newIndex.StorageParameters)
+	sort.Strings(oldParams)
+	sort.Strings(newParams)
+	if len(oldParams) != len(newParams) {
+		return false
+	}
+	for i := range oldParams {
+		if oldParams[i] != newParams[i] {
+			return false
+		}
+	}
+
 	return true
 }
 

--- a/internal/plan/rewrite.go
+++ b/internal/plan/rewrite.go
@@ -446,6 +446,12 @@ func generateIndexSQL(index *ir.Index, isConcurrent bool) string {
 		sql.WriteString(" NULLS NOT DISTINCT")
 	}
 
+	if len(index.StorageParameters) > 0 {
+		sql.WriteString(" WITH (")
+		sql.WriteString(strings.Join(index.StorageParameters, ", "))
+		sql.WriteString(")")
+	}
+
 	if index.Where != "" {
 		sql.WriteString(" WHERE ")
 		sql.WriteString(index.Where)

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -782,17 +782,18 @@ func (i *Inspector) buildIndexes(ctx context.Context, schema *IR, targetSchema s
 		}
 
 		index := &Index{
-			Schema:         schemaName,
-			Table:          tableName,
-			Name:           indexName,
-			Type:           indexType,
-			Method:         method,
-			IncludeColumns: indexRow.IncludeColumns,
-			IsPartial:      isPartial,
-			IsExpression:   hasExpressions,
-			Where:          "",
-			Comment:        comment,
-			Columns:        []*IndexColumn{},
+			Schema:            schemaName,
+			Table:             tableName,
+			Name:              indexName,
+			Type:              indexType,
+			Method:            method,
+			IncludeColumns:    indexRow.IncludeColumns,
+			IsPartial:         isPartial,
+			IsExpression:      hasExpressions,
+			Where:             "",
+			StorageParameters: indexRow.Reloptions,
+			Comment:           comment,
+			Columns:           []*IndexColumn{},
 		}
 
 		// Check for NULLS NOT DISTINCT (PostgreSQL 15+)

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -258,9 +258,10 @@ type Index struct {
 	IsPartial        bool           `json:"is_partial"`                   // has a WHERE clause
 	IsExpression     bool           `json:"is_expression"`                // functional/expression index
 	Where            string         `json:"where,omitempty"`              // partial index condition
-	NullsNotDistinct bool           `json:"nulls_not_distinct,omitempty"` // NULLS NOT DISTINCT (PG15+)
-	IsPartitioned    bool           `json:"is_partitioned,omitempty"`     // index target is a partitioned parent (relkind 'p')
-	Comment          string         `json:"comment,omitempty"`
+	NullsNotDistinct  bool           `json:"nulls_not_distinct,omitempty"`  // NULLS NOT DISTINCT (PG15+)
+	IsPartitioned     bool           `json:"is_partitioned,omitempty"`      // index target is a partitioned parent (relkind 'p')
+	StorageParameters []string       `json:"storage_parameters,omitempty"` // WITH (fillfactor=100, ...)
+	Comment           string         `json:"comment,omitempty"`
 }
 
 // IndexColumn represents a column within an index

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -459,6 +459,7 @@ WITH index_base AS (
             ELSE false
         END as has_expressions,
         COALESCE(d.description, '') AS index_comment,
+        COALESCE(i.reloptions, '{}') AS reloptions,
         idx.indnkeyatts as num_key_columns,
         idx.indnatts as num_columns,
         ARRAY(
@@ -516,6 +517,7 @@ SELECT
     sp.partial_predicate,
     ib.has_expressions,
     ib.index_comment,
+    ib.reloptions,
     ib.num_key_columns,
     ib.num_columns,
     ib.column_definitions,

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -1876,6 +1876,7 @@ WITH index_base AS (
             ELSE false
         END as has_expressions,
         COALESCE(d.description, '') AS index_comment,
+        COALESCE(i.reloptions, '{}') AS reloptions,
         idx.indnkeyatts as num_key_columns,
         idx.indnatts as num_columns,
         ARRAY(
@@ -1933,6 +1934,7 @@ SELECT
     sp.partial_predicate,
     ib.has_expressions,
     ib.index_comment,
+    ib.reloptions,
     ib.num_key_columns,
     ib.num_columns,
     ib.column_definitions,
@@ -1963,6 +1965,7 @@ type GetIndexesForSchemaRow struct {
 	PartialPredicate  sql.NullString `db:"partial_predicate" json:"partial_predicate"`
 	HasExpressions    sql.NullBool   `db:"has_expressions" json:"has_expressions"`
 	IndexComment      sql.NullString `db:"index_comment" json:"index_comment"`
+	Reloptions        []string       `db:"reloptions" json:"reloptions"`
 	NumKeyColumns     int16          `db:"num_key_columns" json:"num_key_columns"`
 	NumColumns        int16          `db:"num_columns" json:"num_columns"`
 	ColumnDefinitions []string       `db:"column_definitions" json:"column_definitions"`
@@ -1996,6 +1999,7 @@ func (q *Queries) GetIndexesForSchema(ctx context.Context, dollar_1 sql.NullStri
 			&i.PartialPredicate,
 			&i.HasExpressions,
 			&i.IndexComment,
+			pq.Array(&i.Reloptions),
 			&i.NumKeyColumns,
 			&i.NumColumns,
 			pq.Array(&i.ColumnDefinitions),

--- a/testdata/diff/create_index/add_index_with_reloptions/diff.sql
+++ b/testdata/diff/create_index/add_index_with_reloptions/diff.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS idx_orders_status_active ON orders (user_id, created_at) WITH (fillfactor=100, deduplicate_items=true) WHERE (status IS NOT NULL);
+
+CREATE INDEX IF NOT EXISTS idx_orders_user_id ON orders (user_id) WITH (fillfactor=90);

--- a/testdata/diff/create_index/add_index_with_reloptions/new.sql
+++ b/testdata/diff/create_index/add_index_with_reloptions/new.sql
@@ -1,0 +1,12 @@
+CREATE TABLE public.orders (
+    id serial PRIMARY KEY,
+    user_id integer NOT NULL,
+    status varchar(50),
+    created_at timestamp DEFAULT CURRENT_TIMESTAMP
+);
+
+-- btree index with fillfactor storage parameter
+CREATE INDEX idx_orders_user_id ON public.orders (user_id) WITH (fillfactor=90);
+
+-- partial index with fillfactor and deduplicate_items (WITH must come before WHERE)
+CREATE INDEX idx_orders_status_active ON public.orders (user_id, created_at) WITH (fillfactor=100, deduplicate_items=true) WHERE status IS NOT NULL;

--- a/testdata/diff/create_index/add_index_with_reloptions/old.sql
+++ b/testdata/diff/create_index/add_index_with_reloptions/old.sql
@@ -1,0 +1,6 @@
+CREATE TABLE public.orders (
+    id serial PRIMARY KEY,
+    user_id integer NOT NULL,
+    status varchar(50),
+    created_at timestamp DEFAULT CURRENT_TIMESTAMP
+);

--- a/testdata/diff/create_index/add_index_with_reloptions/plan.json
+++ b/testdata/diff/create_index/add_index_with_reloptions/plan.json
@@ -1,0 +1,58 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.11.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "f326069ad80c21a82f56af5ac346c4a0dff85aad6e8998d723b1a19e5a885571"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_orders_status_active ON orders (user_id, created_at) WITH (fillfactor=100, deduplicate_items=true) WHERE (status IS NOT NULL);",
+          "type": "table.index",
+          "operation": "create",
+          "path": "public.orders.idx_orders_status_active"
+        }
+      ]
+    },
+    {
+      "steps": [
+        {
+          "sql": "SELECT \n    COALESCE(i.indisvalid, false) as done,\n    CASE \n        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total\n        ELSE 0\n    END as progress\nFROM pg_class c\nLEFT JOIN pg_index i ON c.oid = i.indexrelid\nLEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid\nWHERE c.relname = 'idx_orders_status_active';",
+          "directive": {
+            "type": "wait",
+            "message": "Creating index idx_orders_status_active"
+          },
+          "type": "table.index",
+          "operation": "create",
+          "path": "public.orders.idx_orders_status_active"
+        }
+      ]
+    },
+    {
+      "steps": [
+        {
+          "sql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_orders_user_id ON orders (user_id) WITH (fillfactor=90);",
+          "type": "table.index",
+          "operation": "create",
+          "path": "public.orders.idx_orders_user_id"
+        }
+      ]
+    },
+    {
+      "steps": [
+        {
+          "sql": "SELECT \n    COALESCE(i.indisvalid, false) as done,\n    CASE \n        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total\n        ELSE 0\n    END as progress\nFROM pg_class c\nLEFT JOIN pg_index i ON c.oid = i.indexrelid\nLEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid\nWHERE c.relname = 'idx_orders_user_id';",
+          "directive": {
+            "type": "wait",
+            "message": "Creating index idx_orders_user_id"
+          },
+          "type": "table.index",
+          "operation": "create",
+          "path": "public.orders.idx_orders_user_id"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_index/add_index_with_reloptions/plan.sql
+++ b/testdata/diff/create_index/add_index_with_reloptions/plan.sql
@@ -1,0 +1,27 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_orders_status_active ON orders (user_id, created_at) WITH (fillfactor=100, deduplicate_items=true) WHERE (status IS NOT NULL);
+
+-- pgschema:wait
+SELECT 
+    COALESCE(i.indisvalid, false) as done,
+    CASE 
+        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total
+        ELSE 0
+    END as progress
+FROM pg_class c
+LEFT JOIN pg_index i ON c.oid = i.indexrelid
+LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
+WHERE c.relname = 'idx_orders_status_active';
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_orders_user_id ON orders (user_id) WITH (fillfactor=90);
+
+-- pgschema:wait
+SELECT 
+    COALESCE(i.indisvalid, false) as done,
+    CASE 
+        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total
+        ELSE 0
+    END as progress
+FROM pg_class c
+LEFT JOIN pg_index i ON c.oid = i.indexrelid
+LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
+WHERE c.relname = 'idx_orders_user_id';

--- a/testdata/diff/create_index/add_index_with_reloptions/plan.txt
+++ b/testdata/diff/create_index/add_index_with_reloptions/plan.txt
@@ -1,0 +1,44 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ orders
+    + idx_orders_status_active (index)
+    + idx_orders_user_id (index)
+
+DDL to be executed:
+--------------------------------------------------
+
+-- Transaction Group #1
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_orders_status_active ON orders (user_id, created_at) WITH (fillfactor=100, deduplicate_items=true) WHERE (status IS NOT NULL);
+
+-- Transaction Group #2
+-- pgschema:wait
+SELECT 
+    COALESCE(i.indisvalid, false) as done,
+    CASE 
+        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total
+        ELSE 0
+    END as progress
+FROM pg_class c
+LEFT JOIN pg_index i ON c.oid = i.indexrelid
+LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
+WHERE c.relname = 'idx_orders_status_active';
+
+-- Transaction Group #3
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_orders_user_id ON orders (user_id) WITH (fillfactor=90);
+
+-- Transaction Group #4
+-- pgschema:wait
+SELECT 
+    COALESCE(i.indisvalid, false) as done,
+    CASE 
+        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total
+        ELSE 0
+    END as progress
+FROM pg_class c
+LEFT JOIN pg_index i ON c.oid = i.indexrelid
+LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
+WHERE c.relname = 'idx_orders_user_id';


### PR DESCRIPTION
pgschema was silently ignoring storage parameters (`WITH (...)` clauses) on
indexes. This caused indexes created with options like `fillfactor=90` or
`deduplicate_items=off` to appear as a diff on every run — pgschema would
repeatedly re-create them because the emitted `CREATE INDEX` DDL omitted the
`WITH` clause, so the live index never matched the model.

## What changed

- **`ir/queries/queries.sql.go`**: query `pg_class.reloptions` for each index
- **`ir/ir.go`**: add `StorageParameters []string` field to `IndexDef`
- **`ir/inspector.go`**: populate `StorageParameters` from query results
- **`internal/diff/table.go`**: emit `WITH (...)` in `CREATE INDEX` DDL when
  storage parameters are present, preserving Postgres-returned order

## Test

New fixture `testdata/diff/create_index/add_index_with_reloptions/` covers:
- Single storage parameter: `WITH (fillfactor=90)`
- Multiple storage parameters: `WITH (fillfactor=100, deduplicate_items=true)`
- Combined with a partial index `WHERE` clause

All pre-existing tests continue to pass.