### PR TITLE
feat: add support for trigger comments, trigger enabled/disabled state, and sequence comments

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1064,12 +1064,20 @@ func GenerateMigration(oldIR, newIR *ir.IR, targetSchema string) []Diff {
 	for _, key := range seqKeys {
 		newSeq := newSequences[key]
 		if oldSeq, exists := oldSequences[key]; exists {
-			// Skip sequences owned by table columns (created by SERIAL)
-			if (oldSeq.OwnedByTable != "" && oldSeq.OwnedByColumn != "") ||
-				(newSeq.OwnedByTable != "" && newSeq.OwnedByColumn != "") {
+			// Skip sequences owned by table columns (created by SERIAL) for structural changes,
+			// but allow comment-only changes through so COMMENT ON SEQUENCE can be deployed.
+			isOwned := (oldSeq.OwnedByTable != "" && oldSeq.OwnedByColumn != "") ||
+				(newSeq.OwnedByTable != "" && newSeq.OwnedByColumn != "")
+			if isOwned {
+				if oldSeq.Comment != newSeq.Comment {
+					diff.modifiedSequences = append(diff.modifiedSequences, &sequenceDiff{
+						Old: oldSeq,
+						New: newSeq,
+					})
+				}
 				continue
 			}
-			if !sequencesEqual(oldSeq, newSeq) {
+			if !sequencesEqual(oldSeq, newSeq) || oldSeq.Comment != newSeq.Comment {
 				diff.modifiedSequences = append(diff.modifiedSequences, &sequenceDiff{
 					Old: oldSeq,
 					New: newSeq,

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -288,6 +288,7 @@ type ddlDiff struct {
 	droppedTypes              []*ir.Type
 	modifiedTypes             []*typeDiff
 	addedSequences            []*ir.Sequence
+	addedSerialSeqComments    []*ir.Sequence // SERIAL-owned sequences skipped from addedSequences but with comments to emit
 	droppedSequences          []*ir.Sequence
 	modifiedSequences         []*sequenceDiff
 	addedDefaultPrivileges    []*ir.DefaultPrivilege
@@ -478,6 +479,7 @@ func GenerateMigration(oldIR, newIR *ir.IR, targetSchema string) []Diff {
 		droppedTypes:               []*ir.Type{},
 		modifiedTypes:              []*typeDiff{},
 		addedSequences:             []*ir.Sequence{},
+		addedSerialSeqComments:     []*ir.Sequence{},
 		droppedSequences:           []*ir.Sequence{},
 		modifiedSequences:          []*sequenceDiff{},
 		addedDefaultPrivileges:     []*ir.DefaultPrivilege{},
@@ -1041,6 +1043,11 @@ func GenerateMigration(oldIR, newIR *ir.IR, targetSchema string) []Diff {
 			// (created by SERIAL in CREATE TABLE). If the column already exists,
 			// we need to create the sequence explicitly for ALTER COLUMN to use.
 			if seq.OwnedByTable != "" && seq.OwnedByColumn != "" && !columnExistsInTables(oldTables, seq.Schema, seq.OwnedByTable, seq.OwnedByColumn) {
+				// Sequence is created implicitly by CREATE TABLE (SERIAL). Emit its
+				// comment separately after all tables are created.
+				if seq.Comment != "" {
+					diff.addedSerialSeqComments = append(diff.addedSerialSeqComments, seq)
+				}
 				continue
 			}
 			diff.addedSequences = append(diff.addedSequences, seq)
@@ -1825,6 +1832,12 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 
 	// Create tables WITH function/domain dependencies (now that functions and deferred domains exist)
 	deferredPolicies2, deferredConstraints2 := generateCreateTablesSQL(tablesWithDeps, targetSchema, collector, existingTables, shouldDeferPolicy, d.suppressedInlineFKs)
+
+	// Emit COMMENT ON SEQUENCE for sequences created implicitly via CREATE TABLE (SERIAL/BIGSERIAL).
+	// These were skipped from addedSequences but their comments must still be deployed.
+	for _, seq := range d.addedSerialSeqComments {
+		generateSequenceComment(seq, targetSchema, DiffOperationCreate, collector)
+	}
 
 	// Add deferred foreign key constraints from BOTH batches AFTER all tables are created
 	// This ensures FK references to tables in the second batch (function-dependent tables) work correctly

--- a/internal/diff/sequence.go
+++ b/internal/diff/sequence.go
@@ -31,7 +31,31 @@ func generateCreateSequencesSQL(sequences []*ir.Sequence, targetSchema string, c
 		}
 
 		collector.collect(context, sql)
+
+		// Emit COMMENT ON SEQUENCE if present
+		if seq.Comment != "" {
+			generateSequenceComment(seq, targetSchema, DiffOperationCreate, collector)
+		}
 	}
+}
+
+// generateSequenceComment emits a COMMENT ON SEQUENCE statement
+func generateSequenceComment(seq *ir.Sequence, targetSchema string, operation DiffOperation, collector *diffCollector) {
+	seqName := qualifyEntityName(seq.Schema, seq.Name, targetSchema)
+	var sql string
+	if seq.Comment == "" {
+		sql = fmt.Sprintf("COMMENT ON SEQUENCE %s IS NULL;", seqName)
+	} else {
+		sql = fmt.Sprintf("COMMENT ON SEQUENCE %s IS %s;", seqName, quoteString(seq.Comment))
+	}
+	context := &diffContext{
+		Type:                DiffTypeSequence,
+		Operation:           operation,
+		Path:                fmt.Sprintf("%s.%s", seq.Schema, seq.Name),
+		Source:              seq,
+		CanRunInTransaction: true,
+	}
+	collector.collect(context, sql)
 }
 
 // generateDropSequencesSQL generates DROP SEQUENCE statements
@@ -70,6 +94,11 @@ func generateModifySequencesSQL(diffs []*sequenceDiff, targetSchema string, coll
 			}
 
 			collector.collect(context, stmt)
+		}
+
+		// Emit COMMENT ON SEQUENCE if comment changed
+		if diff.Old.Comment != diff.New.Comment {
+			generateSequenceComment(diff.New, targetSchema, DiffOperationAlter, collector)
 		}
 	}
 }

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -98,10 +98,13 @@ func diffTriggers(oldTable, newTable *ir.Table, diff *tableDiff) {
 		}
 	}
 
-	// Find modified triggers
+	// Find modified triggers (structural changes, comment-only, or enabled-state-only)
 	for name, newTrigger := range newTriggers {
 		if oldTrigger, exists := oldTriggers[name]; exists {
-			if !triggersEqual(oldTrigger, newTrigger) {
+			structurallyEqual := triggersEqual(oldTrigger, newTrigger)
+			commentChanged := oldTrigger.Comment != newTrigger.Comment
+			enabledChanged := oldTrigger.Enabled != newTrigger.Enabled
+			if !structurallyEqual || commentChanged || enabledChanged {
 				diff.ModifiedTriggers = append(diff.ModifiedTriggers, &triggerDiff{
 					Old: oldTrigger,
 					New: newTrigger,
@@ -1383,43 +1386,59 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 
 	// Modify triggers - already sorted by the Diff operation
 	for _, triggerDiff := range td.ModifiedTriggers {
-		// Constraint triggers don't support CREATE OR REPLACE, so we need to DROP and CREATE
-		if triggerDiff.New.IsConstraint {
-			tableName := getTableNameWithSchema(td.Table.Schema, td.Table.Name, targetSchema)
+		structurallyEqual := triggersEqual(triggerDiff.Old, triggerDiff.New)
+		commentChanged := triggerDiff.Old.Comment != triggerDiff.New.Comment
+		enabledChanged := triggerDiff.Old.Enabled != triggerDiff.New.Enabled
 
-			// Step 1: DROP the old trigger
-			dropSQL := fmt.Sprintf("DROP TRIGGER IF EXISTS %s ON %s;", ir.QuoteIdentifier(triggerDiff.Old.Name), tableName)
-			dropContext := &diffContext{
-				Type:                DiffTypeTableTrigger,
-				Operation:           DiffOperationDrop,
-				Path:                fmt.Sprintf("%s.%s.%s", td.Table.Schema, td.Table.Name, triggerDiff.Old.Name),
-				Source:              triggerDiff.Old,
-				CanRunInTransaction: true,
-			}
-			collector.collect(dropContext, dropSQL)
+		if !structurallyEqual {
+			// Constraint triggers don't support CREATE OR REPLACE, so we need to DROP and CREATE
+			if triggerDiff.New.IsConstraint {
+				tableName := getTableNameWithSchema(td.Table.Schema, td.Table.Name, targetSchema)
 
-			// Step 2: CREATE the new constraint trigger
-			createSQL := generateTriggerSQLWithMode(triggerDiff.New, targetSchema)
-			createContext := &diffContext{
-				Type:                DiffTypeTableTrigger,
-				Operation:           DiffOperationCreate,
-				Path:                fmt.Sprintf("%s.%s.%s", td.Table.Schema, td.Table.Name, triggerDiff.New.Name),
-				Source:              triggerDiff.New,
-				CanRunInTransaction: true,
-			}
-			collector.collect(createContext, createSQL)
-		} else {
-			// Use CREATE OR REPLACE for regular triggers
-			sql := generateTriggerSQLWithMode(triggerDiff.New, targetSchema)
+				// Step 1: DROP the old trigger
+				dropSQL := fmt.Sprintf("DROP TRIGGER IF EXISTS %s ON %s;", ir.QuoteIdentifier(triggerDiff.Old.Name), tableName)
+				dropContext := &diffContext{
+					Type:                DiffTypeTableTrigger,
+					Operation:           DiffOperationDrop,
+					Path:                fmt.Sprintf("%s.%s.%s", td.Table.Schema, td.Table.Name, triggerDiff.Old.Name),
+					Source:              triggerDiff.Old,
+					CanRunInTransaction: true,
+				}
+				collector.collect(dropContext, dropSQL)
 
-			context := &diffContext{
-				Type:                DiffTypeTableTrigger,
-				Operation:           DiffOperationAlter,
-				Path:                fmt.Sprintf("%s.%s.%s", td.Table.Schema, td.Table.Name, triggerDiff.New.Name),
-				Source:              triggerDiff,
-				CanRunInTransaction: true,
+				// Step 2: CREATE the new constraint trigger
+				createSQL := generateTriggerSQLWithMode(triggerDiff.New, targetSchema)
+				createContext := &diffContext{
+					Type:                DiffTypeTableTrigger,
+					Operation:           DiffOperationCreate,
+					Path:                fmt.Sprintf("%s.%s.%s", td.Table.Schema, td.Table.Name, triggerDiff.New.Name),
+					Source:              triggerDiff.New,
+					CanRunInTransaction: true,
+				}
+				collector.collect(createContext, createSQL)
+			} else {
+				// Use CREATE OR REPLACE for regular triggers
+				sql := generateTriggerSQLWithMode(triggerDiff.New, targetSchema)
+
+				context := &diffContext{
+					Type:                DiffTypeTableTrigger,
+					Operation:           DiffOperationAlter,
+					Path:                fmt.Sprintf("%s.%s.%s", td.Table.Schema, td.Table.Name, triggerDiff.New.Name),
+					Source:              triggerDiff,
+					CanRunInTransaction: true,
+				}
+				collector.collect(context, sql)
 			}
-			collector.collect(context, sql)
+		}
+
+		// Emit COMMENT ON TRIGGER for comment changes (including after structural recreate)
+		if commentChanged {
+			generateTriggerComment(triggerDiff.New, td.Table.Schema, td.Table.Name, targetSchema, DiffTypeTableTrigger, collector)
+		}
+
+		// Emit ENABLE/DISABLE TRIGGER for enabled state changes
+		if enabledChanged {
+			generateTriggerEnabledState(triggerDiff.New, td.Table.Schema, td.Table.Name, targetSchema, collector)
 		}
 	}
 

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -103,7 +103,7 @@ func diffTriggers(oldTable, newTable *ir.Table, diff *tableDiff) {
 		if oldTrigger, exists := oldTriggers[name]; exists {
 			structurallyEqual := triggersEqual(oldTrigger, newTrigger)
 			commentChanged := oldTrigger.Comment != newTrigger.Comment
-			enabledChanged := oldTrigger.Enabled != newTrigger.Enabled
+			enabledChanged := oldTrigger.Disabled != newTrigger.Disabled
 			if !structurallyEqual || commentChanged || enabledChanged {
 				diff.ModifiedTriggers = append(diff.ModifiedTriggers, &triggerDiff{
 					Old: oldTrigger,
@@ -1388,7 +1388,7 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 	for _, triggerDiff := range td.ModifiedTriggers {
 		structurallyEqual := triggersEqual(triggerDiff.Old, triggerDiff.New)
 		commentChanged := triggerDiff.Old.Comment != triggerDiff.New.Comment
-		enabledChanged := triggerDiff.Old.Enabled != triggerDiff.New.Enabled
+		enabledChanged := triggerDiff.Old.Disabled != triggerDiff.New.Disabled
 
 		if !structurallyEqual {
 			// Constraint triggers don't support CREATE OR REPLACE, so we need to DROP and CREATE

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -1431,14 +1431,16 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			}
 		}
 
-		// Emit COMMENT ON TRIGGER for comment changes (including after structural recreate)
-		if commentChanged {
+		// Emit COMMENT ON TRIGGER when the comment changed, or after structural recreation
+		// so the desired comment is preserved.
+		if commentChanged || (!structurallyEqual && triggerDiff.New.Comment != "") {
 			generateTriggerComment(triggerDiff.New, td.Table.Schema, td.Table.Name, targetSchema, DiffTypeTableTrigger, collector)
 		}
 
-		// Emit ENABLE/DISABLE TRIGGER for enabled state changes
-		if enabledChanged {
-			generateTriggerEnabledState(triggerDiff.New, td.Table.Schema, td.Table.Name, targetSchema, collector)
+		// Emit ENABLE/DISABLE TRIGGER when the state changed, or after structural recreation
+		// so disabled triggers stay disabled.
+		if enabledChanged || (!structurallyEqual && triggerDiff.New.Disabled) {
+			generateTriggerEnabledState(triggerDiff.New, td.Table.Schema, td.Table.Name, targetSchema, DiffTypeTableTrigger, collector)
 		}
 	}
 

--- a/internal/diff/trigger.go
+++ b/internal/diff/trigger.go
@@ -156,7 +156,7 @@ func generateCreateTriggersSQL(triggers []*ir.Trigger, targetSchema string, coll
 
 		// Emit DISABLE TRIGGER if the trigger is disabled
 		if trigger.Disabled {
-			generateTriggerEnabledState(trigger, trigger.Schema, trigger.Table, targetSchema, collector)
+			generateTriggerEnabledState(trigger, trigger.Schema, trigger.Table, targetSchema, DiffTypeTableTrigger, collector)
 		}
 	}
 }
@@ -335,7 +335,7 @@ func generateCreateViewTriggersSQL(triggers []*ir.Trigger, targetSchema string, 
 		}
 
 		if trigger.Disabled {
-			generateTriggerEnabledState(trigger, trigger.Schema, trigger.Table, targetSchema, collector)
+			generateTriggerEnabledState(trigger, trigger.Schema, trigger.Table, targetSchema, DiffTypeViewTrigger, collector)
 		}
 	}
 }
@@ -360,7 +360,7 @@ func generateTriggerComment(trigger *ir.Trigger, schema, table, targetSchema str
 }
 
 // generateTriggerEnabledState emits ALTER TABLE DISABLE/ENABLE TRIGGER
-func generateTriggerEnabledState(trigger *ir.Trigger, schema, table, targetSchema string, collector *diffCollector) {
+func generateTriggerEnabledState(trigger *ir.Trigger, schema, table, targetSchema string, diffType DiffType, collector *diffCollector) {
 	tableName := getTableNameWithSchema(schema, table, targetSchema)
 	state := "ENABLE"
 	if trigger.Disabled {
@@ -368,7 +368,7 @@ func generateTriggerEnabledState(trigger *ir.Trigger, schema, table, targetSchem
 	}
 	sql := fmt.Sprintf("ALTER TABLE %s %s TRIGGER %s;", tableName, state, ir.QuoteIdentifier(trigger.Name))
 	context := &diffContext{
-		Type:                DiffTypeTableTrigger,
+		Type:                diffType,
 		Operation:           DiffOperationAlter,
 		Path:                fmt.Sprintf("%s.%s.%s", schema, table, trigger.Name),
 		Source:              trigger,

--- a/internal/diff/trigger.go
+++ b/internal/diff/trigger.go
@@ -148,6 +148,16 @@ func generateCreateTriggersSQL(triggers []*ir.Trigger, targetSchema string, coll
 		}
 
 		collector.collect(context, sql)
+
+		// Emit COMMENT ON TRIGGER if present
+		if trigger.Comment != "" {
+			generateTriggerComment(trigger, trigger.Schema, trigger.Table, targetSchema, DiffTypeTableTrigger, collector)
+		}
+
+		// Emit DISABLE TRIGGER if the trigger is disabled
+		if !trigger.Enabled {
+			generateTriggerEnabledState(trigger, trigger.Schema, trigger.Table, targetSchema, collector)
+		}
 	}
 }
 
@@ -319,7 +329,46 @@ func generateCreateViewTriggersSQL(triggers []*ir.Trigger, targetSchema string, 
 		}
 
 		collector.collect(context, sql)
+
+		if trigger.Comment != "" {
+			generateTriggerComment(trigger, trigger.Schema, trigger.Table, targetSchema, DiffTypeViewTrigger, collector)
+		}
 	}
 }
 
+// generateTriggerComment emits a COMMENT ON TRIGGER statement
+func generateTriggerComment(trigger *ir.Trigger, schema, table, targetSchema string, diffType DiffType, collector *diffCollector) {
+	tableName := getTableNameWithSchema(schema, table, targetSchema)
+	var sql string
+	if trigger.Comment == "" {
+		sql = fmt.Sprintf("COMMENT ON TRIGGER %s ON %s IS NULL;", ir.QuoteIdentifier(trigger.Name), tableName)
+	} else {
+		sql = fmt.Sprintf("COMMENT ON TRIGGER %s ON %s IS %s;", ir.QuoteIdentifier(trigger.Name), tableName, quoteString(trigger.Comment))
+	}
+	context := &diffContext{
+		Type:                diffType,
+		Operation:           DiffOperationAlter,
+		Path:                fmt.Sprintf("%s.%s.%s", schema, table, trigger.Name),
+		Source:              trigger,
+		CanRunInTransaction: true,
+	}
+	collector.collect(context, sql)
+}
 
+// generateTriggerEnabledState emits ALTER TABLE DISABLE/ENABLE TRIGGER
+func generateTriggerEnabledState(trigger *ir.Trigger, schema, table, targetSchema string, collector *diffCollector) {
+	tableName := getTableNameWithSchema(schema, table, targetSchema)
+	state := "ENABLE"
+	if !trigger.Enabled {
+		state = "DISABLE"
+	}
+	sql := fmt.Sprintf("ALTER TABLE %s %s TRIGGER %s;", tableName, state, ir.QuoteIdentifier(trigger.Name))
+	context := &diffContext{
+		Type:                DiffTypeTableTrigger,
+		Operation:           DiffOperationAlter,
+		Path:                fmt.Sprintf("%s.%s.%s", schema, table, trigger.Name),
+		Source:              trigger,
+		CanRunInTransaction: true,
+	}
+	collector.collect(context, sql)
+}

--- a/internal/diff/trigger.go
+++ b/internal/diff/trigger.go
@@ -155,7 +155,7 @@ func generateCreateTriggersSQL(triggers []*ir.Trigger, targetSchema string, coll
 		}
 
 		// Emit DISABLE TRIGGER if the trigger is disabled
-		if !trigger.Enabled {
+		if trigger.Disabled {
 			generateTriggerEnabledState(trigger, trigger.Schema, trigger.Table, targetSchema, collector)
 		}
 	}
@@ -333,6 +333,10 @@ func generateCreateViewTriggersSQL(triggers []*ir.Trigger, targetSchema string, 
 		if trigger.Comment != "" {
 			generateTriggerComment(trigger, trigger.Schema, trigger.Table, targetSchema, DiffTypeViewTrigger, collector)
 		}
+
+		if trigger.Disabled {
+			generateTriggerEnabledState(trigger, trigger.Schema, trigger.Table, targetSchema, collector)
+		}
 	}
 }
 
@@ -359,7 +363,7 @@ func generateTriggerComment(trigger *ir.Trigger, schema, table, targetSchema str
 func generateTriggerEnabledState(trigger *ir.Trigger, schema, table, targetSchema string, collector *diffCollector) {
 	tableName := getTableNameWithSchema(schema, table, targetSchema)
 	state := "ENABLE"
-	if !trigger.Enabled {
+	if trigger.Disabled {
 		state = "DISABLE"
 	}
 	sql := fmt.Sprintf("ALTER TABLE %s %s TRIGGER %s;", tableName, state, ir.QuoteIdentifier(trigger.Name))

--- a/internal/diff/view.go
+++ b/internal/diff/view.go
@@ -435,6 +435,12 @@ func generateModifyViewsSQL(diffs []*viewDiff, targetSchema string, collector *d
 					CanRunInTransaction: true,
 				}
 				collector.collect(createContext, createSQL)
+				if triggerDiff.New.Comment != "" {
+					generateTriggerComment(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, DiffTypeViewTrigger, collector)
+				}
+				if triggerDiff.New.Disabled {
+					generateTriggerEnabledState(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, collector)
+				}
 			} else {
 				sql := generateTriggerSQLWithMode(triggerDiff.New, targetSchema)
 				context := &diffContext{
@@ -445,6 +451,12 @@ func generateModifyViewsSQL(diffs []*viewDiff, targetSchema string, collector *d
 					CanRunInTransaction: true,
 				}
 				collector.collect(context, sql)
+				if triggerDiff.New.Comment != "" {
+					generateTriggerComment(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, DiffTypeViewTrigger, collector)
+				}
+				if triggerDiff.New.Disabled {
+					generateTriggerEnabledState(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, collector)
+				}
 			}
 		}
 	}

--- a/internal/diff/view.go
+++ b/internal/diff/view.go
@@ -435,11 +435,13 @@ func generateModifyViewsSQL(diffs []*viewDiff, targetSchema string, collector *d
 					CanRunInTransaction: true,
 				}
 				collector.collect(createContext, createSQL)
-				if triggerDiff.New.Comment != "" {
+				commentChanged := triggerDiff.Old.Comment != triggerDiff.New.Comment
+				enabledChanged := triggerDiff.Old.Disabled != triggerDiff.New.Disabled
+				if commentChanged || triggerDiff.New.Comment != "" {
 					generateTriggerComment(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, DiffTypeViewTrigger, collector)
 				}
-				if triggerDiff.New.Disabled {
-					generateTriggerEnabledState(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, collector)
+				if enabledChanged || triggerDiff.New.Disabled {
+					generateTriggerEnabledState(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, DiffTypeViewTrigger, collector)
 				}
 			} else {
 				sql := generateTriggerSQLWithMode(triggerDiff.New, targetSchema)
@@ -451,11 +453,13 @@ func generateModifyViewsSQL(diffs []*viewDiff, targetSchema string, collector *d
 					CanRunInTransaction: true,
 				}
 				collector.collect(context, sql)
-				if triggerDiff.New.Comment != "" {
+				commentChanged := triggerDiff.Old.Comment != triggerDiff.New.Comment
+				enabledChanged := triggerDiff.Old.Disabled != triggerDiff.New.Disabled
+				if commentChanged || triggerDiff.New.Comment != "" {
 					generateTriggerComment(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, DiffTypeViewTrigger, collector)
 				}
-				if triggerDiff.New.Disabled {
-					generateTriggerEnabledState(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, collector)
+				if enabledChanged || triggerDiff.New.Disabled {
+					generateTriggerEnabledState(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, DiffTypeViewTrigger, collector)
 				}
 			}
 		}

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -880,6 +880,11 @@ func (i *Inspector) buildSequences(ctx context.Context, schema *IR, targetSchema
 			}
 		}
 
+		seqComment := ""
+		if seq.SequenceComment.Valid {
+			seqComment = seq.SequenceComment.String
+		}
+
 		sequence := &Sequence{
 			Schema:      schemaName,
 			Name:        sequenceName,
@@ -887,6 +892,7 @@ func (i *Inspector) buildSequences(ctx context.Context, schema *IR, targetSchema
 			StartValue:  seq.StartValue.Int64,
 			Increment:   seq.Increment.Int64,
 			CycleOption: seq.CycleOption.Bool,
+			Comment:     seqComment,
 		}
 
 		// Set default values if not valid
@@ -1724,6 +1730,15 @@ func (i *Inspector) buildTriggers(ctx context.Context, schema *IR, targetSchema 
 			comment = triggerRow.TriggerComment.String
 		}
 
+		// Extract enabled state: tgenabled 'D' = disabled, anything else = enabled
+		enabled := true
+		switch v := triggerRow.TriggerEnabled.(type) {
+		case string:
+			enabled = v != "D"
+		case []byte:
+			enabled = string(v) != "D"
+		}
+
 		// Determine if this is a constraint trigger
 		oid, ok := triggerRow.TriggerConstraintOid.(int64)
 		isConstraint := ok && oid != 0
@@ -1747,6 +1762,7 @@ func (i *Inspector) buildTriggers(ctx context.Context, schema *IR, targetSchema 
 			Deferrable:        deferrable,
 			InitiallyDeferred: initDeferred,
 			Comment:           comment,
+			Enabled:           enabled,
 		}
 
 		// Add trigger to the appropriate map

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -1730,13 +1730,13 @@ func (i *Inspector) buildTriggers(ctx context.Context, schema *IR, targetSchema 
 			comment = triggerRow.TriggerComment.String
 		}
 
-		// Extract enabled state: tgenabled 'D' = disabled, anything else = enabled
-		enabled := true
+		// Extract disabled state: tgenabled 'D' = disabled, anything else = enabled (Postgres default)
+		disabled := false
 		switch v := triggerRow.TriggerEnabled.(type) {
 		case string:
-			enabled = v != "D"
+			disabled = v == "D"
 		case []byte:
-			enabled = string(v) != "D"
+			disabled = string(v) == "D"
 		}
 
 		// Determine if this is a constraint trigger
@@ -1762,7 +1762,7 @@ func (i *Inspector) buildTriggers(ctx context.Context, schema *IR, targetSchema 
 			Deferrable:        deferrable,
 			InitiallyDeferred: initDeferred,
 			Comment:           comment,
-			Enabled:           enabled,
+			Disabled:          disabled,
 		}
 
 		// Add trigger to the appropriate map

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -297,7 +297,7 @@ type Trigger struct {
 	InitiallyDeferred bool           `json:"initially_deferred,omitempty"` // Whether deferred by default
 	OldTable          string         `json:"old_table,omitempty"`          // REFERENCING OLD TABLE AS name
 	NewTable          string         `json:"new_table,omitempty"`          // REFERENCING NEW TABLE AS name
-	Enabled           bool           `json:"enabled"`                      // false = DISABLED (tgenabled='D'), true = enabled (default)
+	Disabled          bool           `json:"disabled,omitempty"`           // true = DISABLED (tgenabled='D'); omitted/false = enabled (Postgres default)
 }
 
 // TriggerTiming represents the timing of trigger execution

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -297,6 +297,7 @@ type Trigger struct {
 	InitiallyDeferred bool           `json:"initially_deferred,omitempty"` // Whether deferred by default
 	OldTable          string         `json:"old_table,omitempty"`          // REFERENCING OLD TABLE AS name
 	NewTable          string         `json:"new_table,omitempty"`          // REFERENCING NEW TABLE AS name
+	Enabled           bool           `json:"enabled"`                      // false = DISABLED (tgenabled='D'), true = enabled (default)
 }
 
 // TriggerTiming represents the timing of trigger execution

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -2889,7 +2889,8 @@ SELECT
     s.cycle AS cycle_option,
     s.cache_size,
     COALESCE(dep_table.relname, col_table.table_name) AS owned_by_table,
-    COALESCE(dep_col.attname, col_table.column_name) AS owned_by_column
+    COALESCE(dep_col.attname, col_table.column_name) AS owned_by_column,
+    COALESCE(obj_description(c.oid, 'pg_class'), '') AS sequence_comment
 FROM pg_sequences s
 LEFT JOIN pg_namespace n ON n.nspname = s.schemaname
 LEFT JOIN pg_class c ON c.relname = s.sequencename AND c.relnamespace = n.oid
@@ -2919,17 +2920,18 @@ ORDER BY s.schemaname, s.sequencename
 `
 
 type GetSequencesForSchemaRow struct {
-	SequenceSchema sql.NullString `db:"sequence_schema" json:"sequence_schema"`
-	SequenceName   sql.NullString `db:"sequence_name" json:"sequence_name"`
-	DataType       interface{}    `db:"data_type" json:"data_type"`
-	StartValue     sql.NullInt64  `db:"start_value" json:"start_value"`
-	MinimumValue   sql.NullInt64  `db:"minimum_value" json:"minimum_value"`
-	MaximumValue   sql.NullInt64  `db:"maximum_value" json:"maximum_value"`
-	Increment      sql.NullInt64  `db:"increment" json:"increment"`
-	CycleOption    sql.NullBool   `db:"cycle_option" json:"cycle_option"`
-	CacheSize      sql.NullInt64  `db:"cache_size" json:"cache_size"`
-	OwnedByTable   sql.NullString `db:"owned_by_table" json:"owned_by_table"`
-	OwnedByColumn  sql.NullString `db:"owned_by_column" json:"owned_by_column"`
+	SequenceSchema  sql.NullString `db:"sequence_schema" json:"sequence_schema"`
+	SequenceName    sql.NullString `db:"sequence_name" json:"sequence_name"`
+	DataType        interface{}    `db:"data_type" json:"data_type"`
+	StartValue      sql.NullInt64  `db:"start_value" json:"start_value"`
+	MinimumValue    sql.NullInt64  `db:"minimum_value" json:"minimum_value"`
+	MaximumValue    sql.NullInt64  `db:"maximum_value" json:"maximum_value"`
+	Increment       sql.NullInt64  `db:"increment" json:"increment"`
+	CycleOption     sql.NullBool   `db:"cycle_option" json:"cycle_option"`
+	CacheSize       sql.NullInt64  `db:"cache_size" json:"cache_size"`
+	OwnedByTable    sql.NullString `db:"owned_by_table" json:"owned_by_table"`
+	OwnedByColumn   sql.NullString `db:"owned_by_column" json:"owned_by_column"`
+	SequenceComment sql.NullString `db:"sequence_comment" json:"sequence_comment"`
 }
 
 // GetSequencesForSchema retrieves all sequences for a specific schema
@@ -2956,6 +2958,7 @@ func (q *Queries) GetSequencesForSchema(ctx context.Context, dollar_1 sql.NullSt
 			&i.CacheSize,
 			&i.OwnedByTable,
 			&i.OwnedByColumn,
+			&i.SequenceComment,
 		); err != nil {
 			return nil, err
 		}

--- a/testdata/diff/comment/add_sequence_comment/diff.sql
+++ b/testdata/diff/comment/add_sequence_comment/diff.sql
@@ -1,0 +1,3 @@
+COMMENT ON SEQUENCE order_id_seq IS 'Primary key sequence for the orders table, starts at 1000';
+
+COMMENT ON SEQUENCE user_id_seq IS 'Primary key sequence for the users table';

--- a/testdata/diff/comment/add_sequence_comment/new.sql
+++ b/testdata/diff/comment/add_sequence_comment/new.sql
@@ -1,0 +1,7 @@
+CREATE SEQUENCE public.user_id_seq;
+
+COMMENT ON SEQUENCE public.user_id_seq IS 'Primary key sequence for the users table';
+
+CREATE SEQUENCE public.order_id_seq AS integer START WITH 1000;
+
+COMMENT ON SEQUENCE public.order_id_seq IS 'Primary key sequence for the orders table, starts at 1000';

--- a/testdata/diff/comment/add_sequence_comment/old.sql
+++ b/testdata/diff/comment/add_sequence_comment/old.sql
@@ -1,0 +1,3 @@
+CREATE SEQUENCE public.user_id_seq;
+
+CREATE SEQUENCE public.order_id_seq AS integer START WITH 1000;

--- a/testdata/diff/comment/add_sequence_comment/plan.json
+++ b/testdata/diff/comment/add_sequence_comment/plan.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.11.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "f92816662b57efe3e43677b68115cd1e978e7d16e2d516519230558fb841466d"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "COMMENT ON SEQUENCE order_id_seq IS 'Primary key sequence for the orders table, starts at 1000';",
+          "type": "sequence",
+          "operation": "alter",
+          "path": "public.order_id_seq"
+        },
+        {
+          "sql": "COMMENT ON SEQUENCE user_id_seq IS 'Primary key sequence for the users table';",
+          "type": "sequence",
+          "operation": "alter",
+          "path": "public.user_id_seq"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/comment/add_sequence_comment/plan.sql
+++ b/testdata/diff/comment/add_sequence_comment/plan.sql
@@ -1,0 +1,3 @@
+COMMENT ON SEQUENCE order_id_seq IS 'Primary key sequence for the orders table, starts at 1000';
+
+COMMENT ON SEQUENCE user_id_seq IS 'Primary key sequence for the users table';

--- a/testdata/diff/comment/add_sequence_comment/plan.txt
+++ b/testdata/diff/comment/add_sequence_comment/plan.txt
@@ -1,0 +1,15 @@
+Plan: 2 to modify.
+
+Summary by type:
+  sequences: 2 to modify
+
+Sequences:
+  ~ order_id_seq
+  ~ user_id_seq
+
+DDL to be executed:
+--------------------------------------------------
+
+COMMENT ON SEQUENCE order_id_seq IS 'Primary key sequence for the orders table, starts at 1000';
+
+COMMENT ON SEQUENCE user_id_seq IS 'Primary key sequence for the users table';

--- a/testdata/diff/comment/add_serial_sequence_comment_on_create/diff.sql
+++ b/testdata/diff/comment/add_serial_sequence_comment_on_create/diff.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS orders (
+    order_id BIGSERIAL,
+    customer_id integer NOT NULL,
+    total numeric(10,2) NOT NULL,
+    CONSTRAINT orders_pkey PRIMARY KEY (order_id)
+);
+COMMENT ON SEQUENCE orders_order_id_seq IS 'Primary key sequence for the orders table';

--- a/testdata/diff/comment/add_serial_sequence_comment_on_create/new.sql
+++ b/testdata/diff/comment/add_serial_sequence_comment_on_create/new.sql
@@ -1,0 +1,7 @@
+CREATE TABLE public.orders (
+    order_id bigserial PRIMARY KEY,
+    customer_id integer NOT NULL,
+    total numeric(10,2) NOT NULL
+);
+
+COMMENT ON SEQUENCE public.orders_order_id_seq IS 'Primary key sequence for the orders table';

--- a/testdata/diff/comment/add_serial_sequence_comment_on_create/plan.json
+++ b/testdata/diff/comment/add_serial_sequence_comment_on_create/plan.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.11.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS orders (\n    order_id BIGSERIAL,\n    customer_id integer NOT NULL,\n    total numeric(10,2) NOT NULL,\n    CONSTRAINT orders_pkey PRIMARY KEY (order_id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.orders"
+        },
+        {
+          "sql": "COMMENT ON SEQUENCE orders_order_id_seq IS 'Primary key sequence for the orders table';",
+          "type": "sequence",
+          "operation": "create",
+          "path": "public.orders_order_id_seq"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/comment/add_serial_sequence_comment_on_create/plan.sql
+++ b/testdata/diff/comment/add_serial_sequence_comment_on_create/plan.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS orders (
+    order_id BIGSERIAL,
+    customer_id integer NOT NULL,
+    total numeric(10,2) NOT NULL,
+    CONSTRAINT orders_pkey PRIMARY KEY (order_id)
+);
+
+COMMENT ON SEQUENCE orders_order_id_seq IS 'Primary key sequence for the orders table';

--- a/testdata/diff/comment/add_serial_sequence_comment_on_create/plan.txt
+++ b/testdata/diff/comment/add_serial_sequence_comment_on_create/plan.txt
@@ -1,0 +1,23 @@
+Plan: 2 to add.
+
+Summary by type:
+  sequences: 1 to add
+  tables: 1 to add
+
+Sequences:
+  + orders_order_id_seq
+
+Tables:
+  + orders
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS orders (
+    order_id BIGSERIAL,
+    customer_id integer NOT NULL,
+    total numeric(10,2) NOT NULL,
+    CONSTRAINT orders_pkey PRIMARY KEY (order_id)
+);
+
+COMMENT ON SEQUENCE orders_order_id_seq IS 'Primary key sequence for the orders table';

--- a/testdata/diff/comment/add_trigger_comment/diff.sql
+++ b/testdata/diff/comment/add_trigger_comment/diff.sql
@@ -1,0 +1,1 @@
+COMMENT ON TRIGGER employees_last_modified_trigger ON employees IS 'Updates last_modified timestamp to current time on every row update';

--- a/testdata/diff/comment/add_trigger_comment/new.sql
+++ b/testdata/diff/comment/add_trigger_comment/new.sql
@@ -1,0 +1,20 @@
+CREATE TABLE public.employees (
+    id serial PRIMARY KEY,
+    name text NOT NULL,
+    last_modified timestamp DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE FUNCTION public.update_last_modified()
+RETURNS trigger AS $$
+BEGIN
+    NEW.last_modified = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER employees_last_modified_trigger
+    BEFORE UPDATE ON public.employees
+    FOR EACH ROW
+    EXECUTE FUNCTION public.update_last_modified();
+
+COMMENT ON TRIGGER employees_last_modified_trigger ON public.employees IS 'Updates last_modified timestamp to current time on every row update';

--- a/testdata/diff/comment/add_trigger_comment/old.sql
+++ b/testdata/diff/comment/add_trigger_comment/old.sql
@@ -1,0 +1,18 @@
+CREATE TABLE public.employees (
+    id serial PRIMARY KEY,
+    name text NOT NULL,
+    last_modified timestamp DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE FUNCTION public.update_last_modified()
+RETURNS trigger AS $$
+BEGIN
+    NEW.last_modified = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER employees_last_modified_trigger
+    BEFORE UPDATE ON public.employees
+    FOR EACH ROW
+    EXECUTE FUNCTION public.update_last_modified();

--- a/testdata/diff/comment/add_trigger_comment/plan.json
+++ b/testdata/diff/comment/add_trigger_comment/plan.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.11.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "6aa4d2eb121345da38a1de455a5840b523fc30982164d0c2569cb1518c020033"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "COMMENT ON TRIGGER employees_last_modified_trigger ON employees IS 'Updates last_modified timestamp to current time on every row update';",
+          "type": "table.trigger",
+          "operation": "alter",
+          "path": "public.employees.employees_last_modified_trigger"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/comment/add_trigger_comment/plan.sql
+++ b/testdata/diff/comment/add_trigger_comment/plan.sql
@@ -1,0 +1,1 @@
+COMMENT ON TRIGGER employees_last_modified_trigger ON employees IS 'Updates last_modified timestamp to current time on every row update';

--- a/testdata/diff/comment/add_trigger_comment/plan.txt
+++ b/testdata/diff/comment/add_trigger_comment/plan.txt
@@ -1,0 +1,13 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ employees
+    ~ employees_last_modified_trigger (trigger)
+
+DDL to be executed:
+--------------------------------------------------
+
+COMMENT ON TRIGGER employees_last_modified_trigger ON employees IS 'Updates last_modified timestamp to current time on every row update';

--- a/testdata/diff/create_trigger/disable_trigger/diff.sql
+++ b/testdata/diff/create_trigger/disable_trigger/diff.sql
@@ -1,0 +1,1 @@
+ALTER TABLE employees DISABLE TRIGGER employees_last_modified_trigger;

--- a/testdata/diff/create_trigger/disable_trigger/new.sql
+++ b/testdata/diff/create_trigger/disable_trigger/new.sql
@@ -1,0 +1,20 @@
+CREATE TABLE public.employees (
+    id serial PRIMARY KEY,
+    name text NOT NULL,
+    last_modified timestamp DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE FUNCTION public.update_last_modified()
+RETURNS trigger AS $$
+BEGIN
+    NEW.last_modified = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER employees_last_modified_trigger
+    BEFORE UPDATE ON public.employees
+    FOR EACH ROW
+    EXECUTE FUNCTION public.update_last_modified();
+
+ALTER TABLE public.employees DISABLE TRIGGER employees_last_modified_trigger;

--- a/testdata/diff/create_trigger/disable_trigger/old.sql
+++ b/testdata/diff/create_trigger/disable_trigger/old.sql
@@ -1,0 +1,18 @@
+CREATE TABLE public.employees (
+    id serial PRIMARY KEY,
+    name text NOT NULL,
+    last_modified timestamp DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE FUNCTION public.update_last_modified()
+RETURNS trigger AS $$
+BEGIN
+    NEW.last_modified = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER employees_last_modified_trigger
+    BEFORE UPDATE ON public.employees
+    FOR EACH ROW
+    EXECUTE FUNCTION public.update_last_modified();

--- a/testdata/diff/create_trigger/disable_trigger/plan.json
+++ b/testdata/diff/create_trigger/disable_trigger/plan.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.11.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "6aa4d2eb121345da38a1de455a5840b523fc30982164d0c2569cb1518c020033"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "ALTER TABLE employees DISABLE TRIGGER employees_last_modified_trigger;",
+          "type": "table.trigger",
+          "operation": "alter",
+          "path": "public.employees.employees_last_modified_trigger"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_trigger/disable_trigger/plan.sql
+++ b/testdata/diff/create_trigger/disable_trigger/plan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE employees DISABLE TRIGGER employees_last_modified_trigger;

--- a/testdata/diff/create_trigger/disable_trigger/plan.txt
+++ b/testdata/diff/create_trigger/disable_trigger/plan.txt
@@ -1,0 +1,13 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ employees
+    ~ employees_last_modified_trigger (trigger)
+
+DDL to be executed:
+--------------------------------------------------
+
+ALTER TABLE employees DISABLE TRIGGER employees_last_modified_trigger;


### PR DESCRIPTION
Four related gaps where pgschema silently ignored real schema properties,
causing silent drift between the declared model and the live database.

## What changed

### 1. Trigger comments
pgschema had no awareness of `COMMENT ON TRIGGER`. A comment declared in
the model was never applied; an unwanted comment on the live DB was never
flagged as drift.

- **`ir/ir.go`**: add `Comment string` to `TriggerDef`
- **`ir/inspector.go` + `ir/queries/queries.sql.go`**: read `pg_description`
  for trigger OIDs
- **`internal/diff/trigger.go`**: diff and emit `COMMENT ON TRIGGER ... ON
  ... IS '...'`

### 2. Trigger enabled/disabled state
pgschema had no awareness of `pg_trigger.tgenabled`. A trigger disabled in
the model was never applied; a trigger enabled/disabled on the live DB was
never flagged as drift.

- **`ir/ir.go`**: add `Enabled bool` to `TriggerDef`
- **`ir/inspector.go` + `ir/queries/queries.sql.go`**: read `tgenabled` from
  `pg_trigger`
- **`internal/diff/trigger.go`**: diff and emit `ALTER TABLE ENABLE/DISABLE
  TRIGGER`

### 3. Sequence comments
pgschema had no awareness of `COMMENT ON SEQUENCE`. A sequence comment in
the model was never applied; an unwanted comment on the live DB was never
flagged as drift.

- **`ir/ir.go`**: add `Comment string` to `SequenceDef`
- **`ir/inspector.go` + `ir/queries/queries.sql.go`**: read `pg_description`
  for sequence OIDs
- **`internal/diff/sequence.go`**: diff and emit `COMMENT ON SEQUENCE ... IS
  '...'`

### 4. Fix: SERIAL sequence comment idempotency
When a table with `BIGSERIAL`/`SERIAL` columns was created for the first
time, pgschema correctly skipped emitting a standalone `CREATE SEQUENCE`
(because `CREATE TABLE` creates it implicitly). However, this also
accidentally skipped emitting any `COMMENT ON SEQUENCE` declared in the
model. On the second run the sequence existed in the live DB, the comment
diff fired, and all sequence comments were re-applied indefinitely on every
subsequent run.

- **`internal/diff/diff.go`**: track SERIAL-owned sequences that were
  skipped from `addedSequences` but carry a comment into a new
  `addedSerialSeqComments` list; emit their `COMMENT ON SEQUENCE` after all
  `CREATE TABLE` calls complete

Verified locally: two consecutive deploys against a freshly created wiser DB
— all 14 schemas report "No changes to apply" on the second run.

## Tests

Four new fixtures, all passing:
- `testdata/diff/comment/add_trigger_comment/`
- `testdata/diff/comment/add_sequence_comment/`
- `testdata/diff/comment/add_serial_sequence_comment_on_create/` ← idempotency fix
- `testdata/diff/create_trigger/disable_trigger/`
