### PR TITLE
fix: detect comment/state-only drift on view triggers (#479 followup)

### DIFF
--- a/internal/diff/view.go
+++ b/internal/diff/view.go
@@ -414,53 +414,60 @@ func generateModifyViewsSQL(diffs []*viewDiff, targetSchema string, collector *d
 			generateCreateViewTriggersSQL(diff.AddedTriggers, targetSchema, collector)
 		}
 		for _, triggerDiff := range diff.ModifiedTriggers {
-			if triggerDiff.New.IsConstraint {
-				viewName := getTableNameWithSchema(diff.New.Schema, diff.New.Name, targetSchema)
-				dropSQL := fmt.Sprintf("DROP TRIGGER IF EXISTS %s ON %s;", ir.QuoteIdentifier(triggerDiff.Old.Name), viewName)
-				dropContext := &diffContext{
-					Type:                DiffTypeViewTrigger,
-					Operation:           DiffOperationDrop,
-					Path:                fmt.Sprintf("%s.%s.%s", diff.New.Schema, diff.New.Name, triggerDiff.Old.Name),
-					Source:              triggerDiff.Old,
-					CanRunInTransaction: true,
-				}
-				collector.collect(dropContext, dropSQL)
+			// Only recreate the trigger when its definition actually changed.
+			// Comment-only or enabled/disabled-only drift is applied via the
+			// dedicated statements below without recreating the trigger
+			// (matching the table-trigger path in table.go).
+			structurallyEqual := triggersEqual(triggerDiff.Old, triggerDiff.New)
+			commentChanged := triggerDiff.Old.Comment != triggerDiff.New.Comment
+			enabledChanged := triggerDiff.Old.Disabled != triggerDiff.New.Disabled
 
-				createSQL := generateTriggerSQLWithMode(triggerDiff.New, targetSchema)
-				createContext := &diffContext{
-					Type:                DiffTypeViewTrigger,
-					Operation:           DiffOperationCreate,
-					Path:                fmt.Sprintf("%s.%s.%s", diff.New.Schema, diff.New.Name, triggerDiff.New.Name),
-					Source:              triggerDiff.New,
-					CanRunInTransaction: true,
+			if !structurallyEqual {
+				if triggerDiff.New.IsConstraint {
+					// Constraint triggers don't support CREATE OR REPLACE, so DROP and CREATE
+					viewName := getTableNameWithSchema(diff.New.Schema, diff.New.Name, targetSchema)
+					dropSQL := fmt.Sprintf("DROP TRIGGER IF EXISTS %s ON %s;", ir.QuoteIdentifier(triggerDiff.Old.Name), viewName)
+					dropContext := &diffContext{
+						Type:                DiffTypeViewTrigger,
+						Operation:           DiffOperationDrop,
+						Path:                fmt.Sprintf("%s.%s.%s", diff.New.Schema, diff.New.Name, triggerDiff.Old.Name),
+						Source:              triggerDiff.Old,
+						CanRunInTransaction: true,
+					}
+					collector.collect(dropContext, dropSQL)
+
+					createSQL := generateTriggerSQLWithMode(triggerDiff.New, targetSchema)
+					createContext := &diffContext{
+						Type:                DiffTypeViewTrigger,
+						Operation:           DiffOperationCreate,
+						Path:                fmt.Sprintf("%s.%s.%s", diff.New.Schema, diff.New.Name, triggerDiff.New.Name),
+						Source:              triggerDiff.New,
+						CanRunInTransaction: true,
+					}
+					collector.collect(createContext, createSQL)
+				} else {
+					sql := generateTriggerSQLWithMode(triggerDiff.New, targetSchema)
+					context := &diffContext{
+						Type:                DiffTypeViewTrigger,
+						Operation:           DiffOperationAlter,
+						Path:                fmt.Sprintf("%s.%s.%s", diff.New.Schema, diff.New.Name, triggerDiff.New.Name),
+						Source:              triggerDiff.New,
+						CanRunInTransaction: true,
+					}
+					collector.collect(context, sql)
 				}
-				collector.collect(createContext, createSQL)
-				commentChanged := triggerDiff.Old.Comment != triggerDiff.New.Comment
-				enabledChanged := triggerDiff.Old.Disabled != triggerDiff.New.Disabled
-				if commentChanged || triggerDiff.New.Comment != "" {
-					generateTriggerComment(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, DiffTypeViewTrigger, collector)
-				}
-				if enabledChanged || triggerDiff.New.Disabled {
-					generateTriggerEnabledState(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, DiffTypeViewTrigger, collector)
-				}
-			} else {
-				sql := generateTriggerSQLWithMode(triggerDiff.New, targetSchema)
-				context := &diffContext{
-					Type:                DiffTypeViewTrigger,
-					Operation:           DiffOperationAlter,
-					Path:                fmt.Sprintf("%s.%s.%s", diff.New.Schema, diff.New.Name, triggerDiff.New.Name),
-					Source:              triggerDiff.New,
-					CanRunInTransaction: true,
-				}
-				collector.collect(context, sql)
-				commentChanged := triggerDiff.Old.Comment != triggerDiff.New.Comment
-				enabledChanged := triggerDiff.Old.Disabled != triggerDiff.New.Disabled
-				if commentChanged || triggerDiff.New.Comment != "" {
-					generateTriggerComment(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, DiffTypeViewTrigger, collector)
-				}
-				if enabledChanged || triggerDiff.New.Disabled {
-					generateTriggerEnabledState(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, DiffTypeViewTrigger, collector)
-				}
+			}
+
+			// Emit COMMENT ON TRIGGER for comment changes (including after a
+			// constraint-trigger DROP+CREATE, which drops the existing comment).
+			if commentChanged || (!structurallyEqual && triggerDiff.New.Comment != "") {
+				generateTriggerComment(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, DiffTypeViewTrigger, collector)
+			}
+			// Emit ENABLE/DISABLE for enabled-state changes. Note PostgreSQL does
+			// not allow disabling triggers on views, so this is effectively a
+			// no-op for view triggers, but kept symmetric with the table path.
+			if enabledChanged || (!structurallyEqual && triggerDiff.New.Disabled) {
+				generateTriggerEnabledState(triggerDiff.New, diff.New.Schema, diff.New.Name, targetSchema, DiffTypeViewTrigger, collector)
 			}
 		}
 	}
@@ -705,7 +712,13 @@ func diffViewTriggers(oldView, newView *ir.View) ([]*ir.Trigger, []*ir.Trigger, 
 	}
 	for name, newTrigger := range newTriggers {
 		if oldTrigger, exists := oldTriggers[name]; exists {
-			if !triggersEqual(oldTrigger, newTrigger) {
+			// triggersEqual covers structural equality only; comment and
+			// enabled/disabled state are tracked separately so that comment-only
+			// or state-only drift is still reported as a modification (matching
+			// the table-trigger path in table.go).
+			commentChanged := oldTrigger.Comment != newTrigger.Comment
+			enabledChanged := oldTrigger.Disabled != newTrigger.Disabled
+			if !triggersEqual(oldTrigger, newTrigger) || commentChanged || enabledChanged {
 				modified = append(modified, &triggerDiff{
 					Old: oldTrigger,
 					New: newTrigger,

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -1731,7 +1731,9 @@ func (i *Inspector) buildTriggers(ctx context.Context, schema *IR, targetSchema 
 			comment = triggerRow.TriggerComment.String
 		}
 
-		// Extract disabled state: tgenabled 'D' = disabled, anything else = enabled (Postgres default)
+		// Extract disabled state: tgenabled 'D' = disabled, anything else = enabled (Postgres default).
+		// pg_trigger.tgenabled can also be 'R' (replica) or 'A' (always); pgschema's model only
+		// expresses enabled vs disabled, so those session-replication modes are treated as enabled.
 		disabled := false
 		switch v := triggerRow.TriggerEnabled.(type) {
 		case string:

--- a/testdata/diff/comment/add_trigger_comment/diff.sql
+++ b/testdata/diff/comment/add_trigger_comment/diff.sql
@@ -1,1 +1,3 @@
 COMMENT ON TRIGGER employees_last_modified_trigger ON employees IS 'Updates last_modified timestamp to current time on every row update';
+
+COMMENT ON TRIGGER trg_employee_emails_insert ON employee_emails IS 'Handles inserts into the employee_emails view';

--- a/testdata/diff/comment/add_trigger_comment/new.sql
+++ b/testdata/diff/comment/add_trigger_comment/new.sql
@@ -18,3 +18,24 @@ CREATE TRIGGER employees_last_modified_trigger
     EXECUTE FUNCTION public.update_last_modified();
 
 COMMENT ON TRIGGER employees_last_modified_trigger ON public.employees IS 'Updates last_modified timestamp to current time on every row update';
+
+CREATE VIEW public.employee_emails AS
+SELECT id, name
+FROM public.employees;
+
+CREATE OR REPLACE FUNCTION public.insert_employee_emails()
+RETURNS trigger AS $$
+BEGIN
+    INSERT INTO public.employees (name)
+    VALUES (NEW.name)
+    RETURNING id, name INTO NEW.id, NEW.name;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_employee_emails_insert
+    INSTEAD OF INSERT ON public.employee_emails
+    FOR EACH ROW
+    EXECUTE FUNCTION public.insert_employee_emails();
+
+COMMENT ON TRIGGER trg_employee_emails_insert ON public.employee_emails IS 'Handles inserts into the employee_emails view';

--- a/testdata/diff/comment/add_trigger_comment/old.sql
+++ b/testdata/diff/comment/add_trigger_comment/old.sql
@@ -16,3 +16,22 @@ CREATE TRIGGER employees_last_modified_trigger
     BEFORE UPDATE ON public.employees
     FOR EACH ROW
     EXECUTE FUNCTION public.update_last_modified();
+
+CREATE VIEW public.employee_emails AS
+SELECT id, name
+FROM public.employees;
+
+CREATE OR REPLACE FUNCTION public.insert_employee_emails()
+RETURNS trigger AS $$
+BEGIN
+    INSERT INTO public.employees (name)
+    VALUES (NEW.name)
+    RETURNING id, name INTO NEW.id, NEW.name;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_employee_emails_insert
+    INSTEAD OF INSERT ON public.employee_emails
+    FOR EACH ROW
+    EXECUTE FUNCTION public.insert_employee_emails();

--- a/testdata/diff/comment/add_trigger_comment/plan.json
+++ b/testdata/diff/comment/add_trigger_comment/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.11.0",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "6aa4d2eb121345da38a1de455a5840b523fc30982164d0c2569cb1518c020033"
+    "hash": "1d98e78c9d27a3514143a85ca1c70dbb812e6e3b1c8c7f0f02b42c06406ada8c"
   },
   "groups": [
     {
@@ -13,6 +13,12 @@
           "type": "table.trigger",
           "operation": "alter",
           "path": "public.employees.employees_last_modified_trigger"
+        },
+        {
+          "sql": "COMMENT ON TRIGGER trg_employee_emails_insert ON employee_emails IS 'Handles inserts into the employee_emails view';",
+          "type": "view.trigger",
+          "operation": "alter",
+          "path": "public.employee_emails.trg_employee_emails_insert"
         }
       ]
     }

--- a/testdata/diff/comment/add_trigger_comment/plan.sql
+++ b/testdata/diff/comment/add_trigger_comment/plan.sql
@@ -1,1 +1,3 @@
 COMMENT ON TRIGGER employees_last_modified_trigger ON employees IS 'Updates last_modified timestamp to current time on every row update';
+
+COMMENT ON TRIGGER trg_employee_emails_insert ON employee_emails IS 'Handles inserts into the employee_emails view';

--- a/testdata/diff/comment/add_trigger_comment/plan.txt
+++ b/testdata/diff/comment/add_trigger_comment/plan.txt
@@ -1,13 +1,20 @@
-Plan: 1 to modify.
+Plan: 2 to modify.
 
 Summary by type:
   tables: 1 to modify
+  views: 1 to modify
 
 Tables:
   ~ employees
     ~ employees_last_modified_trigger (trigger)
 
+Views:
+  ~ employee_emails
+    ~ trg_employee_emails_insert (trigger)
+
 DDL to be executed:
 --------------------------------------------------
 
 COMMENT ON TRIGGER employees_last_modified_trigger ON employees IS 'Updates last_modified timestamp to current time on every row update';
+
+COMMENT ON TRIGGER trg_employee_emails_insert ON employee_emails IS 'Handles inserts into the employee_emails view';


### PR DESCRIPTION
Followup to #479, addressing the Copilot review on the merged PR.

## Problem

`generateModifyViewsSQL` emits `COMMENT ON TRIGGER` / `ENABLE`/`DISABLE` for view triggers, but `diffViewTriggers` only added a trigger to `ModifiedTriggers` when its **structural** definition changed (`!triggersEqual(...)`). `triggersEqual` does not compare `Comment` or `Disabled`, so a view (`INSTEAD OF`) trigger whose only change was its comment was never flagged as modified — the new emission blocks never ran and the drift was **silently ignored**.

The table-trigger path (`table.go`) already accounted for comment/state changes at detection time; the view path was never updated to match.

## Changes

- **`internal/diff/view.go`**
  - `diffViewTriggers`: also flag comment-only / state-only changes as modified.
  - `generateModifyViewsSQL`: only recreate the trigger when it's *structurally* changed; emit `COMMENT`/state statements independently (mirrors `table.go`). A comment-only change now emits just the `COMMENT ON TRIGGER`, instead of a needless `CREATE OR REPLACE TRIGGER`.
- **`ir/inspector.go`**: document that `pg_trigger.tgenabled` `'R'` (replica) / `'A'` (always) modes are treated as enabled, since pgschema's model only expresses enabled vs disabled. *(Copilot comment 2 — known limitation, not expanding scope here.)*
- **`testdata/diff/comment/add_trigger_comment/`**: extended to also cover an `INSTEAD OF` view trigger, so this canonical trigger-comment fixture now exercises both the table path and the view path (the drift detection fixed here) — no separate fixture needed.

## Notes

- PostgreSQL does not allow `DISABLE TRIGGER` on views, so the enabled-state path is effectively a no-op for view triggers but is kept symmetric with the table path.
- Copilot comment 3 (PR description said `Enabled bool` while code used `Disabled bool`) referred to #479's now-merged description. The `Disabled bool` + `omitempty` choice was intentional (zero value = enabled = Postgres default).

## Tests

- `comment/` and `create_trigger/` suites pass — both `TestDiffFromFiles` (diff) and `TestPlanAndApply` (integration), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)