### PR TITLE
docs: document index storage params, trigger comment/state, sequence comments

### DIFF
--- a/docs/syntax/comment_on.mdx
+++ b/docs/syntax/comment_on.mdx
@@ -8,13 +8,14 @@ title: "COMMENT ON"
 comment_on ::= COMMENT ON object_type object_name IS 'comment_text'
              | COMMENT ON object_type object_name IS NULL
 
-object_type ::= AGGREGATE | COLUMN | FUNCTION | INDEX | MATERIALIZED VIEW | PROCEDURE | TABLE | VIEW
+object_type ::= AGGREGATE | COLUMN | FUNCTION | INDEX | MATERIALIZED VIEW | PROCEDURE | SEQUENCE | TABLE | TRIGGER | VIEW
 
 object_name ::= [schema.]name
               | [schema.]table_name.column_name                -- for columns
               | [schema.]function_name(argument_types)         -- for functions
               | [schema.]procedure_name(argument_types)        -- for procedures
               | [schema.]aggregate_name(argument_types)        -- for aggregates
+              | trigger_name ON [schema.]table_name            -- for triggers
 ```
 
 `COMMENT ON` is supported for the following objects:
@@ -25,5 +26,7 @@ object_name ::= [schema.]name
 - Index
 - Materialized View
 - Procedure
+- Sequence
 - Table
+- Trigger
 - View

--- a/docs/syntax/create_index.mdx
+++ b/docs/syntax/create_index.mdx
@@ -8,6 +8,7 @@ title: "CREATE INDEX"
 create_index ::= CREATE [ UNIQUE ] INDEX [ CONCURRENTLY ] [ IF NOT EXISTS ] index_name
                  ON table_name [ USING method ]
                  ( index_element [, ...] )
+                 [ WITH ( storage_parameter [= value] [, ...] ) ]
                  [ WHERE condition ]
 
 index_name ::= name
@@ -15,6 +16,8 @@ index_name ::= name
 table_name ::= [schema.]name
 
 method ::= btree | hash | gist | spgist | gin | brin
+
+storage_parameter ::= name
 
 index_element ::= column_name [ direction ] [ operator_class ]
                 | ( expression ) [ direction ] [ operator_class ]
@@ -39,6 +42,7 @@ pgschema understands the following `CREATE INDEX` features:
 - **Sort direction**: ASC (default) or DESC for each column
 - **Operator classes**: Custom operator classes for specialized indexing
 - **Partial indexes**: WHERE clause for indexing subset of rows
+- **Storage parameters**: WITH clause for index storage parameters (reloptions), e.g. `WITH (fillfactor=90, deduplicate_items=true)`
 - **Schema qualification**: Indexes can be created in specific schemas
 
 ## Canonical Format
@@ -50,7 +54,7 @@ CREATE [UNIQUE] INDEX [CONCURRENTLY] IF NOT EXISTS index_name
 ON [schema.]table_name [USING method] (
     column_or_expression[ direction][,
     ...]
-)[ WHERE condition];
+)[ WITH (storage_parameter=value[, ...])][ WHERE condition];
 ```
 
 **Key characteristics of the canonical format:**
@@ -61,6 +65,7 @@ ON [schema.]table_name [USING method] (
 - Only includes `USING method` when not btree (the default)
 - Only includes direction when not ASC (the default)
 - JSON expressions are wrapped in double parentheses: `((data->>'key'))`
+- Storage parameters are included in a `WITH (...)` clause, placed before the `WHERE` clause
 - Partial index WHERE clause is included when present
 - For DROP operations: `DROP INDEX IF EXISTS [schema.]index_name;`
 

--- a/docs/syntax/create_sequence.mdx
+++ b/docs/syntax/create_sequence.mdx
@@ -40,6 +40,7 @@ pgschema understands the following `CREATE SEQUENCE` features:
 - **MAXVALUE/NO MAXVALUE**: Maximum value for the sequence (default: 2^63-1 for bigint)
 - **CYCLE/NO CYCLE**: Whether the sequence should wrap around when reaching min/max values
 - **OWNED BY**: Associates the sequence with a table column for automatic cleanup
+- **Comments**: `COMMENT ON SEQUENCE` is tracked and applied (see [COMMENT ON](/syntax/comment_on))
 
 ## Canonical Format
 

--- a/docs/syntax/create_trigger.mdx
+++ b/docs/syntax/create_trigger.mdx
@@ -49,6 +49,8 @@ pgschema understands the following `CREATE TRIGGER` features:
   - REFERENCING NEW TABLE AS name - captures inserted/new rows for statement-level triggers
 - **Schema-qualified names**: Tables and functions can be in specific schemas
 - **Function execution**: Triggers execute functions that return TRIGGER type
+- **Enabled/disabled state**: A disabled trigger (`ALTER TABLE ... DISABLE TRIGGER`) is tracked and re-applied; re-enabling emits `ALTER TABLE ... ENABLE TRIGGER`. PostgreSQL does not allow disabling triggers on views.
+- **Comments**: `COMMENT ON TRIGGER` is tracked and applied (see [COMMENT ON](/syntax/comment_on))
 
 ## Canonical Format
 
@@ -72,3 +74,5 @@ CREATE OR REPLACE TRIGGER trigger_name
 - Function names include parentheses even when no arguments
 - Schema qualifiers only included when table is in different schema than target
 - For DROP operations: `DROP TRIGGER IF EXISTS trigger_name ON table_name;`
+- For enabled/disabled state changes: `ALTER TABLE table_name { ENABLE | DISABLE } TRIGGER trigger_name;`
+- For comments: `COMMENT ON TRIGGER trigger_name ON table_name IS 'comment_text';` (or `IS NULL` to remove)


### PR DESCRIPTION
The syntax reference under `docs/syntax/` didn't cover features shipped in #478 and #479. This brings it up to date.

## Changes

- **`create_index.mdx`**: document the `WITH ( storage_parameter = value )` clause (index reloptions, e.g. `fillfactor`, `deduplicate_items`), including its placement before `WHERE` in the canonical format. *(#478)*
- **`create_trigger.mdx`**: document enabled/disabled state (`ALTER TABLE ... ENABLE/DISABLE TRIGGER`, noting views can't be disabled) and `COMMENT ON TRIGGER`. *(#479)*
- **`create_sequence.mdx`**: document `COMMENT ON SEQUENCE`. *(#479)*
- **`comment_on.mdx`**: add `SEQUENCE` and `TRIGGER` to the supported object types and the trigger object-name form. *(#479)*

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)