### PR TITLE
fix: converge trigger WHEN expressions with same-schema enum casts (#481)

### DIFF
--- a/cmd/issue_449_integration_test.go
+++ b/cmd/issue_449_integration_test.go
@@ -12,13 +12,17 @@ import (
 // TestIssue449RepeatPlanIdempotency verifies that a plan generated immediately after a
 // successful apply reports no changes (https://github.com/pgplex/pgschema/issues/449).
 //
-// Two distinct drift sources are covered:
+// Three distinct drift sources are covered:
 //  1. CHECK constraints casting to a type in the managed (non-public) schema: the current
 //     state rendered the cast schema-qualified while the desired state stripped the
 //     qualifier, producing a perpetual DROP/ADD/VALIDATE cycle (also issue #445).
 //  2. RLS policy expressions on a table whose name equals the managed schema name: the
 //     same-schema qualifier stripping mistook table-qualified column references
 //     (profiles.id) for schema qualifiers and removed them from the current state only.
+//  3. Trigger WHEN expressions casting to an enum in the managed (non-public) schema:
+//     pg_get_triggerdef rendered the cast schema-qualified (the schema is not on the
+//     default search_path) while the desired state was unqualified, so a repeat plan kept
+//     recreating the trigger (issue #481).
 func TestIssue449RepeatPlanIdempotency(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -88,6 +92,48 @@ func TestIssue449RepeatPlanIdempotency(t *testing.T) {
 			CREATE POLICY "Users can read their own media" ON profile_media
 				FOR SELECT
 				USING (profile_id IN (SELECT id FROM profiles));
+		`)
+		if replan != "" {
+			t.Errorf("Expected no changes on repeat plan after apply, but got:\n%s", replan)
+		}
+	})
+
+	t.Run("trigger_when_same_schema_enum_cast", func(t *testing.T) {
+		replan := applyThenReplan(t, "content", `
+			CREATE TYPE media_provider AS ENUM ('BUNNY_STREAM', 'OTHER');
+			CREATE TYPE media_type AS ENUM ('VIDEO', 'IMAGE');
+
+			CREATE TABLE media_items (
+				id uuid PRIMARY KEY,
+				post_id uuid,
+				provider media_provider NOT NULL,
+				type media_type NOT NULL,
+				provider_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+				storage_info jsonb NOT NULL DEFAULT '{}'::jsonb
+			);
+
+			CREATE FUNCTION update_post_media_flags()
+			RETURNS trigger
+			LANGUAGE plpgsql
+			AS $$
+			BEGIN
+				RETURN COALESCE(NEW, OLD);
+			END;
+			$$;
+
+			CREATE TRIGGER update_post_media_flags_on_bunny_metadata_update
+				AFTER UPDATE OF provider_payload, storage_info ON media_items
+				FOR EACH ROW
+				WHEN (
+					NEW.post_id IS NOT NULL
+					AND NEW.provider = 'BUNNY_STREAM'::media_provider
+					AND NEW.type = 'VIDEO'::media_type
+					AND (
+						OLD.provider_payload IS DISTINCT FROM NEW.provider_payload
+						OR OLD.storage_info IS DISTINCT FROM NEW.storage_info
+					)
+				)
+				EXECUTE FUNCTION update_post_media_flags();
 		`)
 		if replan != "" {
 			t.Errorf("Expected no changes on repeat plan after apply, but got:\n%s", replan)

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -1050,7 +1050,8 @@ SELECT
     s.cycle AS cycle_option,
     s.cache_size,
     COALESCE(dep_table.relname, col_table.table_name) AS owned_by_table,
-    COALESCE(dep_col.attname, col_table.column_name) AS owned_by_column
+    COALESCE(dep_col.attname, col_table.column_name) AS owned_by_column,
+    COALESCE(obj_description(c.oid, 'pg_class'), '') AS sequence_comment
 FROM pg_sequences s
 LEFT JOIN pg_namespace n ON n.nspname = s.schemaname
 LEFT JOIN pg_class c ON c.relname = s.sequencename AND c.relnamespace = n.oid
@@ -1274,6 +1275,16 @@ ORDER BY vd.table_schema, vd.table_name;
 -- GetTriggersForSchema retrieves all triggers for a specific schema
 -- Uses pg_trigger catalog to include all trigger types (including TRUNCATE)
 -- which are not visible in information_schema.triggers
+--
+-- The trigger definition is rendered with a forced search_path so qualification is
+-- deterministic (mirrors GetRLSPoliciesForSchema):
+-- 1. set_config sets search_path to only the trigger's own schema
+-- 2. pg_get_triggerdef then renders same-schema type casts and function references in
+--    the WHEN clause unqualified (e.g. 'VIDEO'::media_type), while cross-schema
+--    references stay qualified. Without this, qualification depends on the session
+--    search_path: in a non-public schema the current state comes back qualified
+--    ('VIDEO'::content.media_type) while the desired state is unqualified, so a repeat
+--    plan keeps recreating the trigger (issue #481).
 -- name: GetTriggersForSchema :many
 SELECT
     n.nspname AS trigger_schema,
@@ -1284,7 +1295,7 @@ SELECT
     t.tgdeferrable AS trigger_deferrable,
     t.tginitdeferred AS trigger_initdeferred,
     t.tgconstraint AS trigger_constraint_oid,
-    COALESCE(pg_catalog.pg_get_triggerdef(t.oid), '') AS trigger_definition,
+    COALESCE(def.trigger_definition, '') AS trigger_definition,
     COALESCE(t.tgoldtable, '') AS old_table,
     COALESCE(t.tgnewtable, '') AS new_table,
     p.proname AS function_name,
@@ -1296,6 +1307,13 @@ JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 JOIN pg_catalog.pg_proc p ON t.tgfoid = p.oid
 JOIN pg_catalog.pg_namespace pn ON p.pronamespace = pn.oid
 LEFT JOIN pg_description d ON d.objoid = t.oid AND d.classoid = 'pg_trigger'::regclass
+LEFT JOIN LATERAL (
+    SELECT
+        -- Set search_path to the trigger's own schema so same-schema references render
+        -- unqualified; the dummy column forces set_config to execute before pg_get_triggerdef.
+        set_config('search_path', quote_ident(n.nspname), true) AS dummy,
+        pg_catalog.pg_get_triggerdef(t.oid) AS trigger_definition
+) def ON true
 WHERE n.nspname = $1
     AND NOT t.tgisinternal  -- Exclude internal triggers
 ORDER BY n.nspname, c.relname, t.tgname;

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -3161,7 +3161,7 @@ SELECT
     t.tgdeferrable AS trigger_deferrable,
     t.tginitdeferred AS trigger_initdeferred,
     t.tgconstraint AS trigger_constraint_oid,
-    COALESCE(pg_catalog.pg_get_triggerdef(t.oid), '') AS trigger_definition,
+    COALESCE(def.trigger_definition, '') AS trigger_definition,
     COALESCE(t.tgoldtable, '') AS old_table,
     COALESCE(t.tgnewtable, '') AS new_table,
     p.proname AS function_name,
@@ -3173,6 +3173,13 @@ JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 JOIN pg_catalog.pg_proc p ON t.tgfoid = p.oid
 JOIN pg_catalog.pg_namespace pn ON p.pronamespace = pn.oid
 LEFT JOIN pg_description d ON d.objoid = t.oid AND d.classoid = 'pg_trigger'::regclass
+LEFT JOIN LATERAL (
+    SELECT
+        -- Set search_path to the trigger's own schema so same-schema references render
+        -- unqualified; the dummy column forces set_config to execute before pg_get_triggerdef.
+        set_config('search_path', quote_ident(n.nspname), true) AS dummy,
+        pg_catalog.pg_get_triggerdef(t.oid) AS trigger_definition
+) def ON true
 WHERE n.nspname = $1
     AND NOT t.tgisinternal  -- Exclude internal triggers
 ORDER BY n.nspname, c.relname, t.tgname
@@ -3198,6 +3205,16 @@ type GetTriggersForSchemaRow struct {
 // GetTriggersForSchema retrieves all triggers for a specific schema
 // Uses pg_trigger catalog to include all trigger types (including TRUNCATE)
 // which are not visible in information_schema.triggers
+//
+// The trigger definition is rendered with a forced search_path so qualification is
+// deterministic (mirrors GetRLSPoliciesForSchema):
+//  1. set_config sets search_path to only the trigger's own schema
+//  2. pg_get_triggerdef then renders same-schema type casts and function references in
+//     the WHEN clause unqualified (e.g. 'VIDEO'::media_type), while cross-schema
+//     references stay qualified. Without this, qualification depends on the session
+//     search_path: in a non-public schema the current state comes back qualified
+//     ('VIDEO'::content.media_type) while the desired state is unqualified, so a repeat
+//     plan keeps recreating the trigger (issue #481).
 func (q *Queries) GetTriggersForSchema(ctx context.Context, dollar_1 sql.NullString) ([]GetTriggersForSchemaRow, error) {
 	rows, err := q.db.QueryContext(ctx, getTriggersForSchema, dollar_1)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #481. A trigger whose `WHEN` expression contains same-schema enum casts caused perpetual repeat-plan drift in a non-public schema: `apply` succeeded, but an immediate repeat `plan` kept wanting to recreate the same trigger.

## Root cause

`GetTriggersForSchema` called `pg_get_triggerdef` **without a forced `search_path`**, so qualification of enum casts and function references in the `WHEN` clause depended on the ambient session search_path:

- **Current state** (target db, schema `content` not on the default search_path) → rendered qualified: `'VIDEO'::content.media_type`, `content.update_post_media_flags()`
- **Desired state** (built under the schema's own search_path) → rendered unqualified: `'VIDEO'::media_type`

The diff comparator does raw string equality on the normalized `WHEN` condition, so the two never matched → perpetual `CREATE OR REPLACE TRIGGER`.

This is the trigger-expression variant of #449 (which fixed the same class for CHECK constraints and RLS policies via a forced search_path).

## Fix

Wrap `pg_get_triggerdef` in a `LATERAL` that forces `search_path` to the trigger's own schema, exactly mirroring `GetRLSPoliciesForSchema`. Same-schema references now render unqualified on both sides while cross-schema references stay qualified. Regenerated `queries.sql.go` via sqlc.

### Incidental fix

Regenerating surfaced that #479 hand-edited the generated `queries.sql.go` to add `sequence_comment` but never updated the source `queries.sql`. Synced the source so `sqlc generate` no longer silently drops sequence-comment support.

## Test

TDD, folded into the existing `TestIssue449RepeatPlanIdempotency` (the purpose-built repeat-plan idempotency test for this bug family, since #481 is a direct follow-up to #449) as a new `trigger_when_same_schema_enum_cast` subtest using the issue's exact reproduction schema. Confirmed it **fails before** the query fix and **passes after**.

## Verification

- New subtest + both existing #449 subtests pass
- `create_trigger` / `create_sequence` diff + integration tests, `TestPlanAndApply`, `TestNonPublicSchemaOperations`, `ir` / `ir/queries` tests, and the full `cmd/dump` suite all green
- `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)