### PR TITLE
fix: dump and diff RLS enabled on partitioned tables (#471)

### DIFF
--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -775,7 +775,7 @@ WHERE
     n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
     AND n.nspname NOT LIKE 'pg_temp_%'
     AND n.nspname NOT LIKE 'pg_toast_temp_%'
-    AND c.relkind = 'r'
+    AND c.relkind IN ('r', 'p')  -- ordinary and partitioned tables (issue #471)
     AND c.relrowsecurity = true
 ORDER BY n.nspname, c.relname;
 
@@ -837,7 +837,7 @@ FROM pg_catalog.pg_class c
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE
     n.nspname = $1
-    AND c.relkind = 'r'
+    AND c.relkind IN ('r', 'p')  -- ordinary and partitioned tables (issue #471)
     AND c.relrowsecurity = true
 ORDER BY n.nspname, c.relname;
 

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -2590,7 +2590,7 @@ WHERE
     n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
     AND n.nspname NOT LIKE 'pg_temp_%'
     AND n.nspname NOT LIKE 'pg_toast_temp_%'
-    AND c.relkind = 'r'
+    AND c.relkind IN ('r', 'p')  -- ordinary and partitioned tables (issue #471)
     AND c.relrowsecurity = true
 ORDER BY n.nspname, c.relname
 `
@@ -2641,7 +2641,7 @@ FROM pg_catalog.pg_class c
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE
     n.nspname = $1
-    AND c.relkind = 'r'
+    AND c.relkind IN ('r', 'p')  -- ordinary and partitioned tables (issue #471)
     AND c.relrowsecurity = true
 ORDER BY n.nspname, c.relname
 `

--- a/testdata/diff/create_policy/enable_rls_partitioned/diff.sql
+++ b/testdata/diff/create_policy/enable_rls_partitioned/diff.sql
@@ -1,0 +1,3 @@
+ALTER TABLE events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY events_org_isolation ON events TO PUBLIC USING (org_id = (NULLIF(current_setting('app.current_org_id', true), ''::text))::uuid);

--- a/testdata/diff/create_policy/enable_rls_partitioned/new.sql
+++ b/testdata/diff/create_policy/enable_rls_partitioned/new.sql
@@ -1,0 +1,14 @@
+CREATE TABLE events (
+    id uuid NOT NULL,
+    org_id uuid NOT NULL,
+    created_at timestamptz NOT NULL,
+    PRIMARY KEY (created_at, id)
+) PARTITION BY RANGE (created_at);
+
+-- RLS is now enabled with a policy on a partitioned table (issue #471)
+ALTER TABLE events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY events_org_isolation ON events
+    FOR ALL
+    TO PUBLIC
+    USING (org_id = NULLIF(current_setting('app.current_org_id', true), '')::uuid);

--- a/testdata/diff/create_policy/enable_rls_partitioned/old.sql
+++ b/testdata/diff/create_policy/enable_rls_partitioned/old.sql
@@ -1,0 +1,8 @@
+CREATE TABLE events (
+    id uuid NOT NULL,
+    org_id uuid NOT NULL,
+    created_at timestamptz NOT NULL,
+    PRIMARY KEY (created_at, id)
+) PARTITION BY RANGE (created_at);
+
+-- RLS is not enabled

--- a/testdata/diff/create_policy/enable_rls_partitioned/plan.json
+++ b/testdata/diff/create_policy/enable_rls_partitioned/plan.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.11.1",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "2432fe99d3b1ab277b6fff72041a7c4400ada76e7e1ef6dbb04874d87dbc6129"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "ALTER TABLE events ENABLE ROW LEVEL SECURITY;",
+          "type": "table.rls",
+          "operation": "create",
+          "path": "public.events"
+        },
+        {
+          "sql": "CREATE POLICY events_org_isolation ON events TO PUBLIC USING (org_id = (NULLIF(current_setting('app.current_org_id', true), ''::text))::uuid);",
+          "type": "table.policy",
+          "operation": "create",
+          "path": "public.events.events_org_isolation"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_policy/enable_rls_partitioned/plan.sql
+++ b/testdata/diff/create_policy/enable_rls_partitioned/plan.sql
@@ -1,0 +1,3 @@
+ALTER TABLE events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY events_org_isolation ON events TO PUBLIC USING (org_id = (NULLIF(current_setting('app.current_org_id', true), ''::text))::uuid);

--- a/testdata/diff/create_policy/enable_rls_partitioned/plan.txt
+++ b/testdata/diff/create_policy/enable_rls_partitioned/plan.txt
@@ -1,0 +1,16 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ events
+    + events_org_isolation (policy)
+    + events (rls)
+
+DDL to be executed:
+--------------------------------------------------
+
+ALTER TABLE events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY events_org_isolation ON events TO PUBLIC USING (org_id = (NULLIF(current_setting('app.current_org_id', true), ''::text))::uuid);


### PR DESCRIPTION
## Summary

Fixes #471. `ENABLE ROW LEVEL SECURITY` on a **partitioned** table (`relkind 'p'`) was neither dumped nor diffed, while policies on the same table *were* dumped — so a database bootstrapped from a dump ended up with all policies present but RLS not enabled, silently leaving the policies unenforced.

## Root cause

`GetRLSTables` and `GetRLSTablesForSchema` (`ir/queries/queries.sql`) filtered on `c.relkind = 'r'`, excluding partitioned tables. `table.RLSEnabled` was therefore never set for `relkind 'p'`, in both current-state and desired-state inspection — which is why `plan` also reported "No changes detected" even after hand-adding the `ENABLE ROW LEVEL SECURITY` statement (both sides of the comparison saw `false`).

The policy queries have no `relkind` filter, which is why policies survived and the gap was silent.

## Fix

Include `relkind 'p'` alongside `'r'` in both RLS queries (`.sql` source + regenerated `.sql.go`).

## Tests

- New regression case `testdata/diff/create_policy/enable_rls_partitioned/` (mirrors the issue repro: partitioned `events` table + org-isolation policy).
- `TestDiffFromFiles` and `TestPlanAndApply` pass for the new case and the full `create_policy/` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)