### PR TITLE
fix: use DROP INDEX IF EXISTS in online index rebuild (#509)

### DIFF
--- a/internal/plan/rewrite.go
+++ b/internal/plan/rewrite.go
@@ -153,8 +153,13 @@ func generateIndexChangeRewriteFromIndex(index *ir.Index) []RewriteStep {
 	concurrentSQL := generateIndexSQL(&tempIndex, true)
 	waitSQL := generateIndexWaitQueryWithName(tempIndexName)
 
-	// Drop old index and rename new one
-	dropSQL := fmt.Sprintf("DROP INDEX %s;", ir.QuoteIdentifier(index.Name))
+	// Drop old index and rename new one. Use IF EXISTS because a same-plan
+	// DROP COLUMN step may already have implicitly dropped this index
+	// (PostgreSQL drops indexes that depend on a dropped column), which
+	// would otherwise make this bare DROP INDEX fail with SQLSTATE 42704.
+	// Mirrors internal/diff/index.go's non-online DROP INDEX IF EXISTS.
+	// See issue #509 / #384.
+	dropSQL := fmt.Sprintf("DROP INDEX IF EXISTS %s;", ir.QuoteIdentifier(index.Name))
 	renameSQL := fmt.Sprintf("ALTER INDEX %s RENAME TO %s;", ir.QuoteIdentifier(tempIndexName), ir.QuoteIdentifier(index.Name))
 
 	return []RewriteStep{
@@ -199,8 +204,13 @@ func generateIndexChangeRewrite(indexDiff *diff.IndexDiff) []RewriteStep {
 	concurrentSQL := generateIndexSQL(&tempIndex, true)
 	waitSQL := generateIndexWaitQueryWithName(tempIndexName)
 
-	// Drop old index and rename new one
-	dropSQL := fmt.Sprintf("DROP INDEX %s;", ir.QuoteIdentifier(indexDiff.Old.Name))
+	// Drop old index and rename new one. Use IF EXISTS because a same-plan
+	// DROP COLUMN step may already have implicitly dropped this index
+	// (PostgreSQL drops indexes that depend on a dropped column), which
+	// would otherwise make this bare DROP INDEX fail with SQLSTATE 42704.
+	// Mirrors internal/diff/index.go's non-online DROP INDEX IF EXISTS.
+	// See issue #509 / #384.
+	dropSQL := fmt.Sprintf("DROP INDEX IF EXISTS %s;", ir.QuoteIdentifier(indexDiff.Old.Name))
 	renameSQL := fmt.Sprintf("ALTER INDEX %s RENAME TO %s;", ir.QuoteIdentifier(tempIndexName), ir.QuoteIdentifier(indexDiff.New.Name))
 
 	return []RewriteStep{

--- a/testdata/diff/online/alter_composite_index/plan.json
+++ b/testdata/diff/online/alter_composite_index/plan.json
@@ -33,7 +33,7 @@
     {
       "steps": [
         {
-          "sql": "DROP INDEX idx_users_email;",
+          "sql": "DROP INDEX IF EXISTS idx_users_email;",
           "type": "table.index",
           "operation": "alter",
           "path": "public.users.idx_users_email"
@@ -73,7 +73,7 @@
     {
       "steps": [
         {
-          "sql": "DROP INDEX idx_users_status;",
+          "sql": "DROP INDEX IF EXISTS idx_users_status;",
           "type": "table.index",
           "operation": "alter",
           "path": "public.users.idx_users_status"

--- a/testdata/diff/online/alter_composite_index/plan.sql
+++ b/testdata/diff/online/alter_composite_index/plan.sql
@@ -12,7 +12,7 @@ LEFT JOIN pg_index i ON c.oid = i.indexrelid
 LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
 WHERE c.relname = 'idx_users_email_pgschema_new';
 
-DROP INDEX idx_users_email;
+DROP INDEX IF EXISTS idx_users_email;
 
 ALTER INDEX idx_users_email_pgschema_new RENAME TO idx_users_email;
 
@@ -30,6 +30,6 @@ LEFT JOIN pg_index i ON c.oid = i.indexrelid
 LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
 WHERE c.relname = 'idx_users_status_pgschema_new';
 
-DROP INDEX idx_users_status;
+DROP INDEX IF EXISTS idx_users_status;
 
 ALTER INDEX idx_users_status_pgschema_new RENAME TO idx_users_status;

--- a/testdata/diff/online/alter_composite_index/plan.txt
+++ b/testdata/diff/online/alter_composite_index/plan.txt
@@ -28,7 +28,7 @@ LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
 WHERE c.relname = 'idx_users_email_pgschema_new';
 
 -- Transaction Group #3
-DROP INDEX idx_users_email;
+DROP INDEX IF EXISTS idx_users_email;
 
 ALTER INDEX idx_users_email_pgschema_new RENAME TO idx_users_email;
 
@@ -49,6 +49,6 @@ LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
 WHERE c.relname = 'idx_users_status_pgschema_new';
 
 -- Transaction Group #6
-DROP INDEX idx_users_status;
+DROP INDEX IF EXISTS idx_users_status;
 
 ALTER INDEX idx_users_status_pgschema_new RENAME TO idx_users_status;

--- a/testdata/diff/online/alter_materialized_view_index/plan.json
+++ b/testdata/diff/online/alter_materialized_view_index/plan.json
@@ -33,7 +33,7 @@
     {
       "steps": [
         {
-          "sql": "DROP INDEX idx_user_summary_email;",
+          "sql": "DROP INDEX IF EXISTS idx_user_summary_email;",
           "type": "materialized_view.index",
           "operation": "alter",
           "path": "public.user_summary.idx_user_summary_email"

--- a/testdata/diff/online/alter_materialized_view_index/plan.sql
+++ b/testdata/diff/online/alter_materialized_view_index/plan.sql
@@ -12,6 +12,6 @@ LEFT JOIN pg_index i ON c.oid = i.indexrelid
 LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
 WHERE c.relname = 'idx_user_summary_email_pgschema_new';
 
-DROP INDEX idx_user_summary_email;
+DROP INDEX IF EXISTS idx_user_summary_email;
 
 ALTER INDEX idx_user_summary_email_pgschema_new RENAME TO idx_user_summary_email;

--- a/testdata/diff/online/alter_materialized_view_index/plan.txt
+++ b/testdata/diff/online/alter_materialized_view_index/plan.txt
@@ -27,6 +27,6 @@ LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
 WHERE c.relname = 'idx_user_summary_email_pgschema_new';
 
 -- Transaction Group #3
-DROP INDEX idx_user_summary_email;
+DROP INDEX IF EXISTS idx_user_summary_email;
 
 ALTER INDEX idx_user_summary_email_pgschema_new RENAME TO idx_user_summary_email;

--- a/testdata/diff/online/issue_509_index_rebuild_dropped_column/diff.sql
+++ b/testdata/diff/online/issue_509_index_rebuild_dropped_column/diff.sql
@@ -1,0 +1,5 @@
+ALTER TABLE notifications DROP COLUMN valid_period;
+
+DROP INDEX IF EXISTS idx_notifications_tenant_user;
+
+CREATE INDEX IF NOT EXISTS idx_notifications_tenant_user ON notifications (tenant_id, user_id);

--- a/testdata/diff/online/issue_509_index_rebuild_dropped_column/new.sql
+++ b/testdata/diff/online/issue_509_index_rebuild_dropped_column/new.sql
@@ -1,0 +1,7 @@
+CREATE TABLE public.notifications (
+    id integer NOT NULL,
+    tenant_id integer NOT NULL,
+    user_id integer
+);
+
+CREATE INDEX idx_notifications_tenant_user ON public.notifications (tenant_id, user_id);

--- a/testdata/diff/online/issue_509_index_rebuild_dropped_column/old.sql
+++ b/testdata/diff/online/issue_509_index_rebuild_dropped_column/old.sql
@@ -1,0 +1,8 @@
+CREATE TABLE public.notifications (
+    id integer NOT NULL,
+    tenant_id integer NOT NULL,
+    user_id integer,
+    valid_period text
+);
+
+CREATE INDEX idx_notifications_tenant_user ON public.notifications (tenant_id, user_id) WHERE valid_period IS NOT NULL;

--- a/testdata/diff/online/issue_509_index_rebuild_dropped_column/plan.json
+++ b/testdata/diff/online/issue_509_index_rebuild_dropped_column/plan.json
@@ -1,0 +1,60 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.12.0",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "b3aa7ee86fa2b9380d6c3263074199395a1b891a28d56275e803869f51f5c8d4"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "ALTER TABLE notifications DROP COLUMN valid_period;",
+          "type": "table.column",
+          "operation": "drop",
+          "path": "public.notifications.valid_period"
+        }
+      ]
+    },
+    {
+      "steps": [
+        {
+          "sql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notifications_tenant_user_pgschema_new ON notifications (tenant_id, user_id);",
+          "type": "table.index",
+          "operation": "alter",
+          "path": "public.notifications.idx_notifications_tenant_user"
+        }
+      ]
+    },
+    {
+      "steps": [
+        {
+          "sql": "SELECT \n    COALESCE(i.indisvalid, false) as done,\n    CASE \n        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total\n        ELSE 0\n    END as progress\nFROM pg_class c\nLEFT JOIN pg_index i ON c.oid = i.indexrelid\nLEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid\nWHERE c.relname = 'idx_notifications_tenant_user_pgschema_new';",
+          "directive": {
+            "type": "wait",
+            "message": "Creating index idx_notifications_tenant_user_pgschema_new"
+          },
+          "type": "table.index",
+          "operation": "alter",
+          "path": "public.notifications.idx_notifications_tenant_user"
+        }
+      ]
+    },
+    {
+      "steps": [
+        {
+          "sql": "DROP INDEX IF EXISTS idx_notifications_tenant_user;",
+          "type": "table.index",
+          "operation": "alter",
+          "path": "public.notifications.idx_notifications_tenant_user"
+        },
+        {
+          "sql": "ALTER INDEX idx_notifications_tenant_user_pgschema_new RENAME TO idx_notifications_tenant_user;",
+          "type": "table.index",
+          "operation": "alter",
+          "path": "public.notifications.idx_notifications_tenant_user"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/online/issue_509_index_rebuild_dropped_column/plan.sql
+++ b/testdata/diff/online/issue_509_index_rebuild_dropped_column/plan.sql
@@ -1,0 +1,19 @@
+ALTER TABLE notifications DROP COLUMN valid_period;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notifications_tenant_user_pgschema_new ON notifications (tenant_id, user_id);
+
+-- pgschema:wait
+SELECT 
+    COALESCE(i.indisvalid, false) as done,
+    CASE 
+        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total
+        ELSE 0
+    END as progress
+FROM pg_class c
+LEFT JOIN pg_index i ON c.oid = i.indexrelid
+LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
+WHERE c.relname = 'idx_notifications_tenant_user_pgschema_new';
+
+DROP INDEX IF EXISTS idx_notifications_tenant_user;
+
+ALTER INDEX idx_notifications_tenant_user_pgschema_new RENAME TO idx_notifications_tenant_user;

--- a/testdata/diff/online/issue_509_index_rebuild_dropped_column/plan.txt
+++ b/testdata/diff/online/issue_509_index_rebuild_dropped_column/plan.txt
@@ -1,0 +1,36 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ notifications
+    - valid_period (column)
+    ~ idx_notifications_tenant_user (index - concurrent rebuild)
+
+DDL to be executed:
+--------------------------------------------------
+
+-- Transaction Group #1
+ALTER TABLE notifications DROP COLUMN valid_period;
+
+-- Transaction Group #2
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notifications_tenant_user_pgschema_new ON notifications (tenant_id, user_id);
+
+-- Transaction Group #3
+-- pgschema:wait
+SELECT 
+    COALESCE(i.indisvalid, false) as done,
+    CASE 
+        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total
+        ELSE 0
+    END as progress
+FROM pg_class c
+LEFT JOIN pg_index i ON c.oid = i.indexrelid
+LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
+WHERE c.relname = 'idx_notifications_tenant_user_pgschema_new';
+
+-- Transaction Group #4
+DROP INDEX IF EXISTS idx_notifications_tenant_user;
+
+ALTER INDEX idx_notifications_tenant_user_pgschema_new RENAME TO idx_notifications_tenant_user;


### PR DESCRIPTION
Fixes #509.

## Problem

The online index-rebuild path emits a **bare** `DROP INDEX <name>`. When the same plan also drops a column the old index depends on, PostgreSQL implicitly drops that index as part of `ALTER TABLE ... DROP COLUMN`, so the later bare `DROP INDEX` fails with `index "..." does not exist` (SQLSTATE 42704).

The non-online path (`internal/diff/index.go`, `generateIndexModifications`) already guards this with `DROP INDEX IF EXISTS`; only the online rewrite path was affected. This is the index-side sibling of #384 (`fix: skip constraint drop when DROP COLUMN already removes it`, v1.9.0).

## Fix

`internal/plan/rewrite.go`: change the two rebuild drop steps (`generateIndexChangeRewrite`, `generateIndexChangeRewriteFromIndex`) from `DROP INDEX %s` to `DROP INDEX IF EXISTS %s`, matching the existing non-online convention.

## Reproduction (new test fixture)

`testdata/diff/online/issue_509_index_rebuild_dropped_column` — a partial index whose predicate column (`valid_period`) is dropped while a same-named index is redefined. It is not temporal-specific and reproduces on PostgreSQL 14–18.

Before the fix, `TestPlanAndApply` fails on this case with:

```
ERROR: index "idx_notifications_tenant_user" does not exist (SQLSTATE 42704)
```

After the fix it passes end-to-end.

## Tests

- `PGSCHEMA_TEST_FILTER="online/" go test ./cmd -run TestPlanAndApply` — PASS
- `PGSCHEMA_TEST_FILTER="online/" go test ./internal/diff -run TestDiffFromFiles` — PASS

Regenerated the two existing online fixtures whose plan output changed (`alter_composite_index`, `alter_materialized_view_index`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtS1QNgsBYgUr7CRXfdm8q