### PR TITLE
fix: emit COMMENT and DISABLE for newly added table triggers

### DIFF
--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -1511,6 +1511,14 @@ func (td *tableDiff) generateAlterTableStatements(targetSchema string, collector
 			CanRunInTransaction: true,
 		}
 		collector.collect(context, sql)
+
+		if trigger.Comment != "" {
+			generateTriggerComment(trigger, td.Table.Schema, td.Table.Name, targetSchema, DiffTypeTableTrigger, collector)
+		}
+
+		if trigger.Disabled {
+			generateTriggerEnabledState(trigger, td.Table.Schema, td.Table.Name, targetSchema, DiffTypeTableTrigger, collector)
+		}
 	}
 
 	// Add policies - already sorted by the Diff operation

--- a/testdata/diff/create_trigger/add_trigger/diff.sql
+++ b/testdata/diff/create_trigger/add_trigger/diff.sql
@@ -8,6 +8,8 @@ CREATE OR REPLACE TRIGGER employees_last_modified_trigger
     FOR EACH ROW
     EXECUTE FUNCTION update_last_modified();
 
+COMMENT ON TRIGGER employees_last_modified_trigger ON employees IS 'Updates last_modified timestamp on every row update';
+
 CREATE OR REPLACE TRIGGER employees_salary_update_trigger
     BEFORE UPDATE OF salary ON employees
     FOR EACH ROW

--- a/testdata/diff/create_trigger/add_trigger/new.sql
+++ b/testdata/diff/create_trigger/add_trigger/new.sql
@@ -18,6 +18,8 @@ CREATE TRIGGER employees_last_modified_trigger
     FOR EACH ROW
     EXECUTE FUNCTION public.update_last_modified();
 
+COMMENT ON TRIGGER employees_last_modified_trigger ON public.employees IS 'Updates last_modified timestamp on every row update';
+
 CREATE TRIGGER employees_insert_timestamp_trigger
     AFTER INSERT ON public.employees
     FOR EACH ROW

--- a/testdata/diff/create_trigger/add_trigger/plan.json
+++ b/testdata/diff/create_trigger/add_trigger/plan.json
@@ -21,6 +21,12 @@
           "path": "public.employees.employees_last_modified_trigger"
         },
         {
+          "sql": "COMMENT ON TRIGGER employees_last_modified_trigger ON employees IS 'Updates last_modified timestamp on every row update';",
+          "type": "table.trigger",
+          "operation": "alter",
+          "path": "public.employees.employees_last_modified_trigger"
+        },
+        {
           "sql": "CREATE OR REPLACE TRIGGER employees_salary_update_trigger\n    BEFORE UPDATE OF salary ON employees\n    FOR EACH ROW\n    EXECUTE FUNCTION update_last_modified();",
           "type": "table.trigger",
           "operation": "create",

--- a/testdata/diff/create_trigger/add_trigger/plan.sql
+++ b/testdata/diff/create_trigger/add_trigger/plan.sql
@@ -8,6 +8,8 @@ CREATE OR REPLACE TRIGGER employees_last_modified_trigger
     FOR EACH ROW
     EXECUTE FUNCTION update_last_modified();
 
+COMMENT ON TRIGGER employees_last_modified_trigger ON employees IS 'Updates last_modified timestamp on every row update';
+
 CREATE OR REPLACE TRIGGER employees_salary_update_trigger
     BEFORE UPDATE OF salary ON employees
     FOR EACH ROW

--- a/testdata/diff/create_trigger/add_trigger/plan.txt
+++ b/testdata/diff/create_trigger/add_trigger/plan.txt
@@ -8,6 +8,7 @@ Tables:
   ~ employees
     + employees_insert_timestamp_trigger (trigger)
     + employees_last_modified_trigger (trigger)
+    ~ employees_last_modified_trigger (trigger)
     + employees_salary_update_trigger (trigger)
     + employees_truncate_log_trigger (trigger)
 
@@ -27,6 +28,8 @@ CREATE OR REPLACE TRIGGER employees_last_modified_trigger
     BEFORE UPDATE ON employees
     FOR EACH ROW
     EXECUTE FUNCTION update_last_modified();
+
+COMMENT ON TRIGGER employees_last_modified_trigger ON employees IS 'Updates last_modified timestamp on every row update';
 
 CREATE OR REPLACE TRIGGER employees_salary_update_trigger
     BEFORE UPDATE OF salary ON employees


### PR DESCRIPTION
Fixes #515

## Summary
- The added-trigger branch in `table.go` emitted `CREATE TRIGGER` but skipped `COMMENT ON TRIGGER` and `ALTER TABLE DISABLE TRIGGER`, causing trigger comments (and disabled state) to be silently dropped on first apply.
- Added the same comment/disabled-state handling that the modified-trigger and view-trigger paths already had.
- Amended the existing `create_trigger/add_trigger` test fixture to include a trigger comment, verifying the fix end-to-end.

## Test plan
- [x] `PGSCHEMA_TEST_FILTER="create_trigger/add_trigger" go test ./internal/diff/ -run TestDiffFromFiles` passes
- [x] `PGSCHEMA_TEST_FILTER="create_trigger/add_trigger" go test ./cmd/ -run TestPlanAndApply` passes
- [x] Full `TestDiffFromFiles` suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)