### PR TITLE
fix: preserve all function SET clauses from pg_proc.proconfig

### DIFF
--- a/cmd/issue_526_integration_test.go
+++ b/cmd/issue_526_integration_test.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pgplex/pgschema/testutil"
+)
+
+// TestIssue526FunctionSetConfigRoundTrip verifies that all function-local SET
+// clauses—not just search_path—are preserved through plan → apply → plan.
+// (https://github.com/pgplex/pgschema/issues/526)
+func TestIssue526FunctionSetConfigRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	embeddedPG := testutil.SetupPostgres(t)
+	defer embeddedPG.Stop()
+	conn, host, port, dbname, user, password := testutil.ConnectToPostgres(t, embeddedPG)
+	defer conn.Close()
+
+	// applyThenReplan applies the desired state and returns the plan generated
+	// immediately afterwards. An idempotent plan returns "".
+	applyThenReplan := func(t *testing.T, schema, desiredSQL string) string {
+		t.Helper()
+
+		if _, err := conn.ExecContext(ctx, "CREATE SCHEMA IF NOT EXISTS "+schema); err != nil {
+			t.Fatalf("Failed to create schema %s: %v", schema, err)
+		}
+
+		desiredStateFile := filepath.Join(t.TempDir(), "desired.sql")
+		if err := os.WriteFile(desiredStateFile, []byte(desiredSQL), 0644); err != nil {
+			t.Fatalf("Failed to write desired state file: %v", err)
+		}
+
+		if err := applySchemaChanges(host, port, dbname, user, password, schema, desiredStateFile); err != nil {
+			t.Fatalf("Failed to apply desired state: %v", err)
+		}
+
+		replanOutput, err := generatePlanSQLFormatted(host, port, dbname, user, password, schema, desiredStateFile)
+		if err != nil {
+			t.Fatalf("Failed to generate repeat plan: %v", err)
+		}
+		return replanOutput
+	}
+
+	t.Run("function_with_multiple_set_clauses", func(t *testing.T) {
+		replan := applyThenReplan(t, "app526", `
+			CREATE FUNCTION proconfig_repro()
+			RETURNS text
+			LANGUAGE sql
+			STABLE
+			SET search_path = public
+			SET TimeZone = 'UTC'
+			AS $$ SELECT current_setting('TimeZone') $$;
+		`)
+		if replan != "" {
+			t.Errorf("Expected no changes on repeat plan after apply, but got:\n%s", replan)
+		}
+	})
+
+	t.Run("function_with_only_non_search_path_set", func(t *testing.T) {
+		replan := applyThenReplan(t, "app526b", `
+			CREATE FUNCTION timeout_func()
+			RETURNS text
+			LANGUAGE sql
+			SET statement_timeout = '30s'
+			AS $$ SELECT 'ok' $$;
+		`)
+		if replan != "" {
+			t.Errorf("Expected no changes on repeat plan after apply, but got:\n%s", replan)
+		}
+	})
+
+	t.Run("function_with_no_set_clauses_is_unaffected", func(t *testing.T) {
+		replan := applyThenReplan(t, "app526c", `
+			CREATE FUNCTION plain_func()
+			RETURNS int
+			LANGUAGE sql
+			IMMUTABLE
+			AS $$ SELECT 1 $$;
+		`)
+		if replan != "" {
+			t.Errorf("Expected no changes on repeat plan after apply, but got:\n%s", replan)
+		}
+	})
+
+	t.Run("function_with_search_path_only_still_works", func(t *testing.T) {
+		replan := applyThenReplan(t, "app526d", `
+			CREATE FUNCTION search_path_only()
+			RETURNS text
+			LANGUAGE sql
+			SET search_path = pg_catalog
+			AS $$ SELECT 'ok' $$;
+		`)
+		if replan != "" {
+			t.Errorf("Expected no changes on repeat plan after apply, but got:\n%s", replan)
+		}
+	})
+}

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -568,7 +568,9 @@ func normalizeSchemaNames(irData *ir.IR, fromSchema, toSchema string) {
 			fn.Schema = toSchema
 			fn.ReturnType = replaceString(fn.ReturnType)
 			fn.Definition = replaceString(fn.Definition)
-			fn.SearchPath = replaceString(fn.SearchPath)
+			for i := range fn.SetConfig {
+				fn.SetConfig[i] = replaceString(fn.SetConfig[i])
+			}
 			for _, param := range fn.Parameters {
 				param.DataType = replaceString(param.DataType)
 			}

--- a/internal/diff/function.go
+++ b/internal/diff/function.go
@@ -2,6 +2,7 @@ package diff
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/pgplex/pgschema/ir"
@@ -242,17 +243,34 @@ func generateFunctionSQL(function *ir.Function, targetSchema string, qualifySche
 	}
 	// Note: Don't output PARALLEL UNSAFE (it's the default)
 
-	// Add SET search_path if specified
-	// Note: Multi-schema paths are output unquoted (e.g., "SET search_path = pg_catalog, public"),
-	// except for the empty search_path case which requires single quotes: SET search_path = ''
-	if function.SearchPath != "" {
-		// PostgreSQL stores SET search_path = '' as search_path="" in proconfig.
-		// The extracted value is "" (two double-quote chars). Render as '' (single-quoted empty string).
-		// Only the whole-value empty case is handled; mixed paths (e.g. pg_catalog, "") are not expected.
-		if function.SearchPath == `""` {
-			stmt.WriteString("\nSET search_path = ''")
-		} else {
-			stmt.WriteString(fmt.Sprintf("\nSET search_path = %s", function.SearchPath))
+	// Add SET clauses from pg_proc.proconfig.
+	// Each entry is a raw "key=value" pair (e.g., "search_path=public", "TimeZone=UTC").
+	// Render them in sorted order for deterministic output.
+	if len(function.SetConfig) > 0 {
+		sorted := make([]string, len(function.SetConfig))
+		copy(sorted, function.SetConfig)
+		sort.Strings(sorted)
+		for _, cfg := range sorted {
+			// Split on first '=' to separate key from value
+			eqIdx := strings.Index(cfg, "=")
+			if eqIdx < 0 {
+				continue
+			}
+			key := cfg[:eqIdx]
+			value := cfg[eqIdx+1:]
+
+			// search_path has special rendering: unquoted for multi-schema paths,
+			// single-quoted empty string for the empty-search_path case.
+			if key == "search_path" {
+				// PostgreSQL stores SET search_path = '' as search_path="" in proconfig.
+				if value == `""` {
+					stmt.WriteString("\nSET search_path = ''")
+				} else {
+					stmt.WriteString(fmt.Sprintf("\nSET search_path = %s", value))
+				}
+			} else {
+				stmt.WriteString(fmt.Sprintf("\nSET %s = %s", key, value))
+			}
 		}
 	}
 
@@ -389,7 +407,7 @@ func functionsEqualExceptAttributes(old, new *ir.Function) bool {
 	if old.IsSecurityDefiner != new.IsSecurityDefiner {
 		return false
 	}
-	if old.SearchPath != new.SearchPath {
+	if !setConfigEqual(old.SetConfig, new.SetConfig) {
 		return false
 	}
 	// Note: We intentionally do NOT compare IsLeakproof or Parallel here
@@ -433,7 +451,7 @@ func functionsEqual(old, new *ir.Function) bool {
 	if old.Parallel != new.Parallel {
 		return false
 	}
-	if old.SearchPath != new.SearchPath {
+	if !setConfigEqual(old.SetConfig, new.SetConfig) {
 		return false
 	}
 	if old.Comment != new.Comment {
@@ -482,7 +500,7 @@ func functionsEqualExceptComment(old, new *ir.Function) bool {
 	if old.Parallel != new.Parallel {
 		return false
 	}
-	if old.SearchPath != new.SearchPath {
+	if !setConfigEqual(old.SetConfig, new.SetConfig) {
 		return false
 	}
 	// Note: We intentionally do NOT compare Comment here
@@ -612,4 +630,30 @@ func generateFunctionComment(
 		CanRunInTransaction: true,
 	}
 	collector.collect(context, sql)
+}
+
+// setConfigEqual compares two SetConfig slices for equality.
+// Slices are sorted before comparison so that order differences (which are
+// semantically irrelevant) don't cause false-positive diffs.
+func setConfigEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	sortedA := make([]string, len(a))
+	copy(sortedA, a)
+	sort.Strings(sortedA)
+
+	sortedB := make([]string, len(b))
+	copy(sortedB, b)
+	sort.Strings(sortedB)
+
+	for i := range sortedA {
+		if sortedA[i] != sortedB[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/diff/function.go
+++ b/internal/diff/function.go
@@ -269,7 +269,10 @@ func generateFunctionSQL(function *ir.Function, targetSchema string, qualifySche
 					stmt.WriteString(fmt.Sprintf("\nSET search_path = %s", value))
 				}
 			} else {
-				stmt.WriteString(fmt.Sprintf("\nSET %s = %s", key, value))
+				// Non-search_path settings are string literals: the proconfig
+				// array stores values without quotes, but valid migration SQL
+				// requires them (e.g. SET DateStyle = 'ISO, MDY').
+				stmt.WriteString(fmt.Sprintf("\nSET %s = %s", key, quoteString(value)))
 			}
 		}
 	}

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -1038,11 +1038,9 @@ func (i *Inspector) buildFunctions(ctx context.Context, schema *IR, targetSchema
 		// This signature includes all parameter information including modes, names, types, and defaults
 		parameters := i.parseParametersFromSignature(signature, schemaName)
 
-		// Handle search_path
-		searchPath := ""
-		if fn.SearchPath.Valid {
-			searchPath = fn.SearchPath.String
-		}
+		// Preserve SET clauses from pg_proc.proconfig.
+		// Each entry is a raw "key=value" pair (e.g., "search_path=public", "TimeZone=UTC").
+		setConfig := fn.SetConfig
 
 		function := &Function{
 			Schema:            schemaName,
@@ -1057,7 +1055,7 @@ func (i *Inspector) buildFunctions(ctx context.Context, schema *IR, targetSchema
 			IsSecurityDefiner: isSecurityDefiner,
 			IsLeakproof:       isLeakproof,
 			Parallel:          parallelMode,
-			SearchPath:        searchPath,
+			SetConfig:         setConfig,
 		}
 
 		// Use name(arguments) as key to support function overloading

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -149,7 +149,7 @@ type Function struct {
 	IsSecurityDefiner bool         `json:"is_security_definer,omitempty"` // SECURITY DEFINER
 	IsLeakproof       bool         `json:"is_leakproof,omitempty"`        // LEAKPROOF
 	Parallel          string       `json:"parallel,omitempty"`            // SAFE, UNSAFE, RESTRICTED
-	SearchPath        string       `json:"search_path,omitempty"`         // SET search_path value
+	SetConfig         []string     `json:"set_config,omitempty"`          // SET clauses from pg_proc.proconfig (e.g., "search_path=public", "TimeZone=UTC")
 	Dependencies      []string     `json:"dependencies,omitempty"`        // Function keys (name(args)) this function depends on
 }
 

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -1143,7 +1143,7 @@ SELECT
     p.prosecdef AS is_security_definer,
     p.proleakproof AS is_leakproof,
     p.proparallel AS parallel_mode,
-    (SELECT substring(cfg FROM 'search_path=(.*)') FROM unnest(p.proconfig) AS cfg WHERE cfg LIKE 'search_path=%') AS search_path
+    COALESCE(p.proconfig, '{}') AS set_config
 FROM information_schema.routines r
 LEFT JOIN pg_proc p ON p.proname = r.routine_name
     AND p.pronamespace = (SELECT oid FROM pg_namespace WHERE nspname = r.routine_schema)

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -402,6 +402,8 @@ WITH column_base AS (
                     ELSE quote_ident(en.nspname) || '.' || quote_ident(et.typname)
                 END || COALESCE(substring(format_type(a.atttypid, a.atttypmod) FROM '\([^)]*\)'), '') || '[]'
             WHEN dt.typtype = 'b' THEN
+                -- Non-array base types: qualify if not in pg_catalog or table's schema
+                -- Use format_type to preserve typmod for extension types (e.g., vector(384) for pgvector)
                 CASE
                     WHEN dn.nspname = 'pg_catalog' THEN c.udt_name::text
                     WHEN dn.nspname = c.table_schema THEN
@@ -577,11 +579,17 @@ WITH column_base AS (
             WHEN dt.typtype = 'e' OR dt.typtype = 'c' THEN
                 quote_ident(dn.nspname) || '.' || quote_ident(dt.typname)
             WHEN dt.typtype = 'b' AND dt.typcategory = 'A' THEN
+                -- Array types: apply same schema qualification logic to element type
+                -- Use typcategory = 'A' rather than typelem <> 0; the latter is true
+                -- for non-array fixed-length types like name (typelem points to char).
+                -- Use format_type to preserve typmod for element types (e.g., varchar(128)[] for character varying(128)[])
                 CASE
                     WHEN en.nspname = 'pg_catalog' THEN et.typname::text
                     ELSE quote_ident(en.nspname) || '.' || quote_ident(et.typname)
                 END || COALESCE(substring(format_type(a.atttypid, a.atttypmod) FROM '\([^)]*\)'), '') || '[]'
             WHEN dt.typtype = 'b' THEN
+                -- Non-array base types: qualify if not in pg_catalog or table's schema
+                -- Use format_type to preserve typmod for extension types (e.g., vector(384) for pgvector)
                 CASE
                     WHEN dn.nspname = 'pg_catalog' THEN c.udt_name::text
                     WHEN dn.nspname = c.table_schema THEN
@@ -822,7 +830,7 @@ func (q *Queries) GetCompositeTypeColumns(ctx context.Context) ([]GetCompositeTy
 }
 
 const getCompositeTypeColumnsForSchema = `-- name: GetCompositeTypeColumnsForSchema :many
-SELECT
+SELECT 
     n.nspname AS type_schema,
     t.typname AS type_name,
     a.attname AS column_name,
@@ -1345,7 +1353,7 @@ func (q *Queries) GetDomainConstraintsForSchema(ctx context.Context, dollar_1 sq
 }
 
 const getDomains = `-- name: GetDomains :many
-SELECT
+SELECT 
     n.nspname AS domain_schema,
     t.typname AS domain_name,
     CASE
@@ -1418,7 +1426,7 @@ func (q *Queries) GetDomains(ctx context.Context) ([]GetDomainsRow, error) {
 }
 
 const getDomainsForSchema = `-- name: GetDomainsForSchema :many
-SELECT
+SELECT 
     n.nspname AS domain_schema,
     t.typname AS domain_name,
     CASE
@@ -1759,7 +1767,7 @@ SELECT
     p.prosecdef AS is_security_definer,
     p.proleakproof AS is_leakproof,
     p.proparallel AS parallel_mode,
-    (SELECT substring(cfg FROM 'search_path=(.*)') FROM unnest(p.proconfig) AS cfg WHERE cfg LIKE 'search_path=%') AS search_path
+    COALESCE(p.proconfig, '{}') AS set_config
 FROM information_schema.routines r
 LEFT JOIN pg_proc p ON p.proname = r.routine_name
     AND p.pronamespace = (SELECT oid FROM pg_namespace WHERE nspname = r.routine_schema)
@@ -1787,7 +1795,7 @@ type GetFunctionsForSchemaRow struct {
 	IsSecurityDefiner bool           `db:"is_security_definer" json:"is_security_definer"`
 	IsLeakproof       bool           `db:"is_leakproof" json:"is_leakproof"`
 	ParallelMode      interface{}    `db:"parallel_mode" json:"parallel_mode"`
-	SearchPath        sql.NullString `db:"search_path" json:"search_path"`
+	SetConfig         []string       `db:"set_config" json:"set_config"`
 }
 
 // GetFunctionsForSchema retrieves all user-defined functions for a specific schema
@@ -1815,7 +1823,7 @@ func (q *Queries) GetFunctionsForSchema(ctx context.Context, dollar_1 sql.NullSt
 			&i.IsSecurityDefiner,
 			&i.IsLeakproof,
 			&i.ParallelMode,
-			&i.SearchPath,
+			pq.Array(&i.SetConfig),
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

Fixes #526 — `pgschema apply` was silently dropping every function-local `SET` clause except `search_path`.

## Root cause

The function IR had a single `SearchPath` field. The introspection SQL extracted only `search_path` from `pg_proc.proconfig`, and rendering emitted only `SET search_path`.

## Changes

| Layer | Change |
|---|---|
| **IR** (`ir/ir.go`) | Replaced `SearchPath string` with `SetConfig []string` — stores raw `key=value` entries |
| **SQL** (`ir/queries/queries.sql`) | Changed subquery from `WHERE cfg LIKE 'search_path=%'` to `COALESCE(p.proconfig, '{}')` |
| **Inspector** (`ir/inspector.go`) | Reads full `SetConfig` array |
| **Diff** (`internal/diff/function.go`) | Renders all SET clauses in sorted order for deterministic output; compares slices with sort-based equality; non-search_path values are SQL-quoted via `quoteString()` |
| **Plan** (`cmd/plan/plan.go`) | Schema-normalizes all `SetConfig` entries |
| **Tests** | Added round-trip integration tests for: multi-SET, non-search_path-only, no-SET, and search_path-only functions |

## Rendering

- `search_path` keeps existing special behavior (unquoted for multi-schema paths, `''` for empty)
- All other GUCs rendered as `SET <key> = '<value>'` via `quoteString()` (handles whitespace, embedded quotes)
- Entries sorted alphabetically for deterministic output

## Edge cases

- Empty `proconfig`: `COALESCE` produces `{}`, handled gracefully
- Order-insensitive comparison: `setConfigEqual` sorts before comparing
- Values with spaces/quotes: `quoteString` wraps in single quotes and doubles internal quotes
- `replaceSchemaInSearchPath` unaffected — it operates on raw SQL and only matches `SET search_path`
