### PR TITLE
fix: defer functions that reference new tables to after table creation (#530)

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1869,8 +1869,31 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 		functionsWithViewDeps = deferRecreated(functionsWithViewDeps)
 	}
 
-	// Create functions WITHOUT view dependencies (functions may depend on tables created above)
-	generateCreateFunctionsSQL(functionsWithoutViewDeps, targetSchema, collector)
+	// Separate functions WITHOUT view deps into those that reference tables being
+	// created later (tablesWithDeps) and those that don't. Functions that query new
+	// tables must be created after the tables they depend on (issue #530).
+	functionsWithoutTableDeps := functionsWithoutViewDeps
+	var functionsWithTableDeps []*ir.Function
+	if len(tablesWithDeps) > 0 {
+		tablesWithDepsLookup := make(map[string]struct{}, len(tablesWithDeps))
+		for _, table := range tablesWithDeps {
+			qualified := fmt.Sprintf("%s.%s", strings.ToLower(table.Schema), strings.ToLower(table.Name))
+			tablesWithDepsLookup[qualified] = struct{}{}
+			tablesWithDepsLookup[strings.ToLower(table.Name)] = struct{}{}
+		}
+		functionsWithoutTableDeps = nil
+		for _, fn := range functionsWithoutViewDeps {
+			if functionReferencesNewTable(fn, tablesWithDepsLookup) {
+				functionsWithTableDeps = append(functionsWithTableDeps, fn)
+			} else {
+				functionsWithoutTableDeps = append(functionsWithoutTableDeps, fn)
+			}
+		}
+	}
+
+	// Create functions WITHOUT view dependencies AND WITHOUT table dependencies
+	// (these are safe to create before tables with function/domain dependencies)
+	generateCreateFunctionsSQL(functionsWithoutTableDeps, targetSchema, collector)
 
 	// Create domains WITH function dependencies (now that functions exist)
 	// These domains have CHECK constraints that reference functions
@@ -1881,6 +1904,10 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 
 	// Create tables WITH function/domain dependencies (now that functions and deferred domains exist)
 	deferredPolicies2, deferredConstraints2 := generateCreateTablesSQL(tablesWithDeps, targetSchema, collector, existingTables, shouldDeferPolicy, d.suppressedInlineFKs, d.allNewTables)
+
+	// Create functions WITHOUT view deps that reference new tables (now that all tables exist)
+	// These functions query tables that were created in tablesWithDeps above (issue #530)
+	generateCreateFunctionsSQL(functionsWithTableDeps, targetSchema, collector)
 
 	// Emit COMMENT ON SEQUENCE for sequences created implicitly via CREATE TABLE (SERIAL/BIGSERIAL).
 	// These were skipped from addedSequences but their comments must still be deployed.
@@ -2596,6 +2623,23 @@ func referencesNewFunction(expr, defaultSchema string, newFunctions map[string]s
 			if _, ok := newFunctions[qualified]; ok {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// functionReferencesNewTable determines if a function body references any newly
+// added table that will be created after the first function batch (tablesWithDeps).
+// See https://github.com/pgplex/pgschema/issues/530
+func functionReferencesNewTable(fn *ir.Function, newTables map[string]struct{}) bool {
+	if len(newTables) == 0 || fn == nil || fn.Definition == "" {
+		return false
+	}
+
+	body := strings.ToLower(fn.Definition)
+	for tableName := range newTables {
+		if containsIdentifier(body, tableName) {
+			return true
 		}
 	}
 	return false

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -2628,17 +2628,34 @@ func referencesNewFunction(expr, defaultSchema string, newFunctions map[string]s
 	return false
 }
 
+// tableRefPattern matches SQL table references: FROM table, JOIN table,
+// INSERT INTO table, UPDATE [ONLY] table, DELETE FROM table, TABLE table.
+// Captures the table name (possibly schema-qualified) in group 1.
+var tableRefPattern = regexp.MustCompile(
+	`(?i)(?:FROM|JOIN|INTO|UPDATE(?:\s+ONLY)?|DELETE\s+FROM|TABLE)\s+` +
+		`([a-z_][a-z0-9_$]*(?:\.[a-z_][a-z0-9_$]*)*)`,
+)
+
 // functionReferencesNewTable determines if a function body references any newly
 // added table that will be created after the first function batch (tablesWithDeps).
+// It looks for table names in SQL table-reference contexts (FROM, JOIN,
+// INSERT INTO, UPDATE, DELETE FROM) rather than scanning the entire body,
+// avoiding false positives from comments, literals, and aliases.
 // See https://github.com/pgplex/pgschema/issues/530
 func functionReferencesNewTable(fn *ir.Function, newTables map[string]struct{}) bool {
 	if len(newTables) == 0 || fn == nil || fn.Definition == "" {
 		return false
 	}
 
-	body := strings.ToLower(fn.Definition)
-	for tableName := range newTables {
-		if containsIdentifier(body, tableName) {
+	matches := tableRefPattern.FindAllStringSubmatch(fn.Definition, -1)
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		ref := strings.ToLower(match[1])
+		// The lookup contains both qualified (schema.table) and unqualified
+		// (table) keys for each table, so a single check covers both forms.
+		if _, ok := newTables[ref]; ok {
 			return true
 		}
 	}

--- a/testdata/diff/dependency/issue_530_function_table_function_chain/diff.sql
+++ b/testdata/diff/dependency/issue_530_function_table_function_chain/diff.sql
@@ -1,0 +1,27 @@
+CREATE OR REPLACE FUNCTION random_id()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$
+    SELECT CAST(1000000000 + floor(random() * 9000000000) AS bigint);
+$$;
+
+CREATE TABLE IF NOT EXISTS x (
+    id bigint GENERATED ALWAYS AS IDENTITY,
+    public_id text DEFAULT random_id() NOT NULL,
+    name text NOT NULL,
+    flag boolean DEFAULT false NOT NULL,
+    CONSTRAINT x_pkey PRIMARY KEY (id),
+    CONSTRAINT x_name_key UNIQUE (name),
+    CONSTRAINT x_public_id_key UNIQUE (public_id)
+);
+
+CREATE OR REPLACE FUNCTION x_is_flagged(
+    id bigint
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT x.flag FROM x WHERE x.id = id;
+$$;

--- a/testdata/diff/dependency/issue_530_function_table_function_chain/new.sql
+++ b/testdata/diff/dependency/issue_530_function_table_function_chain/new.sql
@@ -1,0 +1,16 @@
+CREATE FUNCTION public.random_id()
+RETURNS bigint LANGUAGE sql AS $$
+    SELECT CAST(1000000000 + floor(random() * 9000000000) AS bigint);
+$$;
+
+CREATE TABLE public.x (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    public_id text NOT NULL UNIQUE DEFAULT random_id(),
+    name text NOT NULL UNIQUE,
+    flag boolean NOT NULL DEFAULT FALSE
+);
+
+CREATE FUNCTION public.x_is_flagged(id bigint)
+RETURNS boolean LANGUAGE sql STABLE AS $$
+    SELECT x.flag FROM x WHERE x.id = id;
+$$;

--- a/testdata/diff/dependency/issue_530_function_table_function_chain/plan.json
+++ b/testdata/diff/dependency/issue_530_function_table_function_chain/plan.json
@@ -1,0 +1,32 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.12.2",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE OR REPLACE FUNCTION random_id()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$\n    SELECT CAST(1000000000 + floor(random() * 9000000000) AS bigint);\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.random_id"
+        },
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS x (\n    id bigint GENERATED ALWAYS AS IDENTITY,\n    public_id text DEFAULT random_id() NOT NULL,\n    name text NOT NULL,\n    flag boolean DEFAULT false NOT NULL,\n    CONSTRAINT x_pkey PRIMARY KEY (id),\n    CONSTRAINT x_name_key UNIQUE (name),\n    CONSTRAINT x_public_id_key UNIQUE (public_id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.x"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION x_is_flagged(\n    id bigint\n)\nRETURNS boolean\nLANGUAGE sql\nSTABLE\nAS $$\n    SELECT x.flag FROM x WHERE x.id = id;\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.x_is_flagged"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/dependency/issue_530_function_table_function_chain/plan.sql
+++ b/testdata/diff/dependency/issue_530_function_table_function_chain/plan.sql
@@ -1,0 +1,27 @@
+CREATE OR REPLACE FUNCTION random_id()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$
+    SELECT CAST(1000000000 + floor(random() * 9000000000) AS bigint);
+$$;
+
+CREATE TABLE IF NOT EXISTS x (
+    id bigint GENERATED ALWAYS AS IDENTITY,
+    public_id text DEFAULT random_id() NOT NULL,
+    name text NOT NULL,
+    flag boolean DEFAULT false NOT NULL,
+    CONSTRAINT x_pkey PRIMARY KEY (id),
+    CONSTRAINT x_name_key UNIQUE (name),
+    CONSTRAINT x_public_id_key UNIQUE (public_id)
+);
+
+CREATE OR REPLACE FUNCTION x_is_flagged(
+    id bigint
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT x.flag FROM x WHERE x.id = id;
+$$;

--- a/testdata/diff/dependency/issue_530_function_table_function_chain/plan.txt
+++ b/testdata/diff/dependency/issue_530_function_table_function_chain/plan.txt
@@ -1,0 +1,43 @@
+Plan: 3 to add.
+
+Summary by type:
+  functions: 2 to add
+  tables: 1 to add
+
+Functions:
+  + random_id
+  + x_is_flagged
+
+Tables:
+  + x
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE OR REPLACE FUNCTION random_id()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$
+    SELECT CAST(1000000000 + floor(random() * 9000000000) AS bigint);
+$$;
+
+CREATE TABLE IF NOT EXISTS x (
+    id bigint GENERATED ALWAYS AS IDENTITY,
+    public_id text DEFAULT random_id() NOT NULL,
+    name text NOT NULL,
+    flag boolean DEFAULT false NOT NULL,
+    CONSTRAINT x_pkey PRIMARY KEY (id),
+    CONSTRAINT x_name_key UNIQUE (name),
+    CONSTRAINT x_public_id_key UNIQUE (public_id)
+);
+
+CREATE OR REPLACE FUNCTION x_is_flagged(
+    id bigint
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT x.flag FROM x WHERE x.id = id;
+$$;


### PR DESCRIPTION
## Problem

When a schema has the dependency chain **function → table → function**, pgschema creates all functions before all tables. This means a function that queries a new table fails with `relation does not exist` because the table hasn't been created yet.

### Minimal reproduction

```sql
CREATE FUNCTION random_id()
RETURNS bigint LANGUAGE sql AS $$
    SELECT CAST(1000000000 + floor(random() * 9000000000) AS bigint);
$$;

CREATE TABLE x (
    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
    public_id text NOT NULL UNIQUE DEFAULT random_id(),
    name text NOT NULL UNIQUE,
    flag boolean NOT NULL DEFAULT FALSE
);

CREATE FUNCTION x_is_flagged(id bigint)
RETURNS boolean LANGUAGE sql STABLE AS $$
    SELECT x.flag FROM x WHERE x.id = id;
$$;
```

The dependency graph is: `random_id` → `x` → `x_is_flagged`

The current `generateCreateSQL` order groups all functions first:
1. `random_id()` ✓
2. `x_is_flagged()` ✗ (table `x` doesn't exist yet)
3. `x`

## Fix

Split `functionsWithoutViewDeps` into those that reference tables in `tablesWithDeps` and those that don't. Functions that query new tables are deferred to after all tables are created, preserving the correct dependency order.

New order:
1. `random_id()` (no table deps)
2. `x` (depends on `random_id`)
3. `x_is_flagged()` (depends on `x` — created after all tables)

## Changes

- **`internal/diff/diff.go`**: Added `functionReferencesNewTable` helper using the existing `containsIdentifier` from `view.go`. Modified `generateCreateSQL` to split functions by table dependencies and emit table-dependent functions after `tablesWithDeps`.
- **Test**: New test case at `testdata/diff/dependency/issue_530_function_table_function_chain/` validates the correct ordering.

Closes #530