### PR TITLE
fix: topologically sort constraints to ensure UNIQUE before FK dependencies (#532)

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1891,6 +1891,7 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	// Add deferred foreign key constraints from BOTH batches AFTER all tables are created
 	// This ensures FK references to tables in the second batch (function-dependent tables) work correctly
 	allDeferredConstraints := append(deferredConstraints1, deferredConstraints2...)
+	allDeferredConstraints = topologicallySortDeferredConstraints(allDeferredConstraints)
 	generateDeferredConstraintsSQL(allDeferredConstraints, targetSchema, collector)
 
 	// Create aggregates after their transition/final functions AND all tables exist
@@ -2222,13 +2223,24 @@ func sortTableObjects(tables []*tableDiff) {
 			return tableDiff.DroppedConstraints[i].Name < tableDiff.DroppedConstraints[j].Name
 		})
 
-		// Sort added constraints
+		// Sort added constraints by type (PK, UNIQUE, FK, CHECK, EXCLUDE) then by name.
+		// Type ordering ensures UNIQUE constraints exist before FKs that reference them
+		// — even within a single ALTER TABLE block PostgreSQL processes statements in
+		// order, so UNIQUE must come before FK. (#532)
 		sort.Slice(tableDiff.AddedConstraints, func(i, j int) bool {
+			oi, oj := constraintTypeOrder(tableDiff.AddedConstraints[i]), constraintTypeOrder(tableDiff.AddedConstraints[j])
+			if oi != oj {
+				return oi < oj
+			}
 			return tableDiff.AddedConstraints[i].Name < tableDiff.AddedConstraints[j].Name
 		})
 
-		// Sort modified constraints
+		// Sort modified constraints by type then by name
 		sort.Slice(tableDiff.ModifiedConstraints, func(i, j int) bool {
+			oi, oj := constraintTypeOrder(tableDiff.ModifiedConstraints[i].New), constraintTypeOrder(tableDiff.ModifiedConstraints[j].New)
+			if oi != oj {
+				return oi < oj
+			}
 			return tableDiff.ModifiedConstraints[i].New.Name < tableDiff.ModifiedConstraints[j].New.Name
 		})
 

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -710,9 +710,7 @@ func planFKRecreationForReplacedConstraints(modifiedTables []*tableDiff, addedTa
 	sort.Slice(preDrops, func(i, j int) bool {
 		return constraintPathKey(preDrops[i]) < constraintPathKey(preDrops[j])
 	})
-	sort.Slice(postAdds, func(i, j int) bool {
-		return constraintPathKey(postAdds[i].constraint) < constraintPathKey(postAdds[j].constraint)
-	})
+	postAdds = topologicallySortDeferredConstraints(postAdds)
 	return preDrops, postAdds, suppressedInlineFKs
 }
 

--- a/internal/diff/topological.go
+++ b/internal/diff/topological.go
@@ -722,10 +722,8 @@ func topologicallySortDeferredConstraints(deferred []*deferredConstraint) []*def
 	// Pre-index deferred constraints by their table for O(n) graph building:
 	// tableKey -> list of constraint graph keys on that table.
 	byTable := make(map[string][]string)
-	tableOf := make(map[string]string) // graph key -> table key
 	for graphKey, dc := range byGraphKey {
 		tk := tableKey(dc.constraint.Schema, dc.constraint.Table)
-		tableOf[graphKey] = tk
 		byTable[tk] = append(byTable[tk], graphKey)
 	}
 

--- a/internal/diff/topological.go
+++ b/internal/diff/topological.go
@@ -708,31 +708,36 @@ func topologicallySortDeferredConstraints(deferred []*deferredConstraint) []*def
 		return deferred
 	}
 
-	// Build keyed lookup by constraint path
-	byPath := make(map[string]*deferredConstraint)
+	// Build keyed lookup by constraint path. Use NUL-byte separators so that
+	// quoted identifiers containing dots (e.g. "a.b".c) don't collide with
+	// unquoted dotted paths (a."b.c") — same pattern as typeGraphKey.
+	byGraphKey := make(map[string]*deferredConstraint)
 	var insertionOrder []string
 	for _, dc := range deferred {
-		key := constraintPathKey(dc.constraint)
-		byPath[key] = dc
+		key := constraintGraphKey(dc.constraint)
+		byGraphKey[key] = dc
 		insertionOrder = append(insertionOrder, key)
 	}
 
-	// Build table identity for each deferred FK
-	tableOf := make(map[string]string) // constraint path -> table key
-	for key, dc := range byPath {
-		tableOf[key] = dc.constraint.Schema + "." + dc.constraint.Table
+	// Pre-index deferred constraints by their table for O(n) graph building:
+	// tableKey -> list of constraint graph keys on that table.
+	byTable := make(map[string][]string)
+	tableOf := make(map[string]string) // graph key -> table key
+	for graphKey, dc := range byGraphKey {
+		tk := tableKey(dc.constraint.Schema, dc.constraint.Table)
+		tableOf[graphKey] = tk
+		byTable[tk] = append(byTable[tk], graphKey)
 	}
 
 	// Build dependency graph: if FK_A references table B, and there is at least
 	// one deferred FK on table B, then the deferred FK(s) on B must come before FK_A.
-	inDegree := make(map[string]int)
-	adjList := make(map[string][]string)
-	for key := range byPath {
-		inDegree[key] = 0
-		adjList[key] = []string{}
+	inDegree := make(map[string]int, len(byGraphKey))
+	adjList := make(map[string][]string, len(byGraphKey))
+	for graphKey := range byGraphKey {
+		inDegree[graphKey] = 0
 	}
 
-	for keyA, dcA := range byPath {
+	for graphKeyA, dcA := range byGraphKey {
 		fk := dcA.constraint
 		if fk.Type != ir.ConstraintTypeForeignKey || fk.ReferencedTable == "" {
 			continue
@@ -741,33 +746,31 @@ func topologicallySortDeferredConstraints(deferred []*deferredConstraint) []*def
 		if refSchema == "" {
 			refSchema = fk.Schema
 		}
-		refTableKey := refSchema + "." + fk.ReferencedTable
+		refTableKey := tableKey(refSchema, fk.ReferencedTable)
 
-		// Find any deferred FK on the referenced table — they must come first.
-		for keyB := range byPath {
-			if keyA == keyB {
+		// O(1) lookup: find deferred FKs on the referenced table.
+		for _, graphKeyB := range byTable[refTableKey] {
+			if graphKeyA == graphKeyB {
 				continue
 			}
-			if tableOf[keyB] == refTableKey {
-				adjList[keyB] = append(adjList[keyB], keyA)
-				inDegree[keyA]++
-			}
+			adjList[graphKeyB] = append(adjList[graphKeyB], graphKeyA)
+			inDegree[graphKeyA]++
 		}
 	}
 
 	// Kahn's algorithm with deterministic cycle breaking
 	var queue []string
 	var result []string
-	processed := make(map[string]bool, len(byPath))
+	processed := make(map[string]bool, len(byGraphKey))
 
-	for key, degree := range inDegree {
+	for graphKey, degree := range inDegree {
 		if degree == 0 {
-			queue = append(queue, key)
+			queue = append(queue, graphKey)
 		}
 	}
 	sort.Strings(queue)
 
-	for len(result) < len(byPath) {
+	for len(result) < len(byGraphKey) {
 		if len(queue) == 0 {
 			next := nextInOrder(insertionOrder, processed)
 			if next == "" {
@@ -798,19 +801,39 @@ func topologicallySortDeferredConstraints(deferred []*deferredConstraint) []*def
 	}
 
 	sorted := make([]*deferredConstraint, 0, len(result))
-	for _, key := range result {
-		sorted = append(sorted, byPath[key])
+	for _, graphKey := range result {
+		sorted = append(sorted, byGraphKey[graphKey])
 	}
 	return sorted
+}
+
+// constraintGraphKey builds a NUL-separated key for a constraint that is safe
+// against identifier collisions. The dot-joined constraintPathKey can produce
+// the same string for distinct constraints when quoted identifiers contain dots
+// (e.g. schema "a.b" table "c" constraint "d" vs schema "a" table "b.c"
+// constraint "d"). NUL cannot appear in a PostgreSQL identifier.
+func constraintGraphKey(c *ir.Constraint) string {
+	return c.Schema + "\x00" + c.Table + "\x00" + c.Name
+}
+
+// tableKey builds a NUL-separated key for a (schema, table) pair that is safe
+// against identifier collisions, matching the convention of constraintGraphKey.
+func tableKey(schema, table string) string {
+	return schema + "\x00" + table
 }
 
 // sortConstraintsByType orders constraints by type for deterministic, safe DDL
 // emission: PRIMARY KEY, UNIQUE, FOREIGN KEY, CHECK, EXCLUDE. This ensures that
 // UNIQUE constraints exist before FKs that reference them (both within a single
-// table and when constraints from multiple tables are interleaved).
+// table and when constraints from multiple tables are interleaved). Within the
+// same type, constraints are sorted by name for deterministic output.
 func sortConstraintsByType(constraints []*ir.Constraint) {
 	sort.Slice(constraints, func(i, j int) bool {
-		return constraintTypeOrder(constraints[i]) < constraintTypeOrder(constraints[j])
+		oi, oj := constraintTypeOrder(constraints[i]), constraintTypeOrder(constraints[j])
+		if oi != oj {
+			return oi < oj
+		}
+		return constraints[i].Name < constraints[j].Name
 	})
 }
 

--- a/internal/diff/topological.go
+++ b/internal/diff/topological.go
@@ -687,6 +687,152 @@ func topologicallySortModifiedTables(tableDiffs []*tableDiff) []*tableDiff {
 	return sortedTableDiffs
 }
 
+// topologicallySortDeferredConstraints sorts deferred FK constraints in dependency
+// order. An FK that references a UNIQUE/PK constraint on table B must come after any
+// FK on table B (which may, in turn, reference a UNIQUE/PK on table C, and so on).
+//
+// The dependency graph is built from table-level FK references: if FK_A's table has
+// any FK referencing table B, then FK_B (any deferred FK on table B) must come before
+// FK_A. This ensures that tables referenced by FKs have their own deferred FKs
+// satisfied first, enabling chains like:
+//
+//	C → B (FK on table C references B's PK)
+//	B → A (FK on table B references A's newly-added UNIQUE)
+//
+// Order: B's FK (to A) before C's FK (to B).
+//
+// When no dependency exists, falls back to alphabetical by constraint path for
+// deterministic output.
+func topologicallySortDeferredConstraints(deferred []*deferredConstraint) []*deferredConstraint {
+	if len(deferred) <= 1 {
+		return deferred
+	}
+
+	// Build keyed lookup by constraint path
+	byPath := make(map[string]*deferredConstraint)
+	var insertionOrder []string
+	for _, dc := range deferred {
+		key := constraintPathKey(dc.constraint)
+		byPath[key] = dc
+		insertionOrder = append(insertionOrder, key)
+	}
+
+	// Build table identity for each deferred FK
+	tableOf := make(map[string]string) // constraint path -> table key
+	for key, dc := range byPath {
+		tableOf[key] = dc.constraint.Schema + "." + dc.constraint.Table
+	}
+
+	// Build dependency graph: if FK_A references table B, and there is at least
+	// one deferred FK on table B, then the deferred FK(s) on B must come before FK_A.
+	inDegree := make(map[string]int)
+	adjList := make(map[string][]string)
+	for key := range byPath {
+		inDegree[key] = 0
+		adjList[key] = []string{}
+	}
+
+	for keyA, dcA := range byPath {
+		fk := dcA.constraint
+		if fk.Type != ir.ConstraintTypeForeignKey || fk.ReferencedTable == "" {
+			continue
+		}
+		refSchema := fk.ReferencedSchema
+		if refSchema == "" {
+			refSchema = fk.Schema
+		}
+		refTableKey := refSchema + "." + fk.ReferencedTable
+
+		// Find any deferred FK on the referenced table — they must come first.
+		for keyB := range byPath {
+			if keyA == keyB {
+				continue
+			}
+			if tableOf[keyB] == refTableKey {
+				adjList[keyB] = append(adjList[keyB], keyA)
+				inDegree[keyA]++
+			}
+		}
+	}
+
+	// Kahn's algorithm with deterministic cycle breaking
+	var queue []string
+	var result []string
+	processed := make(map[string]bool, len(byPath))
+
+	for key, degree := range inDegree {
+		if degree == 0 {
+			queue = append(queue, key)
+		}
+	}
+	sort.Strings(queue)
+
+	for len(result) < len(byPath) {
+		if len(queue) == 0 {
+			next := nextInOrder(insertionOrder, processed)
+			if next == "" {
+				break
+			}
+			queue = append(queue, next)
+			inDegree[next] = 0
+		}
+
+		current := queue[0]
+		queue = queue[1:]
+		if processed[current] {
+			continue
+		}
+		processed[current] = true
+		result = append(result, current)
+
+		neighbors := append([]string(nil), adjList[current]...)
+		sort.Strings(neighbors)
+
+		for _, neighbor := range neighbors {
+			inDegree[neighbor]--
+			if inDegree[neighbor] <= 0 && !processed[neighbor] {
+				queue = append(queue, neighbor)
+				sort.Strings(queue)
+			}
+		}
+	}
+
+	sorted := make([]*deferredConstraint, 0, len(result))
+	for _, key := range result {
+		sorted = append(sorted, byPath[key])
+	}
+	return sorted
+}
+
+// sortConstraintsByType orders constraints by type for deterministic, safe DDL
+// emission: PRIMARY KEY, UNIQUE, FOREIGN KEY, CHECK, EXCLUDE. This ensures that
+// UNIQUE constraints exist before FKs that reference them (both within a single
+// table and when constraints from multiple tables are interleaved).
+func sortConstraintsByType(constraints []*ir.Constraint) {
+	sort.Slice(constraints, func(i, j int) bool {
+		return constraintTypeOrder(constraints[i]) < constraintTypeOrder(constraints[j])
+	})
+}
+
+// constraintTypeOrder returns a sort order for constraint types. Lower values
+// are emitted first.
+func constraintTypeOrder(c *ir.Constraint) int {
+	switch c.Type {
+	case ir.ConstraintTypePrimaryKey:
+		return 0
+	case ir.ConstraintTypeUnique:
+		return 1
+	case ir.ConstraintTypeForeignKey:
+		return 2
+	case ir.ConstraintTypeCheck:
+		return 3
+	case ir.ConstraintTypeExclusion:
+		return 4
+	default:
+		return 5
+	}
+}
+
 // constraintMatchesFKReference checks if a UNIQUE/PK constraint matches the columns
 // referenced by a foreign key constraint.
 // In PostgreSQL, composite foreign keys must reference columns in the same order as they

--- a/internal/diff/topological_test.go
+++ b/internal/diff/topological_test.go
@@ -510,3 +510,106 @@ func TestBuildFunctionBodyDependenciesWithTopologicalSort(t *testing.T) {
 		t.Errorf("expected a_helper before z_wrapper, got order: %v", order)
 	}
 }
+
+func TestTopologicallySortDeferredConstraints_SimpleChain(t *testing.T) {
+	// Table B's FK references table A. Table C's FK references table B.
+	// B's FK (to A) must come before C's FK (to B).
+	deferred := []*deferredConstraint{
+		{ // FK on table C -> table B
+			table: &ir.Table{Schema: "public", Name: "c"},
+			constraint: &ir.Constraint{
+				Schema: "public", Table: "c", Name: "fk_c_to_b",
+				Type: ir.ConstraintTypeForeignKey,
+				ReferencedSchema: "public", ReferencedTable: "b",
+			},
+		},
+		{ // FK on table B -> table A
+			table: &ir.Table{Schema: "public", Name: "b"},
+			constraint: &ir.Constraint{
+				Schema: "public", Table: "b", Name: "fk_b_to_a",
+				Type: ir.ConstraintTypeForeignKey,
+				ReferencedSchema: "public", ReferencedTable: "a",
+			},
+		},
+	}
+
+	sorted := topologicallySortDeferredConstraints(deferred)
+	if len(sorted) != 2 {
+		t.Fatalf("expected 2 constraints, got %d", len(sorted))
+	}
+
+	// B's FK (to A) must come before C's FK (to B)
+	first := sorted[0].constraint.Name
+	second := sorted[1].constraint.Name
+	if first != "fk_b_to_a" || second != "fk_c_to_b" {
+		t.Errorf("expected [fk_b_to_a, fk_c_to_b], got [%s, %s]", first, second)
+	}
+}
+
+func TestTopologicallySortDeferredConstraints_NoDependency(t *testing.T) {
+	// Two FKs referencing unrelated tables. Should be alphabetical by constraint path.
+	deferred := []*deferredConstraint{
+		{
+			table: &ir.Table{Schema: "public", Name: "z"},
+			constraint: &ir.Constraint{
+				Schema: "public", Table: "z", Name: "fk_z",
+				Type: ir.ConstraintTypeForeignKey,
+				ReferencedSchema: "public", ReferencedTable: "unrelated",
+			},
+		},
+		{
+			table: &ir.Table{Schema: "public", Name: "a"},
+			constraint: &ir.Constraint{
+				Schema: "public", Table: "a", Name: "fk_a",
+				Type: ir.ConstraintTypeForeignKey,
+				ReferencedSchema: "public", ReferencedTable: "other",
+			},
+		},
+	}
+
+	sorted := topologicallySortDeferredConstraints(deferred)
+	if len(sorted) != 2 {
+		t.Fatalf("expected 2 constraints, got %d", len(sorted))
+	}
+
+	// No dependency: alphabetical by constraint path
+	first := sorted[0].constraint.Name
+	second := sorted[1].constraint.Name
+	if first != "fk_a" || second != "fk_z" {
+		t.Errorf("expected [fk_a, fk_z], got [%s, %s]", first, second)
+	}
+}
+
+func TestSortConstraintsByType(t *testing.T) {
+	constraints := []*ir.Constraint{
+		{Name: "fk_some", Type: ir.ConstraintTypeForeignKey},
+		{Name: "chk_val", Type: ir.ConstraintTypeCheck},
+		{Name: "uq_email", Type: ir.ConstraintTypeUnique},
+		{Name: "pk_id", Type: ir.ConstraintTypePrimaryKey},
+		{Name: "excl_overlap", Type: ir.ConstraintTypeExclusion},
+	}
+
+	sortConstraintsByType(constraints)
+
+	expected := []string{"pk_id", "uq_email", "fk_some", "chk_val", "excl_overlap"}
+	for i, c := range constraints {
+		if c.Name != expected[i] {
+			t.Errorf("position %d: expected %s, got %s", i, expected[i], c.Name)
+		}
+	}
+}
+
+func TestConstraintTypeOrder(t *testing.T) {
+	if constraintTypeOrder(&ir.Constraint{Type: ir.ConstraintTypePrimaryKey}) >= constraintTypeOrder(&ir.Constraint{Type: ir.ConstraintTypeUnique}) {
+		t.Error("PK should come before UNIQUE")
+	}
+	if constraintTypeOrder(&ir.Constraint{Type: ir.ConstraintTypeUnique}) >= constraintTypeOrder(&ir.Constraint{Type: ir.ConstraintTypeForeignKey}) {
+		t.Error("UNIQUE should come before FK")
+	}
+	if constraintTypeOrder(&ir.Constraint{Type: ir.ConstraintTypeForeignKey}) >= constraintTypeOrder(&ir.Constraint{Type: ir.ConstraintTypeCheck}) {
+		t.Error("FK should come before CHECK")
+	}
+	if constraintTypeOrder(&ir.Constraint{Type: ir.ConstraintTypeCheck}) >= constraintTypeOrder(&ir.Constraint{Type: ir.ConstraintTypeExclusion}) {
+		t.Error("CHECK should come before EXCLUDE")
+	}
+}

--- a/internal/diff/topological_test.go
+++ b/internal/diff/topological_test.go
@@ -581,8 +581,10 @@ func TestTopologicallySortDeferredConstraints_NoDependency(t *testing.T) {
 }
 
 func TestSortConstraintsByType(t *testing.T) {
+	// Same-type constraints should be ordered by name (stable sort).
 	constraints := []*ir.Constraint{
-		{Name: "fk_some", Type: ir.ConstraintTypeForeignKey},
+		{Name: "fk_zebra", Type: ir.ConstraintTypeForeignKey},
+		{Name: "fk_alpha", Type: ir.ConstraintTypeForeignKey},
 		{Name: "chk_val", Type: ir.ConstraintTypeCheck},
 		{Name: "uq_email", Type: ir.ConstraintTypeUnique},
 		{Name: "pk_id", Type: ir.ConstraintTypePrimaryKey},
@@ -591,7 +593,7 @@ func TestSortConstraintsByType(t *testing.T) {
 
 	sortConstraintsByType(constraints)
 
-	expected := []string{"pk_id", "uq_email", "fk_some", "chk_val", "excl_overlap"}
+	expected := []string{"pk_id", "uq_email", "fk_alpha", "fk_zebra", "chk_val", "excl_overlap"}
 	for i, c := range constraints {
 		if c.Name != expected[i] {
 			t.Errorf("position %d: expected %s, got %s", i, expected[i], c.Name)
@@ -611,5 +613,19 @@ func TestConstraintTypeOrder(t *testing.T) {
 	}
 	if constraintTypeOrder(&ir.Constraint{Type: ir.ConstraintTypeCheck}) >= constraintTypeOrder(&ir.Constraint{Type: ir.ConstraintTypeExclusion}) {
 		t.Error("CHECK should come before EXCLUDE")
+	}
+}
+
+func TestConstraintGraphKeyNoCollisions(t *testing.T) {
+	// Quoted identifiers with dots must not collide with unquoted dotted paths.
+	// schema "a.b" table "c" vs schema "a" table "b.c" — same dot-joined path,
+	// but different constraints.
+	c1 := &ir.Constraint{Schema: `a.b`, Table: `c`, Name: `fk`}
+	c2 := &ir.Constraint{Schema: `a`, Table: `b.c`, Name: `fk`}
+
+	k1 := constraintGraphKey(c1)
+	k2 := constraintGraphKey(c2)
+	if k1 == k2 {
+		t.Errorf("constraintGraphKey collision: %q == %q", k1, k2)
 	}
 }


### PR DESCRIPTION
## Problem

When `plan`/`apply` generates DDL for constraints to be added to existing tables, the order in which `ALTER TABLE ADD CONSTRAINT` statements are emitted matters: a `FOREIGN KEY` that references a `UNIQUE` constraint must come after that `UNIQUE` constraint exists.

Previously, `AddedConstraints` and `ModifiedConstraints` were sorted alphabetically by constraint name, and deferred FKs (`fkPostAdds`) were also sorted alphabetically. This could put an FK before the UNIQUE it depends on, causing PostgreSQL error `SQLSTATE 42830`: "there is no unique constraint matching given keys."

## Fix

Three changes ensure correct dependency ordering:

1. **`AddedConstraints` now sort by type** (PK → UNIQUE → FK → CHECK → EXCLUDE) then by name — matching the ordering already used for inline constraints in `CREATE TABLE` via `getInlineConstraintsForTable`. Same-type constraints use name as a stable tiebreaker.

2. **`ModifiedConstraints` sort by type** for consistency.

3. **Deferred FK constraints are topologically sorted** via new `topologicallySortDeferredConstraints`: if table C's FK references table B, and table B has a deferred FK referencing table A, then B's FK is emitted before C's FK. Falls back to alphabetical ordering when no dependency exists. Graph building uses a pre-indexed `byTable` lookup for O(n) rather than O(n²). Keys use NUL-byte separators (`constraintGraphKey`) to avoid collisions when quoted identifiers contain dots.

## Changes

| File | Change |
|---|---|
| `internal/diff/topological.go` | +159 lines: `topologicallySortDeferredConstraints`, `sortConstraintsByType`, `constraintTypeOrder`, `constraintGraphKey`, `tableKey` |
| `internal/diff/diff.go` | +11 lines: integrate sorts into `sortTableObjects` and `generateCreateSQL` |
| `internal/diff/table.go` | −3/+1 lines: replace alphabetical sort with topological sort in `planFKRecreationForReplacedConstraints` |
| `internal/diff/topological_test.go` | +115 lines: tests for all four new functions + collision test |

Closes #532