### PR TITLE
feat: add --version flag to cli

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ Commands:
 
 Use "pgschema [command] --help" for more information about a command.`,
 		version.App(), GitCommit, platform(), BuildDate),
+	Version: version.App(),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		setupLogger()
 		globallogger.SetGlobal(logger, Debug)
@@ -45,6 +46,8 @@ Use "pgschema [command] --help" for more information about a command.`,
 
 func init() {
 	RootCmd.PersistentFlags().BoolVar(&Debug, "debug", false, "Enable debug logging")
+	// Print a clean, machine-parseable version line, e.g. "1.12.3"
+	RootCmd.SetVersionTemplate("{{.Version}}\n")
 	RootCmd.CompletionOptions.DisableDefaultCmd = true
 	RootCmd.AddCommand(dump.DumpCmd)
 	RootCmd.AddCommand(plan.PlanCmd)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/pgplex/pgschema/internal/version"
 )
 
 func TestRootCommand(t *testing.T) {
@@ -37,6 +39,31 @@ func TestRootCommandWithoutArgs(t *testing.T) {
 	output := buf.String()
 	if !strings.Contains(output, "Declarative schema migration for Postgres") {
 		t.Errorf("expected output to contain description, got: %s", output)
+	}
+}
+
+func TestRootCommandVersionFlag(t *testing.T) {
+	// Reset flags that earlier tests may have set on the shared global RootCmd.
+	// pflag does not reset flag values between Parse calls, and cobra checks
+	// the help flag before the version flag.
+	if err := RootCmd.Flags().Set("help", "false"); err != nil {
+		t.Fatalf("failed to reset help flag: %v", err)
+	}
+
+	var buf bytes.Buffer
+	RootCmd.SetOut(&buf)
+	RootCmd.SetErr(&buf)
+	RootCmd.SetArgs([]string{"--version"})
+
+	err := RootCmd.Execute()
+	if err != nil {
+		t.Errorf("root command with --version failed: %v", err)
+	}
+
+	output := buf.String()
+	expected := version.App() + "\n"
+	if output != expected {
+		t.Errorf("expected version output %q, got %q", expected, output)
 	}
 }
 


### PR DESCRIPTION
## What

Closes #542 — adds a `--version` flag to the pgschema CLI.

```bash
$ pgschema --version
1.12.3
```

Output is a single, machine-parseable line containing only the semantic version, so agentic tools and scripts can detect behavioral changes between releases.

## Changes

- **`cmd/root.go`**: Set cobra's `Version` field (adds the `--version` flag to the root command) and a custom version template that prints just the version string.
- **`cmd/root_test.go`**: New test asserting `pgschema --version` output equals `version.App() + "\n"`. Includes a flag reset since tests share the global `RootCmd` (pflag doesn't reset flag values between `Parse` calls, and cobra checks help before version).

## Notes

- `--version` is a root-command flag: `pgschema --version` works, `pgschema dump --version` errors (standard cobra behavior).
- The version string comes from `internal/version/VERSION` (`1.12.3`); `pgschema --help` still shows the fuller `Version: 1.12.3@<commit> <os/arch> <date>` line.

## Tests

- `go test ./cmd/ -run TestRoot -v` — all pass
- `go vet ./cmd/` — clean
- Verified end-to-end: `pgschema --version` → `1.12.3`; `pgschema --debug --version` → `1.12.3`; `pgschema dump --version` → `unknown flag: --version`
